### PR TITLE
Support renaming / moving files in the repo

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -443,7 +443,7 @@ def createBuildList() {
 	// since impact build list creation already scanned the incoming changed files
 	// we do not need to scan them again
 	if (!props.impactBuild && !props.userBuild) {
-		impactUtils.updateCollection(buildList, null, repositoryClient)
+		impactUtils.updateCollection(buildList, null, null, repositoryClient)
 	}
 	
 	return buildList

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -15,16 +15,16 @@ def isGitDir(String dir) {
 	StringBuffer gitResponse = new StringBuffer()
 	StringBuffer gitError = new StringBuffer()
 	boolean isGit = false
-	
+
 	Process process = cmd.execute()
 	process.waitForProcessOutput(gitResponse, gitError)
 	if (gitError) {
-		println("*? Warning executing isGitDir($dir). Git command: $cmd error: $gitError")	
+		println("*? Warning executing isGitDir($dir). Git command: $cmd error: $gitError")
 	}
 	else if (gitResponse) {
 		isGit = gitResponse.toString().trim().toBoolean()
 	}
-		
+
 	return isGit
 }
 
@@ -38,7 +38,7 @@ def getCurrentGitBranch(String gitDir) {
 	String cmd = "git -C $gitDir rev-parse --abbrev-ref HEAD"
 	StringBuffer gitBranch = new StringBuffer()
 	StringBuffer gitError = new StringBuffer()
-	
+
 	Process process = cmd.execute()
 	process.waitForProcessOutput(gitBranch, gitError)
 	if (gitError) {
@@ -53,16 +53,16 @@ def getCurrentGitBranch(String gitDir) {
  * @param  String gitDir  		Local Git repository directory
  * @return String gitBranch     The current Git branch
  */
- def getCurrentGitDetachedBranch(String gitDir) {
-	 String cmd = "git -C $gitDir show -s --pretty=%D HEAD"
-	 StringBuffer gitBranch = new StringBuffer()
-	 StringBuffer gitError = new StringBuffer()
+def getCurrentGitDetachedBranch(String gitDir) {
+	String cmd = "git -C $gitDir show -s --pretty=%D HEAD"
+	StringBuffer gitBranch = new StringBuffer()
+	StringBuffer gitError = new StringBuffer()
 
-	 Process process = cmd.execute();
-	 process.waitForProcessOutput(gitBranch, gitError)
-	 if (gitError) {
-		 println("*! Error executing Git command: $cmd error: $gitError")
-	 }
+	Process process = cmd.execute();
+	process.waitForProcessOutput(gitBranch, gitError)
+	if (gitError) {
+		println("*! Error executing Git command: $cmd error: $gitError")
+	}
 
 	String gitBranchString = gitBranch.toString()
 	def gitBranchArr = gitBranchString.split(',')
@@ -74,26 +74,26 @@ def getCurrentGitBranch(String gitDir) {
 	}
 
 	return (solution != "") ? solution : println("*! Error parsing branch name: $gitBranch")
- }
+}
 
 /*
  * Returns true if this is a detached HEAD
  *
  * @param  String gitDir  		Local Git repository directory
  */
- def isGitDetachedHEAD(String gitDir) {
-	 String cmd = "git -C $gitDir status"
-	 StringBuffer gitStatus = new StringBuffer()
-	 StringBuffer gitError = new StringBuffer()
+def isGitDetachedHEAD(String gitDir) {
+	String cmd = "git -C $gitDir status"
+	StringBuffer gitStatus = new StringBuffer()
+	StringBuffer gitError = new StringBuffer()
 
-	 Process process = cmd.execute()
-	 process.waitForProcessOutput(gitStatus, gitError)
-	 if (gitError) {
-		 println("*! Error executing Git command: $cmd error $gitError")
-	 }
-	 
-	 return gitStatus.toString().contains("HEAD detached at")
- }
+	Process process = cmd.execute()
+	process.waitForProcessOutput(gitStatus, gitError)
+	if (gitError) {
+		println("*! Error executing Git command: $cmd error $gitError")
+	}
+
+	return gitStatus.toString().contains("HEAD detached at")
+}
 
 /*
  * Returns the current Git hash
@@ -105,9 +105,9 @@ def getCurrentGitHash(String gitDir) {
 	String cmd = "git -C $gitDir rev-parse HEAD"
 	StringBuffer gitHash = new StringBuffer()
 	StringBuffer gitError = new StringBuffer()
-	
+
 	Process process = cmd.execute()
-	process.waitForProcessOutput(gitHash, gitError) 	
+	process.waitForProcessOutput(gitHash, gitError)
 	if (gitError) {
 		print("*! Error executing Git command: $cmd error: $gitError")
 	}
@@ -125,7 +125,7 @@ def getFileCurrentGitHash(String gitDir, String filePath) {
 	String cmd = "git -C $gitDir rev-list -1 HEAD " + filePath
 	StringBuffer gitHash = new StringBuffer()
 	StringBuffer gitError = new StringBuffer()
-	
+
 	Process process = cmd.execute()
 	process.waitForProcessOutput(gitHash, gitError)
 	if (gitError) {
@@ -144,10 +144,10 @@ def getCurrentGitUrl(String gitDir) {
 	String cmd = "git -C $gitDir config --get remote.origin.url"
 	StringBuffer gitUrl = new StringBuffer()
 	StringBuffer gitError = new StringBuffer()
-	
+
 	Process process = cmd.execute()
 	process.waitForProcessOutput(gitUrl, gitError)
-	
+
 	if (gitError) {
 		print("*! Error executing Git command: $cmd error: $gitError")
 	}
@@ -165,7 +165,7 @@ def getPreviousGitHash(String gitDir) {
 	String cmd = "git -C $gitDir --no-pager log -n 1 --skip=1"
 	StringBuffer gitStdout = new StringBuffer()
 	StringBuffer gitError = new StringBuffer()
-	
+
 	Process process = cmd.execute()
 	process.waitForProcessOutput(gitStdout, gitError)
 	if (gitError) {
@@ -183,66 +183,67 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
 	def changedFiles = []
 	def deletedFiles = []
 	def renamedFiles = []
-	
+
 	def process = cmd.execute()
 	process.waitForProcessOutput(git_diff, git_error)
-	
+
 	// handle command error
 	if (git_error.size() > 0) {
 		println("*! Error executing Git command: $cmd error: $git_error")
 		println ("*! Attempting to parse unstable git command for changed files...")
 	}
-	
+
 	for (line in git_diff.toString().split("\n")) {
 		// process files from git diff
 		try {
-			action = line.split()[0]
-			file = line.split()[1]
-			// handle deleted files
-			if (action == "D") {
-				deletedFiles.add(file)
-			}
-			// handle changed and new added files
-			if (action == "M" || action == "A") {
+			gitDiffOutput = line.split()
+			action = gitDiffOutput[0]
+			file = gitDiffOutput[1]
+			
+			if (action == "M" || action == "A") { // handle changed and new added files
 				changedFiles.add(file)
-			}
-			
-			// handle renamed file
-			if (action == "R100") {
-				renamedFile = line.split()[1]
-				newFileName = file = line.split()[2]
-				
-				changedFiles.add(newFileName)
+			} else if (action == "D") {// handle deleted files
+				deletedFiles.add(file)
+			} else if (action == "R100") { // handle renamed file
+				renamedFile = gitDiffOutput[1]
+				newFileName = gitDiffOutput[2]
+				changedFiles.add(newFileName) // will rebuild file
 				renamedFiles.add(renamedFile)
-				
 			}
-			
+			else {
+				println ("*! (GitUtils.getChangedFiles) Error in determining action in git diff. ")
+				println ("*! (GitUtils.getChangedFiles) Git diff output: $line. ")
+			}
 		}
 		catch (Exception e) {
 			// no changes or unhandled format
 		}
 	}
-	
-	return [changedFiles, deletedFiles, renamedFiles]
+
+	return [
+		changedFiles,
+		deletedFiles,
+		renamedFiles
+	]
 }
 
 def getCurrentChangedFiles(String gitDir, String currentHash, String verbose) {
 	if (verbose) println "** Running git command: git -C $gitDir show --pretty=format: --name-status $currentHash"
-	String cmd = "git -C $gitDir show --pretty=format: --name-status $currentHash"	
+	String cmd = "git -C $gitDir show --pretty=format: --name-status $currentHash"
 	def gitDiff = new StringBuffer()
 	def gitError = new StringBuffer()
 	def changedFiles = []
 	def deletedFiles = []
-	
+
 	Process process = cmd.execute()
 	process.waitForProcessOutput(gitDiff, gitError)
-	
+
 	// handle command error
 	if (gitError.size() > 0) {
 		println("*! Error executing Git command: $cmd error: $gitError")
 		println ("*! Attempting to parse unstable git command for changed files...")
 	}
-	
+
 	for (line in gitDiff.toString().split("\n")) {
 		if (verbose) println "** Git command line: $line"
 		// process files from git diff
@@ -262,7 +263,7 @@ def getCurrentChangedFiles(String gitDir, String currentHash, String verbose) {
 			// no changes or unhandled format
 		}
 	}
-	
+
 	return [changedFiles, deletedFiles]
 }
 

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -182,6 +182,7 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
 	def git_error = new StringBuffer()
 	def changedFiles = []
 	def deletedFiles = []
+	def renamedFiles = []
 	
 	def process = cmd.execute()
 	process.waitForProcessOutput(git_diff, git_error)
@@ -202,16 +203,27 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
 				deletedFiles.add(file)
 			}
 			// handle changed files
-			else {
+			if (action == "M") {
 				changedFiles.add(file)
 			}
+			
+			// handle renamed file
+			if (action == "R100") {
+				renamedFile = line.split()[1]
+				newFileName = file = line.split()[2]
+				
+				changedFiles.add(newFileName)
+				renamedFiles.add(renamedFile)
+				
+			}
+			
 		}
 		catch (Exception e) {
 			// no changes or unhandled format
 		}
 	}
 	
-	return [changedFiles, deletedFiles]
+	return [changedFiles, deletedFiles, renamedFiles]
 }
 
 def getCurrentChangedFiles(String gitDir, String currentHash, String verbose) {

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -202,8 +202,8 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
 			if (action == "D") {
 				deletedFiles.add(file)
 			}
-			// handle changed files
-			if (action == "M") {
+			// handle changed and new added files
+			if (action == "M" || action == "A") {
 				changedFiles.add(file)
 			}
 			

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -231,16 +231,18 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 	deletedFiles.each { file ->
 		// files in a collection are stored as relative paths from a source directory
 		if (props.verbose) println "*** Deleting logical file for $file"
-		repositoryClient.deleteLogicalFile(props.applicationCollectionName, buildUtils.relativizePath(file))
-		repositoryClient.deleteLogicalFile(props.applicationOutputsCollectionName, buildUtils.relativizePath(file))
+		logicalFile = buildUtils.relativizePath(file)
+		repositoryClient.deleteLogicalFile(props.applicationCollectionName, logicalFile)
+		repositoryClient.deleteLogicalFile(props.applicationOutputsCollectionName, logicalFile)
 	}
 
 	// remove renamed files from collection
 	renamedFiles.each { file ->
 		// files in a collection are stored as relative paths from a source directory
 		if (props.verbose) println "*** Deleting renamed logical file for $file"
-		repositoryClient.deleteLogicalFile(props.applicationCollectionName, buildUtils.relativizePath(file))
-		repositoryClient.deleteLogicalFile(props.applicationOutputsCollectionName, buildUtils.relativizePath(file))
+		logicalFile = buildUtils.relativizePath(file)
+		repositoryClient.deleteLogicalFile(props.applicationCollectionName, logicalFile)
+		repositoryClient.deleteLogicalFile(props.applicationOutputsCollectionName, logicalFile)
 	}
 
 	// scan changed files

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -384,7 +384,7 @@ def fixGitDiffPath(String file, String dir, boolean mustExist, mode) {
 
 	if ( new File("${props.workspace}/${fixedFileName}").exists())
 		return [fixedFileName, 1];
-	if (mode==1) return fixedFileName
+	if (mode==1 && !mustExist) return fixedFileName
 
 	// Scenario 2: Repository name is used as Application Root directory
 	String dirName = new File(dir).getName()
@@ -393,7 +393,7 @@ def fixGitDiffPath(String file, String dir, boolean mustExist, mode) {
 			"$dirName/$file" as String,
 			2
 		]
-	if (mode==2) return "$dirName/$file" as String
+	if (mode==2 && !mustExist) return "$dirName/$file" as String
 
 	// Scenario 3: Directory ${dir} is not the root directory of the file
 	// Example :
@@ -401,7 +401,7 @@ def fixGitDiffPath(String file, String dir, boolean mustExist, mode) {
 	fixedFileName = buildUtils.relativizePath(dir) + ( file.indexOf ("/") >= 0 ? file.substring(file.lastIndexOf("/")) : file )
 	if ( new File("${props.workspace}/${fixedFileName}").exists())
 		return [fixedFileName, 3];
-	if (mode==3) return fixedFileName
+	if (mode==3 && !mustExist) return fixedFileName
 
 	// returns null or assumed fullPath to file
 	if (mustExist){

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -171,7 +171,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 			(file, mode) = fixGitDiffPath(file, dir, true, null)
 			if ( file != null ) {
 				changedFiles << file
-				if (props.verbose) println "*** $file"
+				if (props.verbose) println "** $file"
 			}
 		}
 
@@ -179,14 +179,14 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 		deleted.each { file ->
 			file = fixGitDiffPath(file, dir, false, mode)
 			deletedFiles << file
-			if (props.verbose) println "*** $file"
+			if (props.verbose) println "** $file"
 		}
 		
 		if (props.verbose) println "*** Renamed files for directory $dir:"
 		renamed.each { file ->
 			file = fixGitDiffPath(file, dir, false, mode)
 			renamedFiles << file
-			if (props.verbose) println "*** $file"
+			if (props.verbose) println "** $file"
 		}
 	}
 
@@ -226,7 +226,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 		// files in a collection are stored as relative paths from a source directory
 		if (props.verbose) println "*** Deleting logical file for $file"
 		repositoryClient.deleteLogicalFile(props.applicationCollectionName, buildUtils.relativizePath(file))
-		//props.applicationOutputsCollectionName
+		repositoryClient.deleteLogicalFile(props.applicationOutputsCollectionName, buildUtils.relativizePath(file))
 	}
 	
 	// remove renamed files from collection
@@ -234,7 +234,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 		// files in a collection are stored as relative paths from a source directory
 		if (props.verbose) println "*** Deleting renamed logical file for $file"
 		repositoryClient.deleteLogicalFile(props.applicationCollectionName, buildUtils.relativizePath(file))
-		//props.applicationOutputsCollectionName
+		repositoryClient.deleteLogicalFile(props.applicationOutputsCollectionName, buildUtils.relativizePath(file))
 	}
 
 	// scan changed files


### PR DESCRIPTION
This addresses the scenario of renaming or moving files within a git repository.

In git, an exact move is presented in the git diff as:
```
> git --no-pager diff --name-status hash1 hash2
R100	genapp/cobol/Tlgicdb0.cbl	genapp/testcase/Tlgicdb0.cbl
```
`fixGitDiffPath` is enhanced to capture the mode, in which the repository layout is used (important in rename and delete scenarios, while we cannot test if the file exists).

Additionally, updating the dbb collections is improved and expanded to the output collection as well.

Addresses issue #62 