### PR TITLE
Simple way to add existing libraries to syslib concatenation

### DIFF
--- a/build-conf/Assembler.properties
+++ b/build-conf/Assembler.properties
@@ -41,3 +41,4 @@ dbb.DependencyScanner.languageHint=ASM :: **/*.asm, **/*.mac
 #
 # Add custom concatenation
 # assembler_SYSLIBConcatenation=
+# assembler_linkedit_SYSLIBConcatenation=

--- a/build-conf/Assembler.properties
+++ b/build-conf/Assembler.properties
@@ -39,6 +39,9 @@ assembler_linkEditor=IEWBLINK
 dbb.DependencyScanner.languageHint=ASM :: **/*.asm, **/*.mac
 
 #
-# Add custom concatenation
-# assembler_SYSLIBConcatenation=
-# assembler_linkedit_SYSLIBConcatenation=
+# additional libraries for assembler SYSLIB concatenation, comma-separated, see definitions in application-conf
+# assembler_assemblySyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
+# assembler_linkEditSyslibConcatenation=

--- a/build-conf/Assembler.properties
+++ b/build-conf/Assembler.properties
@@ -37,3 +37,7 @@ assembler_linkEditor=IEWBLINK
 
 # ASM scanner language hint
 dbb.DependencyScanner.languageHint=ASM :: **/*.asm, **/*.mac
+
+#
+# Add custom concatenation
+# assembler_SYSLIBConcatenation=

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -73,7 +73,7 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
 #
 # Add concatenation
-cobol_SYSLIBConcatenation=MDALBIN.PROG.MORTV2.COPY
+cobol_SYSLIBConcatenation=MDALBIN.PROG.MORTV2.BMS.COPY
 
 
 

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -73,7 +73,7 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
 #
 # Add concatenation
-cobol_SYSLIBConcat=MDALBIN.PROG.MORTV2.BMS.COPY
+cobol_SYSLIBConcatenation=MDALBIN.PROG.MORTV2.BMS.COPY
 
 
 

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -53,8 +53,8 @@ cobol_test_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(libr
 cobol_test_loadDatasets=${cobol_testcase_loadPDS}
 cobol_test_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library)
 
-# Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List 
-cobol_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep 
+# Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List
+cobol_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep
 
 #
 # COBOL scanner language hint
@@ -71,6 +71,9 @@ dbb.DependencyScanner.languageHint=COB :: **/*.cbl, **/*.cpy
 dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
 
+#
+# Add concatenation
+cobol_SYSLIBConcatenation=MDALBIN.PROG.MORTV2.COPY
 
 
 

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -72,9 +72,12 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
 
 #
-# Add custom concatenation
-cobol_SYSLIBConcatenation=
-cobol_linkedit_SYSLIBConcatenation=
+# additional libraries for compile SYSLIB concatenation, comma-separated, see definitions in application-conf
+# cobol_compileSyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
+# cobol_linkEditSyslibConcatenation=
 
 
 

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -74,6 +74,7 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 #
 # Add custom concatenation
 cobol_SYSLIBConcatenation=
+cobol_linkedit_SYSLIBConcatenation=
 
 
 

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -73,7 +73,7 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
 #
 # Add concatenation
-cobol_SYSLIBConcatenation=MDALBIN.PROG.MORTV2.BMS.COPY
+cobol_SYSLIBConcat=MDALBIN.PROG.MORTV2.BMS.COPY
 
 
 

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -72,8 +72,8 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
 
 #
-# Add concatenation
-cobol_SYSLIBConcatenation=MDALBIN.PROG.MORTV2.BMS.COPY
+# Add custom concatenation
+cobol_SYSLIBConcatenation=
 
 
 

--- a/build-conf/LinkEdit.properties
+++ b/build-conf/LinkEdit.properties
@@ -30,5 +30,5 @@ linkedit_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(li
 linkedit_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 
 #
-# Add custom concatenation
-# linkedit_SYSLIBConcatenation=
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
+# linkedit_linkEditSyslibConcatenation=

--- a/build-conf/LinkEdit.properties
+++ b/build-conf/LinkEdit.properties
@@ -5,7 +5,7 @@
 linkedit_requiredBuildProperties=linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,\
   linkedit_linkEditor,linkedit_tempOptions,applicationOutputsCollectionName,\
   SDFHLOAD,SCEELKED
-  
+
 #
 # linker name
 linkedit_linkEditor=IEWBLINK
@@ -29,3 +29,6 @@ linkedit_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(li
 
 linkedit_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 
+#
+# Add custom concatenation
+# linkedit_SYSLIBConcatenation=

--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -45,6 +45,9 @@ pli_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998)
 dbb.DependencyScanner.languageHint=PLI :: **/*.pli, **/*.inc, **/*.cpy
 
 #
-# Add custom concatenation
-pli_SYSLIBConcatenation=
-pli_linkedit_SYSLIBConcatenation=
+# additional libraries for compile SYSLIB concatenation, comma-separated, see definitions in application-conf
+# pli_compileSyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
+# pli_linkEditSyslibConcatenation=

--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -47,3 +47,4 @@ dbb.DependencyScanner.languageHint=PLI :: **/*.pli, **/*.inc, **/*.cpy
 #
 # Add custom concatenation
 pli_SYSLIBConcatenation=
+pli_linkedit_SYSLIBConcatenation=

--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -38,8 +38,12 @@ pli_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 pli_listOptions=cyl space(5,5) unit(vio) blksize(0) lrecl(137) recfm(v,b) new
 
 # Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List
-pli_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep  
+pli_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep
 
 #
 # PL/I scanner language hint
 dbb.DependencyScanner.languageHint=PLI :: **/*.pli, **/*.inc, **/*.cpy
+
+#
+# Add custom concatenation
+pli_SYSLIBConcatenation=

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -175,6 +175,13 @@ def createLinkEditCommand(String buildFile, String member, File logFile) {
 	
 	// add a syslib to the linkedit command
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.assembler_objPDS).options("shr"))
+	// add custom concatenation
+	def SYSLIBConcatenation = props.getFileProperty('assembler_linkedit_SYSLIBConcatenation', buildFile) ?: ""
+	if (SYSLIBConcatenation) {
+		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
+		for (String SYSLIBDataset : SYSLIBDatasets )
+		linkedit.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	}
 	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
 	if ( props.SDFHLOAD )
 		linkedit.dd(new DDStatement().dsn(props.SDFHLOAD).options("shr"))

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -126,11 +126,11 @@ def createAssemblerCommand(String buildFile, String member, File logFile) {
 	// create a SYSLIB concatenation with optional MACLIB and MODGEN	
 	assembler.dd(new DDStatement().name("SYSLIB").dsn(props.assembler_macroPDS).options("shr"))
 	// add custom concatenation
-	def SYSLIBConcatenation = props.getFileProperty('assembler_SYSLIBConcatenation', buildFile) ?: ""
-	if (SYSLIBConcatenation) {
-		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
-		for (String SYSLIBDataset : SYSLIBDatasets )
-		compile.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	def assemblySyslibConcatenation = props.getFileProperty('assembler_assemblySyslibConcatenation', buildFile) ?: ""
+	if (assemblySyslibConcatenation) {
+		def String[] syslibDatasets = assemblySyslibConcatenation.split(',');
+		for (String syslibDataset : syslibDatasets )
+		compile.dd(new DDStatement().dsn(syslibDataset).options("shr"))
 	}
 	if (props.SCEEMAC)
 		assembler.dd(new DDStatement().dsn(props.SCEEMAC).options("shr"))
@@ -176,11 +176,11 @@ def createLinkEditCommand(String buildFile, String member, File logFile) {
 	// add a syslib to the linkedit command
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.assembler_objPDS).options("shr"))
 	// add custom concatenation
-	def SYSLIBConcatenation = props.getFileProperty('assembler_linkedit_SYSLIBConcatenation', buildFile) ?: ""
-	if (SYSLIBConcatenation) {
-		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
-		for (String SYSLIBDataset : SYSLIBDatasets )
-		linkedit.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	def linkEditSyslibConcatenation = props.getFileProperty('assembler_linkEditSyslibConcatenation', buildFile) ?: ""
+	if (linkEditSyslibConcatenation) {
+		def String[] syslibDatasets = linkEditSyslibConcatenation.split(',');
+		for (String syslibDataset : syslibDatasets )
+		linkedit.dd(new DDStatement().dsn(syslibDataset).options("shr"))
 	}
 	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
 	if ( props.SDFHLOAD )

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -125,6 +125,13 @@ def createAssemblerCommand(String buildFile, String member, File logFile) {
 	
 	// create a SYSLIB concatenation with optional MACLIB and MODGEN	
 	assembler.dd(new DDStatement().name("SYSLIB").dsn(props.assembler_macroPDS).options("shr"))
+	// add custom concatenation
+	def SYSLIBConcatenation = props.getFileProperty('assembler_SYSLIBConcatenation', buildFile) ?: ""
+	if (SYSLIBConcatenation) {
+		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
+		for (String SYSLIBDataset : SYSLIBDatasets )
+		compile.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	}
 	if (props.SCEEMAC)
 		assembler.dd(new DDStatement().dsn(props.SCEEMAC).options("shr"))
 	if (props.MACLIB)

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -208,7 +208,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
 
 	// add concatenation
-	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: ""
+	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcatenation
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
 		for (String SYSLIBDataset : SYSLIBDatasets )

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -201,20 +201,18 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.cobol_BMS_PDS).options("shr"))
-	if (buildUtils.isCICS(logicalFile))
-		compile.dd(new DDStatement().dsn(props.SDFHCOB).options("shr"))
-	String isMQ = props.getFileProperty('cobol_isMQ', buildFile)
-	if (isMQ && isMQ.toBoolean())
-		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
-
-	// add concatenation
-//	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcat
+	// add custom concatenation
 	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: ""
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
 		for (String SYSLIBDataset : SYSLIBDatasets )
 		compile.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
 	}
+	if (buildUtils.isCICS(logicalFile))
+		compile.dd(new DDStatement().dsn(props.SDFHCOB).options("shr"))
+	String isMQ = props.getFileProperty('cobol_isMQ', buildFile)
+	if (isMQ && isMQ.toBoolean())
+		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
 		
 	// add additional zunit libraries
 	if (isZUnitTestCase)

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -208,7 +208,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
 
 	// add concatenation
-	println(props.cobol_SYSLIBConcatenation)
+	println("Cobol compiler= " + cobol_compiler + "    - Concat= " + props.cobol_SYSLIBConcatenation)
 	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcatenation
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -213,7 +213,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
 		for (String SYSLIBDataset : SYSLIBDatasets )
-		println(SYSLIBDataset);
+		compile.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
 	}
 		
 	// add additional zunit libraries

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -208,7 +208,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
 
 	// add concatenation
-	println("Cobol compiler= " + props.cobol_compiler + "    - Concat= " + props.cobol_SYSLIBConcat)
+	println("Cobol compiler= " + props.cobol_compiler + "    - Concat= " + props.cobol_SYSLIBConcatenation)
 	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcat
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -201,12 +201,13 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.cobol_BMS_PDS).options("shr"))
+		
 	// add custom concatenation
-	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: ""
-	if (SYSLIBConcatenation) {
-		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
-		for (String SYSLIBDataset : SYSLIBDatasets )
-		compile.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	def compileSyslibConcatenation = props.getFileProperty('cobol_compileSyslibConcatenation', buildFile) ?: ""
+	if (compileSyslibConcatenation) {
+		def String[] syslibDatasets = compileSyslibConcatenation.split(',');
+		for (String syslibDataset : syslibDatasets )
+		compile.dd(new DDStatement().dsn(syslibDataset).options("shr"))
 	}
 	if (buildUtils.isCICS(logicalFile))
 		compile.dd(new DDStatement().dsn(props.SDFHCOB).options("shr"))
@@ -302,12 +303,13 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// add a syslib to the compile command with optional CICS concatenation
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.cobol_objPDS).options("shr"))
+	
 	// add custom concatenation
-	def SYSLIBConcatenation = props.getFileProperty('cobol_linkedit_SYSLIBConcatenation', buildFile) ?: ""
-	if (SYSLIBConcatenation) {
-		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
-		for (String SYSLIBDataset : SYSLIBDatasets )
-		linkedit.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	def linkEditSyslibConcatenation = props.getFileProperty('cobol_linkEditSyslibConcatenation', buildFile) ?: ""
+	if (linkEditSyslibConcatenation) {
+		def String[] syslibDatasets = linkEditSyslibConcatenation.split(',');
+		for (String syslibDataset : syslibDatasets )
+		linkedit.dd(new DDStatement().dsn(syslibDataset).options("shr"))
 	}
 	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
 

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -208,7 +208,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
 
 	// add concatenation
-	println("Cobol compiler= " + cobol_compiler + "    - Concat= " + props.cobol_SYSLIBConcatenation)
+	println("Cobol compiler= " + props.cobol_compiler + "    - Concat= " + props.cobol_SYSLIBConcatenation)
 	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcatenation
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -208,8 +208,8 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
 
 	// add concatenation
-	println("Cobol compiler= " + props.cobol_compiler + "    - Concat= " + props.cobol_SYSLIBConcatenation)
-	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcat
+//	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcat
+	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: ""
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
 		for (String SYSLIBDataset : SYSLIBDatasets )

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -213,8 +213,6 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
 		for (String SYSLIBDataset : SYSLIBDatasets )
 		println(SYSLIBDataset);
-	} else {
-		println("no concat")
 	}
 		
 	// add additional zunit libraries

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -207,6 +207,16 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	if (isMQ && isMQ.toBoolean())
 		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
 
+	// add concatenation
+	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: ""
+	if (SYSLIBConcatenation) {
+		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
+		for (String SYSLIBDataset : SYSLIBDatasets )
+		println(SYSLIBDataset);
+	} else {
+		println("no concat")
+	}
+		
 	// add additional zunit libraries
 	if (isZUnitTestCase)
 	compile.dd(new DDStatement().dsn(props.SBZUSAMP).options("shr"))

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -208,8 +208,8 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
 
 	// add concatenation
-	println("Cobol compiler= " + props.cobol_compiler + "    - Concat= " + props.cobol_SYSLIBConcatenation)
-	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcatenation
+	println("Cobol compiler= " + props.cobol_compiler + "    - Concat= " + props.cobol_SYSLIBConcat)
+	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcat
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
 		for (String SYSLIBDataset : SYSLIBDatasets )

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -302,6 +302,13 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// add a syslib to the compile command with optional CICS concatenation
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.cobol_objPDS).options("shr"))
+	// add custom concatenation
+	def SYSLIBConcatenation = props.getFileProperty('cobol_linkedit_SYSLIBConcatenation', buildFile) ?: ""
+	if (SYSLIBConcatenation) {
+		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
+		for (String SYSLIBDataset : SYSLIBDatasets )
+		linkedit.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	}
 	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
 
 	// Add Debug Dataset to find the debug exit to SYSLIB

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -208,6 +208,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.SCSQCOBC).options("shr"))
 
 	// add concatenation
+	println(props.cobol_SYSLIBConcatenation)
 	def SYSLIBConcatenation = props.getFileProperty('cobol_SYSLIBConcatenation', buildFile) ?: props.cobol_SYSLIBConcatenation
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -94,6 +94,8 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.linkedit_objPDS).options("shr"))
 	// add custom concatenation
 	def SYSLIBConcatenation = props.getFileProperty('linkedit_SYSLIBConcatenation', buildFile) ?: ""
+	println("***********")
+	println("Linkedit concat = " + props.getFileProperty('linkedit_SYSLIBConcatenation', buildFile))
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
 		for (String SYSLIBDataset : SYSLIBDatasets )

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -93,11 +93,11 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	// add a syslib to the compile command with optional CICS concatenation
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.linkedit_objPDS).options("shr"))
 	// add custom concatenation
-	def SYSLIBConcatenation = props.getFileProperty('linkedit_SYSLIBConcatenation', buildFile) ?: ""
-	if (SYSLIBConcatenation) {
-		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
-		for (String SYSLIBDataset : SYSLIBDatasets )
-		linkedit.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	def linkEditSyslibConcatenation = props.getFileProperty('linkedit_linkEditSyslibConcatenation', buildFile) ?: ""
+	if (linkEditSyslibConcatenation) {
+		def String[] syslibDatasets = linkEditSyslibConcatenation.split(',');
+		for (String syslibDataset : syslibDatasets )
+		linkedit.dd(new DDStatement().dsn(syslibDataset).options("shr"))
 	}
 	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
 	linkedit.dd(new DDStatement().dsn(props.SDFHLOAD).options("shr"))

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -92,6 +92,13 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// add a syslib to the compile command with optional CICS concatenation
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.linkedit_objPDS).options("shr"))
+	// add custom concatenation
+	def SYSLIBConcatenation = props.getFileProperty('linkedit_SYSLIBConcatenation', buildFile) ?: ""
+	if (SYSLIBConcatenation) {
+		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
+		for (String SYSLIBDataset : SYSLIBDatasets )
+		linkedit.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	}
 	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
 	linkedit.dd(new DDStatement().dsn(props.SDFHLOAD).options("shr"))
 

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -94,8 +94,6 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.linkedit_objPDS).options("shr"))
 	// add custom concatenation
 	def SYSLIBConcatenation = props.getFileProperty('linkedit_SYSLIBConcatenation', buildFile) ?: ""
-	println("***********")
-	println("Linkedit concat = " + props.getFileProperty('linkedit_SYSLIBConcatenation', buildFile))
 	if (SYSLIBConcatenation) {
 		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
 		for (String SYSLIBDataset : SYSLIBDatasets )

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -231,6 +231,13 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// add a syslib to the compile command with optional CICS concatenation
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.pli_objPDS).options("shr"))
+	// add custom concatenation
+	def SYSLIBConcatenation = props.getFileProperty('pli_linkedit_SYSLIBConcatenation', buildFile) ?: ""
+	if (SYSLIBConcatenation) {
+		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
+		for (String SYSLIBDataset : SYSLIBDatasets )
+		linkedit.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	}
 	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
 	if (buildUtils.isCICS(logicalFile))
 		linkedit.dd(new DDStatement().dsn(props.SDFHLOAD).options("shr"))

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -149,13 +149,15 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.pli_BMS_PDS).options("shr"))
+		
 	// add custom concatenation
-	def SYSLIBConcatenation = props.getFileProperty('pli_SYSLIBConcatenation', buildFile) ?: ""
-	if (SYSLIBConcatenation) {
-		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
-		for (String SYSLIBDataset : SYSLIBDatasets )
-		compile.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	def compileSyslibConcatenation = props.getFileProperty('pli_compileSyslibConcatenation', buildFile) ?: ""
+	if (compileSyslibConcatenation) {
+		def String[] syslibDatasets = compileSyslibConcatenation.split(',');
+		for (String syslibDataset : syslibDatasets )
+		compile.dd(new DDStatement().dsn(syslibDataset).options("shr"))
 	}
+	
 	if (buildUtils.isCICS(logicalFile))
 		compile.dd(new DDStatement().dsn(props.SDFHCOB).options("shr"))
 
@@ -232,11 +234,11 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	// add a syslib to the compile command with optional CICS concatenation
 	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.pli_objPDS).options("shr"))
 	// add custom concatenation
-	def SYSLIBConcatenation = props.getFileProperty('pli_linkedit_SYSLIBConcatenation', buildFile) ?: ""
-	if (SYSLIBConcatenation) {
-		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
-		for (String SYSLIBDataset : SYSLIBDatasets )
-		linkedit.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	def linkEditSyslibConcatenation = props.getFileProperty('pli_linkEditSyslibConcatenation', buildFile) ?: ""
+	if (linkEditSyslibConcatenation) {
+		def String[] syslibDatasets = syslibConcatenation.split(',');
+		for (String syslibDataset : syslibDatasets )
+		linkedit.dd(new DDStatement().dsn(syslibDataset).options("shr"))
 	}
 	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
 	if (buildUtils.isCICS(logicalFile))

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -149,6 +149,13 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.pli_BMS_PDS).options("shr"))
+	// add custom concatenation
+	def SYSLIBConcatenation = props.getFileProperty('pli_SYSLIBConcatenation', buildFile) ?: ""
+	if (SYSLIBConcatenation) {
+		def String[] SYSLIBDatasets = SYSLIBConcatenation.split(',');
+		for (String SYSLIBDataset : SYSLIBDatasets )
+		compile.dd(new DDStatement().dsn(SYSLIBDataset).options("shr"))
+	}
 	if (buildUtils.isCICS(logicalFile))
 		compile.dd(new DDStatement().dsn(props.SDFHCOB).options("shr"))
 

--- a/samples/MortgageApplication/application-conf/Assembler.properties
+++ b/samples/MortgageApplication/application-conf/Assembler.properties
@@ -13,3 +13,4 @@ assembler_maxRC=0
 #
 # Add custom concatenation
 # assembler_SYSLIBConcatenation=
+# assembler_linkedit_SYSLIBConcatenation=

--- a/samples/MortgageApplication/application-conf/Assembler.properties
+++ b/samples/MortgageApplication/application-conf/Assembler.properties
@@ -9,3 +9,7 @@ assembler_fileBuildRank=
 # default Assembler maximum RC allowed
 # can be overridden by file properties
 assembler_maxRC=0
+
+#
+# Add custom concatenation
+# assembler_SYSLIBConcatenation=

--- a/samples/MortgageApplication/application-conf/Assembler.properties
+++ b/samples/MortgageApplication/application-conf/Assembler.properties
@@ -11,6 +11,9 @@ assembler_fileBuildRank=
 assembler_maxRC=0
 
 #
-# Add custom concatenation
-# assembler_SYSLIBConcatenation=
-# assembler_linkedit_SYSLIBConcatenation=
+# additional libraries for assembler SYSLIB concatenation, comma-separated
+assembler_assemblySyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+assembler_linkEditSyslibConcatenation=

--- a/samples/MortgageApplication/application-conf/Cobol.properties
+++ b/samples/MortgageApplication/application-conf/Cobol.properties
@@ -45,9 +45,12 @@ cobol_linkEdit=true
 cobol_scanLoadModule=true
 
 #
-# Add custom concatenation
-# cobol_SYSLIBConcatenation=
-# cobol_linkedit_SYSLIBConcatenation=
+# additional libraries for compile SYSLIB concatenation, comma-separated
+cobol_compileSyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+cobol_linkEditSyslibConcatenation=
 
 
 

--- a/samples/MortgageApplication/application-conf/Cobol.properties
+++ b/samples/MortgageApplication/application-conf/Cobol.properties
@@ -51,12 +51,3 @@ cobol_compileSyslibConcatenation=
 #
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated
 cobol_linkEditSyslibConcatenation=
-
-
-
-
-
-
-
-
-

--- a/samples/MortgageApplication/application-conf/Cobol.properties
+++ b/samples/MortgageApplication/application-conf/Cobol.properties
@@ -47,7 +47,7 @@ cobol_scanLoadModule=true
 #
 # Add custom concatenation
 # cobol_SYSLIBConcatenation=
-
+# cobol_linkedit_SYSLIBConcatenation=
 
 
 

--- a/samples/MortgageApplication/application-conf/Cobol.properties
+++ b/samples/MortgageApplication/application-conf/Cobol.properties
@@ -22,7 +22,7 @@ cobol_compileMaxRC=4
 cobol_linkEditMaxRC=0
 
 #
-# default COBOL compiler parameters 
+# default COBOL compiler parameters
 # can be overridden by file properties
 cobol_compileParms=LIB
 cobol_compileCICSParms=CICS
@@ -30,7 +30,7 @@ cobol_compileSQLParms=SQL
 cobol_compileErrorPrefixParms=ADATA,EX(ADX(ELAXMGUX))
 
 #
-# default LinkEdit parameters 
+# default LinkEdit parameters
 # can be overridden by file properties
 cobol_linkEditParms=MAP,RENT,COMPAT(PM5)
 
@@ -44,6 +44,9 @@ cobol_linkEdit=true
 # can be overridden by file properties
 cobol_scanLoadModule=true
 
+#
+# Add custom concatenation
+# cobol_SYSLIBConcatenation=
 
 
 

--- a/samples/MortgageApplication/application-conf/LinkEdit.properties
+++ b/samples/MortgageApplication/application-conf/LinkEdit.properties
@@ -11,7 +11,7 @@ linkedit_fileBuildRank=
 linkedit_maxRC=0
 
 #
-# default LinkEdit parameters 
+# default LinkEdit parameters
 # can be overridden by file properties
 linkEdit_parms=MAP,RENT,COMPAT(PM5)
 
@@ -19,3 +19,7 @@ linkEdit_parms=MAP,RENT,COMPAT(PM5)
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 linkedit_scanLoadModule=true
+
+#
+# Add custom concatenation
+# linkedit_SYSLIBConcatenation=

--- a/samples/MortgageApplication/application-conf/LinkEdit.properties
+++ b/samples/MortgageApplication/application-conf/LinkEdit.properties
@@ -21,5 +21,5 @@ linkEdit_parms=MAP,RENT,COMPAT(PM5)
 linkedit_scanLoadModule=true
 
 #
-# Add custom concatenation
-# linkedit_SYSLIBConcatenation=
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+linkedit_linkEditSyslibConcatenation=

--- a/samples/MortgageApplication/application-conf/PLI.properties
+++ b/samples/MortgageApplication/application-conf/PLI.properties
@@ -11,6 +11,9 @@ pli_fileBuildRank=
 pli_maxRC=0
 
 #
-# Add custom concatenation
-# pli_SYSLIBConcatenation=
-# pli_linkedit_SYSLIBConcatenation=
+# additional libraries for compile SYSLIB concatenation, comma-separated
+pli_compileSyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+pli_linkEditSyslibConcatenation=

--- a/samples/MortgageApplication/application-conf/PLI.properties
+++ b/samples/MortgageApplication/application-conf/PLI.properties
@@ -13,4 +13,4 @@ pli_maxRC=0
 #
 # Add custom concatenation
 # pli_SYSLIBConcatenation=
-
+# pli_linkedit_SYSLIBConcatenation=

--- a/samples/MortgageApplication/application-conf/PLI.properties
+++ b/samples/MortgageApplication/application-conf/PLI.properties
@@ -10,3 +10,7 @@ pli_fileBuildRank=
 # can be overridden by file properties
 pli_maxRC=0
 
+#
+# Add custom concatenation
+# pli_SYSLIBConcatenation=
+

--- a/samples/MortgageApplication/application-conf/README.md
+++ b/samples/MortgageApplication/application-conf/README.md
@@ -37,7 +37,9 @@ assembler_linkEdit | Flag indicating to execute the link edit step to produce a 
 assembler_maxRC | Default Assembler maximum RC allowed. | true
 assembler_linkEditMaxRC | Default link edit maximum RC allowed. | true
 assembler_resolutionRules | Assembler dependency resolution rules used to create a Assmebler dependency resolver.  Format is a JSON array of resolution rule property keys.  Resolution rule properties are defined in `application-conf/application.properties`. | true
-cobol_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+assembler_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+assembler_assemblySyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during assembly step | true
+assembler_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### BMS.properties
 Application properties used by zAppBuild/language/BMS.groovy
@@ -68,6 +70,8 @@ cobol_linkEditParms | Default link edit parameters. | true
 cobol_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
 cobol_isMQ | Flag indicating that the program contains MQ calls | true
 cobol_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+cobol_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
+cobol_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### LinkEdit.properties
 Application properties used by zAppBuild/language/LinkEdit.groovy
@@ -78,6 +82,7 @@ linkedit_fileBuildRank | Default link card build rank. Used to sort link card bu
 linkedit_maxRC | Default link edit maximum RC allowed. | true
 linkedit_parms | Default link edit parameters. | true
 linkedit_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+linkEdit_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### PLI.properties
 Application properties used by zAppBuild/language/LinkEdit.groovy
@@ -95,4 +100,6 @@ pli_compileSQLParms | Default SQL compile parameters. Appended to base parameter
 pli_compileErrorPrefixParms | IDz user build parameters. Appended to base parameters if has value. | true
 pli_linkEditParms | Default link edit parameters. | true
 pli_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
-plil_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+pli_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+pli_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
+pli_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true

--- a/samples/application-conf/Assembler.properties
+++ b/samples/application-conf/Assembler.properties
@@ -34,6 +34,9 @@ assembler_resolutionRules=[${maclibRule}]
 assembler_scanLoadModule=true
 
 #
-# Add custom concatenation
-# assembler_SYSLIBConcatenation=
-# assembler_linkedit_SYSLIBConcatenation=
+# additional libraries for assembler SYSLIB concatenation, comma-separated
+assembler_assemblySyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+assembler_linkEditSyslibConcatenation=

--- a/samples/application-conf/Assembler.properties
+++ b/samples/application-conf/Assembler.properties
@@ -36,4 +36,4 @@ assembler_scanLoadModule=true
 #
 # Add custom concatenation
 # assembler_SYSLIBConcatenation=
-
+# assembler_linkedit_SYSLIBConcatenation=

--- a/samples/application-conf/Assembler.properties
+++ b/samples/application-conf/Assembler.properties
@@ -33,4 +33,7 @@ assembler_resolutionRules=[${maclibRule}]
 # can be overridden by file properties
 assembler_scanLoadModule=true
 
+#
+# Add custom concatenation
+# assembler_SYSLIBConcatenation=
 

--- a/samples/application-conf/Cobol.properties
+++ b/samples/application-conf/Cobol.properties
@@ -61,6 +61,7 @@ cobol_scanLoadModule=true
 #
 # Add custom concatenation
 # cobol_SYSLIBConcatenation=
+# cobol_linkedit_SYSLIBConcatenation=
 
 
 

--- a/samples/application-conf/Cobol.properties
+++ b/samples/application-conf/Cobol.properties
@@ -59,16 +59,9 @@ cobol_linkEdit=true
 cobol_scanLoadModule=true
 
 #
-# Add custom concatenation
-# cobol_SYSLIBConcatenation=
-# cobol_linkedit_SYSLIBConcatenation=
+# additional libraries for compile SYSLIB concatenation, comma-separated
+cobol_compileSyslibConcatenation=
 
-
-
-
-
-
-
-
-
-
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+cobol_linkEditSyslibConcatenation=

--- a/samples/application-conf/Cobol.properties
+++ b/samples/application-conf/Cobol.properties
@@ -30,7 +30,7 @@ cobol_compileSQLParms=SQL
 cobol_compileErrorPrefixParms=ADATA,EX(ADX(ELAXMGUX))
 
 # Compile Options for IBM Debugger. Assuming to keep Dwarf Files inside the load.
-# If you would like to separate debug info, additional allocations needed (See COBOL + Debugger libraries) 
+# If you would like to separate debug info, additional allocations needed (See COBOL + Debugger libraries)
 cobol_compileDebugParms=TEST
 
 #
@@ -58,6 +58,9 @@ cobol_linkEdit=true
 # can be overridden by file properties
 cobol_scanLoadModule=true
 
+#
+# Add custom concatenation
+# cobol_SYSLIBConcatenation=
 
 
 

--- a/samples/application-conf/LinkEdit.properties
+++ b/samples/application-conf/LinkEdit.properties
@@ -11,7 +11,7 @@ linkedit_fileBuildRank=
 linkedit_maxRC=0
 
 #
-# default LinkEdit parameters 
+# default LinkEdit parameters
 # can be overridden by file properties
 linkEdit_parms=MAP,RENT,COMPAT(PM5)
 
@@ -19,3 +19,7 @@ linkEdit_parms=MAP,RENT,COMPAT(PM5)
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 linkedit_scanLoadModule=true
+
+#
+# Add custom concatenation
+# linkedit_SYSLIBConcatenation=

--- a/samples/application-conf/LinkEdit.properties
+++ b/samples/application-conf/LinkEdit.properties
@@ -21,5 +21,5 @@ linkEdit_parms=MAP,RENT,COMPAT(PM5)
 linkedit_scanLoadModule=true
 
 #
-# Add custom concatenation
-# linkedit_SYSLIBConcatenation=
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+linkedit_linkEditSyslibConcatenation=

--- a/samples/application-conf/PLI.properties
+++ b/samples/application-conf/PLI.properties
@@ -45,6 +45,9 @@ pli_linkEdit=true
 pli_scanLoadModule=true
 
 #
-# Add custom concatenation
-# pli_SYSLIBConcatenation=
-# pli_linkedit_SYSLIBConcatenation=
+# additional libraries for compile SYSLIB concatenation, comma-separated
+pli_compileSyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+pli_linkEditSyslibConcatenation=

--- a/samples/application-conf/PLI.properties
+++ b/samples/application-conf/PLI.properties
@@ -43,3 +43,7 @@ pli_linkEdit=true
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 pli_scanLoadModule=true
+
+#
+# Add custom concatenation
+# pli_SYSLIBConcatenation=

--- a/samples/application-conf/PLI.properties
+++ b/samples/application-conf/PLI.properties
@@ -47,3 +47,4 @@ pli_scanLoadModule=true
 #
 # Add custom concatenation
 # pli_SYSLIBConcatenation=
+# pli_linkedit_SYSLIBConcatenation=

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -43,7 +43,9 @@ assembler_linkEdit | Flag indicating to execute the link edit step to produce a 
 assembler_maxRC | Default Assembler maximum RC allowed. | true
 assembler_linkEditMaxRC | Default link edit maximum RC allowed. | true
 assembler_resolutionRules | Assembler dependency resolution rules used to create a Assmebler dependency resolver.  Format is a JSON array of resolution rule property keys.  Resolution rule properties are defined in `application-conf/application.properties`. | true
-cobol_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+assembler_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+assembler_assemblySyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during assembly step | true
+assembler_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### BMS.properties
 Application properties used by zAppBuild/language/BMS.groovy
@@ -74,6 +76,8 @@ cobol_linkEditParms | Default link edit parameters. | true
 cobol_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
 cobol_isMQ | Flag indicating that the program contains MQ calls | true
 cobol_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+cobol_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
+cobol_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### LinkEdit.properties
 Application properties used by zAppBuild/language/LinkEdit.groovy
@@ -84,6 +88,7 @@ linkedit_fileBuildRank | Default link card build rank. Used to sort link card bu
 linkedit_maxRC | Default link edit maximum RC allowed. | true
 linkedit_parms | Default link edit parameters. | true
 linkedit_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+linkEdit_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### PLI.properties
 Application properties used by zAppBuild/language/LinkEdit.groovy
@@ -101,7 +106,9 @@ pli_compileSQLParms | Default SQL compile parameters. Appended to base parameter
 pli_compileErrorPrefixParms | IDz user build parameters. Appended to base parameters if has value. | true
 pli_linkEditParms | Default link edit parameters. | true
 pli_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
-plil_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+pli_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
+pli_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
+pli_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### bind.properties
 Application properties used by zAppBuild/language/COBOL.groovy


### PR DESCRIPTION
This is related to #49 _Simple way to add existing libraries to syslib concatenation_ 

By providing a comma-separated list of existing PDS libraries a user is able to contribute additional existing libraries to the syslib concatenation for ASM, Cobol, PLI or LinkEdit. DD statements for these libraries are added automatically by the language script -between the application libraries populated by zappbuild  and the system libraries for the middleware components. 