### PR TITLE
zUnit execution enhancements

### DIFF
--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -65,9 +65,9 @@ buildUtils.createLanguageDatasets(langQualifier)
 // BZUCBK=${props.cobol_testcase_loadPDS},
 // BZULOD=${props.cobol_loadPDS},
 //  PARM=('STOP=E,REPORT=XML')
-//BZUPLAY DD DISP=SHR,
+//REPLAY.BZUPLAY DD DISP=SHR,
 // DSN=${props.zunit_bzuplayPDS}(${playback})
-//BZURPT DD DISP=SHR,
+//REPLAY.BZURPT DD DISP=SHR,
 // DSN=${props.zunit_bzureportPDS}(${member})
 //*
 //IFGOOD IF RC<=4 THEN

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -77,7 +77,8 @@ buildUtils.createLanguageDatasets(langQualifier)
 //             SPACE=(TRK,(1,1),RLSE)
 //       ENDIF
 """
-	println(jcl)
+	if (props.verbose) println(jcl)
+		
 	def dbbConf = System.getenv("DBB_CONF")
 
 	// Create jclExec

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -131,13 +131,15 @@ buildUtils.createLanguageDatasets(langQualifier)
 		// manage processing the RC, up to your logic. You might want to flag the build as failed.
 		if (rc <= props.zunit_maxPassRC.toInteger()){
 			println   "***  zUnit Test Job ${zUnitRunJCL.submittedJobId} completed with $rc "
-			printReport(reportLogFile)
 			// Store Report in Workspace
 			new CopyToHFS().dataset(props.zunit_bzureportPDS).member(member).file(reportLogFile).hfsEncoding(props.logEncoding).append(false).copy()
+			// printReport 
+			printReport(reportLogFile)
 		} else if (rc <= props.zunit_maxWarnRC.toInteger()){
 			String warningMsg = "*! The zunit test returned a warning ($rc) for $buildFile"
 			// Store Report in Workspace
 			new CopyToHFS().dataset(props.zunit_bzureportPDS).member(member).file(reportLogFile).hfsEncoding(props.logEncoding).append(false).copy()
+			// print warning and report
 			println warningMsg
 			printReport(reportLogFile)
 			buildUtils.updateBuildResult(warningMsg:warningMsg,logs:["${member}_zunit.log":logFile],client:getRepositoryClient())


### PR DESCRIPTION
Adding #53 and #54 

JCL will now be displayed only on verbose mode.

Summary will look like this:

```
***  zUnit Test Job RUNZUNIT(JOB09534) completed with 4 
****************** Module [TEBUD01] ******************
Name:       TEBUD01
Status:     warn
Test cases: 2 (1 passed, 1 failed, 0 errors)
Details: 
      TEST2   pass
      TEST3   warn
****************** Module [TEBUD01] ****************** 
```