### PR TITLE
Fix zUnit Test PDS creation/Fix zUnit missing report in case of failure

### DIFF
--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -45,6 +45,8 @@ cobol_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(libra
 cobol_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 cobol_printTempOptions=cyl space(5,5) unit(vio) blksize(133) lrecl(133) recfm(f,b) new
 
+#
+# List the data sets for tests that need to be created and their creation options
 cobol_test_srcDatasets=${cobol_testcase_srcPDS}
 cobol_test_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
 

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -45,11 +45,11 @@ cobol_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(libra
 cobol_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 cobol_printTempOptions=cyl space(5,5) unit(vio) blksize(133) lrecl(133) recfm(f,b) new
 
-cobol_testsrcDatasets=${cobol_testcase_srcPDS}
-cobol_testsrcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
+cobol_test_srcDatasets=${cobol_testcase_srcPDS}
+cobol_test_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
 
-cobol_testloadDatasets=${cobol_testcase_loadPDS}
-cobol_testloadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library)
+cobol_test_loadDatasets=${cobol_testcase_loadPDS}
+cobol_test_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library)
 
 # Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List 
 cobol_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep 

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -100,12 +100,12 @@ cobol_srcOptions | BPXWDYN creation options for creating 'source' type data sets
 cobol_loadDatasets | Comma separated list of 'load module' type data sets
 cobol_loadOptions | BPXWDYN creation options for 'load module' type data sets
 cobol_tempOptions | BPXWDYN creation options for temporary data sets
-cobol_testcase_srcPDS | Dataset to move COBOL test source files to from USS
-cobol_testcase_loadPDS | Dataset to create load modules in from link edit step
-cobol_testsrcDatasets | Comma separated list of test 'source' type data sets
-cobol_testsrcOptions | BPXWDYN creation options for creating 'source' type data sets
-cobol_testloadDatasets | Comma separated list of test 'load module' type data sets
-cobol_testloadOptions | BPXWDYN creation options for creating 'load module' type data sets
+cobol_test_case_srcPDS | Dataset to move COBOL test source files to from USS
+cobol_test_case_loadPDS | Dataset to create load modules in from link edit step
+cobol_test_srcDatasets | Comma separated list of test 'source' type data sets
+cobol_test_srcOptions | BPXWDYN creation options for creating 'source' type data sets
+cobol_test_loadDatasets | Comma separated list of test 'load module' type data sets
+cobol_test_loadOptions | BPXWDYN creation options for creating 'load module' type data sets
 cobol_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
 cobol_compiler | MVS program name of the COBOL compiler
 cobol_linkEditor | MVS program name of the link editor

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -20,6 +20,11 @@ buildUtils.assertBuildProperties(props.cobol_requiredBuildProperties)
 def langQualifier = "cobol"
 buildUtils.createLanguageDatasets(langQualifier)
 
+if (props.runzTests == "True") {
+	langQualifier = "cobol_test"
+	buildUtils.createLanguageDatasets(langQualifier)
+}
+
 // sort the build list based on build file rank if provided
 List<String> sortedList = buildUtils.sortBuildList(argMap.buildList, 'cobol_fileBuildRank')
 

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -95,7 +95,12 @@ buildUtils.createLanguageDatasets(langQualifier)
 	zUnitRunJCL.saveOutput(logFile, props.logEncoding)
 
 	// Store Report in Workspace
-	new CopyToHFS().dataset(props.zunit_bzureportPDS).member(member).file(reportLogFile).hfsEncoding(props.logEncoding).append(false).copy()
+	try {
+		new CopyToHFS().dataset(props.zunit_bzureportPDS).member(member).file(reportLogFile).hfsEncoding(props.logEncoding).append(false).copy()
+	}
+	catch (Exception e) {
+		println "*! Warning the zunit test did not produce report for $buildFile"
+	}
 
 	//	// Extract Job BZURPT as XML
 	//	def logEncoding = "UTF-8"

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -94,14 +94,6 @@ buildUtils.createLanguageDatasets(langQualifier)
 	// Save Job Spool to logFile
 	zUnitRunJCL.saveOutput(logFile, props.logEncoding)
 
-	// Store Report in Workspace
-	try {
-		new CopyToHFS().dataset(props.zunit_bzureportPDS).member(member).file(reportLogFile).hfsEncoding(props.logEncoding).append(false).copy()
-	}
-	catch (Exception e) {
-		println "*! Warning the zunit test did not produce report for $buildFile"
-	}
-
 	//	// Extract Job BZURPT as XML
 	//	def logEncoding = "UTF-8"
 	//	zUnitRunJCL.getAllDDNames().each({ ddName ->
@@ -139,8 +131,12 @@ buildUtils.createLanguageDatasets(langQualifier)
 		// manage processing the RC, up to your logic. You might want to flag the build as failed.
 		if (rc < props.zunit_maxPassRC.toInteger()){
 			println   "***  zUnit Test Job ${zUnitRunJCL.submittedJobId} completed with $rc "
+			// Store Report in Workspace
+			new CopyToHFS().dataset(props.zunit_bzureportPDS).member(member).file(reportLogFile).hfsEncoding(props.logEncoding).append(false).copy()
 		} else if (props.zunit_maxPassRC.toInteger() >= 4 && rc <props.zunit_maxWarnRC.toInteger()){
 			String warningMsg = "*! The zunit test returned a warning ($rc) for $buildFile"
+			// Store Report in Workspace
+			new CopyToHFS().dataset(props.zunit_bzureportPDS).member(member).file(reportLogFile).hfsEncoding(props.logEncoding).append(false).copy()
 			println warningMsg
 			buildUtils.updateBuildResult(warningMsg:warningMsg,logs:["${member}_zunit.log":logFile],client:getRepositoryClient())
 		} else { // rc >= props.zunit_maxWarnRC.toInteger()

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -354,8 +354,6 @@ def createLanguageDatasets(String lang) {
 	if (props."${lang}_reportDatasets")
 		createDatasets(props."${lang}_reportDatasets".split(','), props."${lang}_reportOptions")
 	
-	if (props."${lang}_testDatasets" && props.runzunitTests == "True")
-		createDatasets(props."${lang}_testDatasets".split(','), props."${lang}_testOptions")
 }
 
 /*


### PR DESCRIPTION
@dennis-behm @ricedavida 
This is minor fixes that you may already work on this.

NOTES:
- Before calling the JCL we may need to remove the report in the PDS member to be sure to not have a report from a previous build (not done).