### PR TITLE
Expose list of deleted files

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -357,8 +357,7 @@ def createBuildList() {
 	else if (props.impactBuild) {
 		println "** --impactBuild option selected. $action impacted programs for application ${props.application} "
 		if (repositoryClient) {
-			buildSet = impactUtils.createImpactBuildList(repositoryClient)
-		}
+			(buildSet, deletedFiles) = impactUtils.createImpactBuildList(repositoryClient)		}
 		else {
 			println "*! Impact build requires a repository client connection to a DBB web application"
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -344,6 +344,8 @@ def createBuildList() {
 	
 	// using a set to create build list to eliminate duplicate files
 	Set<String> buildSet = new HashSet<String>()
+	Set<String> deletedFiles = new HashSet<String>()
+	
 	String action = (props.scanOnly) ? 'Scanning' : 'Building'
 
 	// check if full build
@@ -402,6 +404,19 @@ def createBuildList() {
 		buildList.each { file ->
 			if (props.verbose) println file
 			writer.write("$file\n")
+		}
+	}
+	
+	// write out list of deleted files (for documentation, not actually used by build scripts)
+	if (deletedFiles.size() > 0){
+		String deletedFilesListLoc = "${props.buildOutDir}/deletedFilesList.${props.buildListFileExt}"
+		println "** Writing lists of deleted files to $deletedFilesListLoc"
+		File deletedFilesListFile = new File(deletedFilesListLoc)
+		deletedFilesListFile.withWriter(enc) { writer ->
+			deletedFiles.each { file ->
+				if (props.verbose) println file
+				writer.write("$file\n")
+			}
 		}
 	}
 	

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -87,7 +87,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 		}
 	}
 
-	return buildSet
+	return [buildSet, deletedFiles]
 }
 
 


### PR DESCRIPTION
zAppBuild already calculates the deleted files to cleanup collections. 

This PR contributes that a list of deleted files is written as `deletedFilesList` to the build workspace, if deletions were found during impactCalculation. This is available for `impactBuilds`.