### PR TITLE
Test if BMS datasets exit

### DIFF
--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -3,6 +3,7 @@ import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
+import com.ibm.jzos.ZFile
 
 
 // define script properties
@@ -194,7 +195,8 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 
 	// add a syslib to the compile command with optional bms output copybook and CICS concatenation
 	compile.dd(new DDStatement().name("SYSLIB").dsn(props.cobol_cpyPDS).options("shr"))
-	if (props.bms_cpyPDS)
+	// adding bms copybook libraries only when it exists
+	if (ZFile.dsExists(props.bms_cpyPDS))
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.cobol_BMS_PDS).options("shr"))

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -196,7 +196,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	// add a syslib to the compile command with optional bms output copybook and CICS concatenation
 	compile.dd(new DDStatement().name("SYSLIB").dsn(props.cobol_cpyPDS).options("shr"))
 	// adding bms copybook libraries only when it exists
-	if (ZFile.dsExists(props.bms_cpyPDS))
+	if (props.bms_cpyPDS && ZFile.dsExists("'${props.bms_cpyPDS}'"))
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.cobol_BMS_PDS).options("shr"))

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -145,7 +145,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	// add a syslib to the compile command with optional bms output copybook and CICS concatenation
 	compile.dd(new DDStatement().name("SYSLIB").dsn(props.pli_incPDS).options("shr"))
 	// adding bms copybook libraries only when it exists
-	if (ZFile.dsExists(props.bms_cpyPDS))
+	if (props.bms_cpyPDS && ZFile.dsExists("'${props.bms_cpyPDS}'"))
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.pli_BMS_PDS).options("shr"))

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -3,6 +3,7 @@ import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
+import com.ibm.jzos.ZFile
 
 
 // define script properties
@@ -143,7 +144,8 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 
 	// add a syslib to the compile command with optional bms output copybook and CICS concatenation
 	compile.dd(new DDStatement().name("SYSLIB").dsn(props.pli_incPDS).options("shr"))
-	if (props.bms_cpyPDS)
+	// adding bms copybook libraries only when it exists
+	if (ZFile.dsExists(props.bms_cpyPDS))
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.pli_BMS_PDS).options("shr"))


### PR DESCRIPTION
While the dataset creation was moved to the language scripts, we might see builds failing due to a missing dataset - e.q. the application does not make use of BMS. See #43 