### PR TITLE
Fixed typo in property name

### DIFF
--- a/build-conf/Assembler.properties
+++ b/build-conf/Assembler.properties
@@ -2,7 +2,7 @@
 
 #
 # Comma separated list of required build properties for language/Assembler.groovy
-assembler_requiredBuildPropeties=assembler_srcPDS,assembler_macroPDS,assembler_objPDS,assembler_loadPDS, \
+assembler_requiredBuildProperties=assembler_srcPDS,assembler_macroPDS,assembler_objPDS,assembler_loadPDS, \
   assembler_pgm,assembler_linkEditor,assembler_tempOptions,assembler_maxRC, \
   SASMMOD1,SDFHLOAD,SDFHMAC,MACLIB,SCEELKED,SCEEMAC
 


### PR DESCRIPTION
Updated assembler_requiredBuildProperties to match what is being used in Assembler.groovy