### PR TITLE
Verify if an impactedFile is on excludeList

### DIFF
--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -62,7 +62,10 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 		// perform impact analysis on changed file
 		if (props.verbose) println "** Performing impact analysis on changed file $changedFile"
 		ImpactResolver impactResolver = createImpactResolver(changedFile, props.impactResolutionRules, repositoryClient)
-
+		
+		// get excludeListe
+		List<PathMatcher> excludeMatchers = createExcludePatterns()
+		
 		def impacts = impactResolver.resolve()
 		impacts.each { impact ->
 			def impactFile = impact.getFile()
@@ -70,7 +73,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			// only add impacted files that have a build script mapped to it
 			if (ScriptMappings.getScriptName(impactFile)) {
 				// only add impacted files, that are in scope of the build.
-				if (!matches(impactFile, excludeMatchers){
+				if (!matches(impactFile, excludeMatchers)){
 					buildSet.add(impactFile)
 					if (props.verbose) println "** $impactFile is impacted by changed file $changedFile. Adding to build list."
 				}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -69,8 +69,17 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			if (props.verbose) println "** Found impacted file $impactFile"
 			// only add impacted files that have a build script mapped to it
 			if (ScriptMappings.getScriptName(impactFile)) {
-				buildSet.add(impactFile)
-				if (props.verbose) println "** $impactFile is impacted by changed file $changedFile. Adding to build list."
+				// only add impacted files, that are in scope of the build.
+				if (!matches(impactFile, excludeMatchers){
+					buildSet.add(impactFile)
+					if (props.verbose) println "** $impactFile is impacted by changed file $changedFile. Adding to build list."
+				}
+				else {
+					// impactedFile found, but on Exclude List
+					//   Possible reasons: Exclude of file was defined after building the collection.
+					//   Rescan/Rebuild Collection to synchronize it with defined build scope.
+					if (props.verbose) println "!! $impactFile is impacted by changed file $changedFile, but is on Exlude List. Not added to build list."
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Issue a warning if an impactedFile is on excludeList. This scenario indicates, that the collection is no longer in sync with the intended build scope. 

This targets #4 