### PR TITLE
The assembler RC should be at least 4.

### DIFF
--- a/samples/MortgageApplication/application-conf/Assembler.properties
+++ b/samples/MortgageApplication/application-conf/Assembler.properties
@@ -8,4 +8,4 @@ assembler_fileBuildRank=
 #
 # default Assembler maximum RC allowed
 # can be overridden by file properties
-assembler_maxRC=0
+assembler_maxRC=4


### PR DESCRIPTION
Example.. on BMS maps in genapp application the rc is 4.  This should be changed here..