### PR TITLE
zunit cleanup

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -68,8 +68,7 @@ build options:
                           IBM Debug for z/OS
  -l,--logEncoding <arg>   Encoding of output logs. Default is EBCDIC 
                              directory for user build
- -zTest,--runzTests <arg> Specify if zUnit Tests should be run "True",
-                             or not run "False"
+ -zTest,--runzTests       Specify if zUnit Tests should be run
 
 web application credentials
  -url,--url <arg>         DBB repository URL

--- a/build.groovy
+++ b/build.groovy
@@ -39,7 +39,7 @@ else {
 		println("** Invoking build scripts according to build order: ${props.buildOrder}")
 		String[] buildOrderList = props.buildOrder.split(',')
 		String[] testOrderList;
-		if (props.runzTests == "True") { 
+		if (props.runzTests) { 
 			println("** Invoking test scripts according to test order: ${props.testOrder}")
 			testOrderList = props.testOrder.split(',')
 		}
@@ -176,7 +176,7 @@ options:
 	cli.srcDir(longOpt:'sourceDir', args:1, 'Absolute path to workspace (root) directory containing all required source directories for user build')
 	cli.wrkDir(longOpt:'workDir', args:1, 'Absolute path to the build output root directory for user build')
 	cli.t(longOpt:'team', args:1, argName:'hlq', 'Team build hlq for user build syslib concatenations')
-	cli.zTest(longOpt:'runzTests', args:1, 'Specify if zUnit Tests should be run "True", or not run "False"')
+	cli.zTest(longOpt:'runzTests', 'Specify if zUnit Tests should be executed')
 
 	// debug option
 	cli.d(longOpt:'debug', 'Flag to indicate a build for debugging')
@@ -222,8 +222,6 @@ def populateBuildProperties(String[] args) {
 	if (opts.srcDir) props.workspace = opts.srcDir
 	if (opts.wrkDir) props.outDir = opts.wrkDir
 	buildUtils.assertBuildProperties('workspace,outDir')
-	
-	if (opts.zTest) props.runzTests = opts.zTest
 	
 	// load build.properties
 	def buildConf = "${zAppBuildDir}/build-conf"
@@ -275,6 +273,9 @@ def populateBuildProperties(String[] args) {
 			props.load(new File(propFile))
 		}
 	}
+	
+	// set flag indicating to run unit tests
+	if (opts.zTest) props.runzTests = 'true'
 
 	// set optional command line arguments
 	if (opts.l) props.logEncoding = opts.l

--- a/build.groovy
+++ b/build.groovy
@@ -39,7 +39,7 @@ else {
 		println("** Invoking build scripts according to build order: ${props.buildOrder}")
 		String[] buildOrderList = props.buildOrder.split(',')
 		String[] testOrderList;
-		if (props.runzTests) { 
+		if (props.runzTests && props.runzTests.toBoolean()) { 
 			println("** Invoking test scripts according to test order: ${props.testOrder}")
 			testOrderList = props.testOrder.split(',')
 		}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -17,10 +17,11 @@ println("** Building files mapped to ${this.class.getName()}.groovy script")
 // verify required build properties
 buildUtils.assertBuildProperties(props.cobol_requiredBuildProperties)
 
+// create language datasets
 def langQualifier = "cobol"
 buildUtils.createLanguageDatasets(langQualifier)
 
-if (props.runzTests == "True") {
+if (props.runzTests) {
 	langQualifier = "cobol_test"
 	buildUtils.createLanguageDatasets(langQualifier)
 }

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -21,7 +21,7 @@ buildUtils.assertBuildProperties(props.cobol_requiredBuildProperties)
 def langQualifier = "cobol"
 buildUtils.createLanguageDatasets(langQualifier)
 
-if (props.runzTests) {
+if (props.runzTests && props.runzTests.toBoolean()) {
 	langQualifier = "cobol_test"
 	buildUtils.createLanguageDatasets(langQualifier)
 }

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -129,17 +129,17 @@ buildUtils.createLanguageDatasets(langQualifier)
 		rc = zUnitRunJCL.maxRC.split("CC")[1].toInteger()
 
 		// manage processing the RC, up to your logic. You might want to flag the build as failed.
-		if (rc < props.zunit_maxPassRC.toInteger()){
+		if (rc <= props.zunit_maxPassRC.toInteger()){
 			println   "***  zUnit Test Job ${zUnitRunJCL.submittedJobId} completed with $rc "
 			// Store Report in Workspace
 			new CopyToHFS().dataset(props.zunit_bzureportPDS).member(member).file(reportLogFile).hfsEncoding(props.logEncoding).append(false).copy()
-		} else if (props.zunit_maxPassRC.toInteger() >= 4 && rc <props.zunit_maxWarnRC.toInteger()){
+		} else if (rc <= props.zunit_maxWarnRC.toInteger()){
 			String warningMsg = "*! The zunit test returned a warning ($rc) for $buildFile"
 			// Store Report in Workspace
 			new CopyToHFS().dataset(props.zunit_bzureportPDS).member(member).file(reportLogFile).hfsEncoding(props.logEncoding).append(false).copy()
 			println warningMsg
 			buildUtils.updateBuildResult(warningMsg:warningMsg,logs:["${member}_zunit.log":logFile],client:getRepositoryClient())
-		} else { // rc >= props.zunit_maxWarnRC.toInteger()
+		} else { // rc > props.zunit_maxWarnRC.toInteger()
 			props.error = "true"
 			String errorMsg = "*! The zunit test failed with RC=($rc) for $buildFile "
 			println(errorMsg)

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -2,8 +2,8 @@
 
 #
 # Run zUnit Tests
-# Defaults to "False", to enable, set to "True"
-#runzTests=True
+# Defaults to "false", to enable, set to "true"
+#runzTests=true
 
 #
 # Comma separated list of additional application property files to load

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -331,7 +331,7 @@ def relativizeFolderPath(String folder, String path) {
  * getScannerInstantiates - returns the mapped scanner or default scanner
  */
 def getScanner(String buildFile){
-	if (props.runzTests) {
+	if (props.runzTests && props.runzTests.toBoolean()) {
 		scannerUtils= loadScript(new File("ScannerUtilities.groovy"))
 		scanner = scannerUtils.getScanner(buildFile)
 	}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -331,7 +331,7 @@ def relativizeFolderPath(String folder, String path) {
  * getScannerInstantiates - returns the mapped scanner or default scanner
  */
 def getScanner(String buildFile){
-	if (props.runzTests == "True") {
+	if (props.runzTests) {
 		scannerUtils= loadScript(new File("ScannerUtilities.groovy"))
 		scanner = scannerUtils.getScanner(buildFile)
 	}


### PR DESCRIPTION
- uses the standard boolean representation
    a) single cmdline option, b) application-conf uses `true` rather than `True`
- fixes the classification return codes reported from the zunit runner
@jbyibm @drbruce-git 
