### PR TITLE
ImpactBuild fixGitDiffPath not working with some configuration

### DIFF
--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -346,7 +346,13 @@ def fixGitDiffPath(String file, String dir, boolean mustExist ) {
 	String dirName = new File(dir).getName()
 	if (new File("${dir}/${file}").exists())
 		return "$dirName/$file" as String
-
+		
+	// Scenario: Directory ${dir} is not the root directory of the file
+	// Example : 
+	//   - applicationSrcDirs=nazare-demo-genapp/base/src/cobol,nazare-demo-genapp/base/src/bms
+	fixedFileName = buildUtils.relativizePath(dir) + ( file.indexOf ("/") >= 0 ? file.substring(file.lastIndexOf("/")) : file )
+	if ( new File("${props.workspace}/${fixedFileName}").exists())
+		return fixedFileName;
 	// returns null or assumed fullPath to file
 	return mustExist ? null : "${props.workspace}/${fixedFileName}"
 }


### PR DESCRIPTION
The new method fixGitDiffPath  is not working with some configuration. It only works if the `applicationSrcDirs=${application}`. But if we want to specify folders under the `${application}` to only scan source folders that we want to build (to avoid scanning the whole  `${application}` folder it does not work. In this case impact build find nothing. Example config:
>applicationSrcDirs=nazare-demo-genapp/base/src/cobol,nazare-demo-genapp/base/src/bms