### PR TITLE
New option for file level overwrites

### DIFF
--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -45,7 +45,7 @@ dbb.RepositoryClient.userId | DBB configuration property for web application log
 dbb.RepositoryClient.password | DBB configuration property for web application logon password.  ***Can be overridden by build.groovy option -pw, --pw***
 dbb.RepositoryClient.passwordFile | DBB configuration property for web application logon password file.  ***Can be overridden by build.groovy option -pf, --pf***
 allowFileLevelOverwrites| Configuration property to enable zAppBuild to search for property files for each buildable file defined by the propertiesFileLocation property in application-conf 
-whitelistFileLevelOverwrites | Comma-separated list of file level properties, which can be overridden by a file level property file retrieved via props.getFileProperty api in the lanaguage scripts
+whitelistFileLevelOverwrites | Comma-separated list of file level properties, which can be overridden by a file level property file retrieved via props.getFileProperty api in the language scripts. If empty, any overwrite is allowed. As soon as one entry exists, it validates against the list.
 
 ### Assembler.properties
 Build properties used by zAppBuild/language/Assembler.groovy

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -44,7 +44,8 @@ dbb.RepositoryClient.url | DBB configuration property for web application URL.  
 dbb.RepositoryClient.userId | DBB configuration property for web application logon id.  ***Can be overridden by build.groovy option -id, --id***
 dbb.RepositoryClient.password | DBB configuration property for web application logon password.  ***Can be overridden by build.groovy option -pw, --pw***
 dbb.RepositoryClient.passwordFile | DBB configuration property for web application logon password file.  ***Can be overridden by build.groovy option -pf, --pf***
-
+allowFileLevelOverwrites| Configuration property to enable zAppBuild to search for property files for each buildable file defined by the propertiesFileLocation property in application-conf 
+whitelistFileLevelOverwrites | Comma-separated list of file level properties, which can be overridden by a file level property file retrieved via props.getFileProperty api in the lanaguage scripts
 
 ### Assembler.properties
 Build properties used by zAppBuild/language/Assembler.groovy

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -113,5 +113,6 @@ dbb.gateway.logLevel=2
 allowFileLevelOverwrites=false
 
 # Manage a comma-separated list of allowed file level properties, which are retrieved via props.getFileProperty api
+# If empty, any overwrite is allowed. As soon as one entry exists, it validates against the list.
 whitelistFileLevelOverwrites=
 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -109,6 +109,9 @@ dbb.gateway.regionSize=
 # 16 - Log information to the system console
 dbb.gateway.logLevel=2
 
+# boolean condition to activate looking for file level property files 
+allowFileLevelOverwrites=true
 
-
+# Comma-separated list of permitted file level properties, which are retrieved via props.getFileProperty api
+whitelistFileLevelOverwrites=cobol_compileParms
 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -109,9 +109,9 @@ dbb.gateway.regionSize=
 # 16 - Log information to the system console
 dbb.gateway.logLevel=2
 
-# boolean condition to activate looking for file level property files 
-allowFileLevelOverwrites=true
+# boolean condition (default:false) to activate looking for file level property files
+allowFileLevelOverwrites=false
 
-# Comma-separated list of permitted file level properties, which are retrieved via props.getFileProperty api
-whitelistFileLevelOverwrites=cobol_compileParms
+# Manage a comma-separated list of allowed file level properties, which are retrieved via props.getFileProperty api
+whitelistFileLevelOverwrites=
 

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -6,9 +6,10 @@ import groovy.transform.*
 
 
 // define script properties
-@Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-@Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
+@Field BuildProperties zApp = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def impactUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
+@Field def props = buildUtils
 @Field RepositoryClient repositoryClient
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -6,9 +6,9 @@ import groovy.transform.*
 
 
 // define script properties
-@Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-
+@Field BuildProperties zApp = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def props = buildUtils
 @Field RepositoryClient repositoryClient
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -7,10 +7,11 @@ import com.ibm.jzos.ZFile
 
 
 // define script properties
-@Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-@Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
-@Field def bindUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BindUtilities.groovy"))
+@Field BuildProperties zApp = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def impactUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
+@Field def bindUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BindUtilities.groovy"))
+@Field def props = buildUtils 
 @Field RepositoryClient repositoryClient
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")

--- a/languages/DBDgen.groovy
+++ b/languages/DBDgen.groovy
@@ -5,9 +5,9 @@ import com.ibm.dbb.build.*
 import groovy.transform.*
 
 // define script properties
-@Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-
+@Field BuildProperties zApp = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def props = buildUtils
 @Field RepositoryClient repositoryClient
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -6,9 +6,10 @@ import groovy.transform.*
 
 
 // define script properties
-@Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-@Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
+@Field BuildProperties zApp = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def impactUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
+@Field def props = buildUtils
 @Field RepositoryClient repositoryClient
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")

--- a/languages/MFS.groovy
+++ b/languages/MFS.groovy
@@ -7,9 +7,9 @@ import groovy.transform.*
 // docs: https://www.ibm.com/support/knowledgecenter/en/SSEPH2_13.1.0/com.ibm.ims13.doc.sur/ims_mfslangbatchmd.htm
 
 // define script properties
-@Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-
+@Field BuildProperties zApp = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def props = buildUtils
 @Field RepositoryClient repositoryClient
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -7,9 +7,11 @@ import com.ibm.jzos.ZFile
 
 
 // define script properties
-@Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-@Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
+@Field BuildProperties zApp = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def impactUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
+@Field def bindUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BindUtilities.groovy"))
+@Field def props = buildUtils 
 @Field RepositoryClient repositoryClient
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")

--- a/languages/PSBgen.groovy
+++ b/languages/PSBgen.groovy
@@ -5,9 +5,9 @@ import com.ibm.dbb.build.*
 import groovy.transform.*
 
 // define script properties
-@Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-
+@Field BuildProperties zApp = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def props = buildUtils
 @Field RepositoryClient repositoryClient
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -6,10 +6,10 @@ import groovy.transform.*
 
 
 // define script properties
-@Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-@Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
-@Field def bindUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BindUtilities.groovy"))
+@Field BuildProperties zApp = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def impactUtils= loadScript(new File("${zApp.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
+@Field def props = buildUtils 
 @Field RepositoryClient repositoryClient
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -19,6 +19,7 @@ mainBuildBranch | The main build branch of the main application repository.  Use
 excludeFileList | Files to exclude when scanning or running full build.
 skipImpactCalculationList | Files for which the impact analysis should be skipped in impact build
 jobCard | JOBCARD for JCL execs
+propertiesFileLocation |  Location of property files providing file level property overwrites, files follow naming convention <sourcefile-name>.*** -> <sourcefile-name>.properties
 impactResolutionRules | Comma separated list of resolution rule properties used for impact builds.  Sample resolution rule properties (in JSON format) are included below.
 
 ### file.properties

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -19,7 +19,7 @@ mainBuildBranch | The main build branch of the main application repository.  Use
 excludeFileList | Files to exclude when scanning or running full build.
 skipImpactCalculationList | Files for which the impact analysis should be skipped in impact build
 jobCard | JOBCARD for JCL execs
-propertiesFileLocation |  Location of property files providing file level property overwrites, files follow naming convention <sourcefile-name>.*** -> <sourcefile-name>.properties
+propertiesFileLocation |  Location of property files providing file level property overwrites, files follow naming convention <sourcefile-name>.<ext> -> <sourcefile-name>.<ext>.properties
 impactResolutionRules | Comma separated list of resolution rule properties used for impact builds.  Sample resolution rule properties (in JSON format) are included below.
 
 ### file.properties

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -44,7 +44,7 @@ skipImpactCalculationList=
 jobCard=
 
 #
-# folder of property files for file level property overwrites; relative to {props.application}; files follow the naming convention <sourcefile-name>.*** -> <sourcefile-name>.properties
+# folder of property files for file level property overwrites; relative to {props.application}; files follow the naming convention <sourcefile-name>.<ext> -> <sourcefile-name>.<ext>.properties
 # {props.application}/{propertiesFileLocation}
 # see properties allowFileLevelOverwrites + whitelistFileLevelOverwrites in build-conf/build.properties
 propertiesFileLocation = properties

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -43,7 +43,11 @@ skipImpactCalculationList=
 # Example: jobCard=//RUNZUNIT JOB ,MSGCLASS=H,CLASS=A,NOTIFY=&SYSUID,REGION=0M
 jobCard=
 
-
+#
+# folder of property files for file level property overwrites; relative to {props.application}; files follow the naming convention <sourcefile-name>.*** -> <sourcefile-name>.properties
+# {props.application}/{propertiesFileLocation}
+# see properties allowFileLevelOverwrites + whitelistFileLevelOverwrites in build-conf/build.properties
+propertiesFileLocation = properties
 
 #
 # Impact analysis resolution rules (JSON format).

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -386,31 +386,6 @@ def getFileProperty(String prop, String buildFile){
 			fileLevelProperty = fileLevelOverwrites.getProperty(prop)
 			if (fileLevelProperty!=null){
 				if (props.verbose) println("** File level overwrite found for $buildFile - $prop: $fileLevelProperty")
-				if (props.verbose)
-					return fileLevelProperty
-			}
-		}
-	}
-
-	//return DBB File Property or Global property
-	return props.getFileProperty(prop, buildFile)
-}
-
-/*
- * getFileProperty - verifies if a properties file for the buildFile exists to overwrite properties 
- */
-def getFileProperty(String prop, String buildFile){
-	// validate if build framework allows overwrites
-	if (props.allowFileLevelOverwrites && props.allowFileLevelOverwrites.toBoolean()){
-		if(!fileLevelPropertiesCache.containsKey(buildFile)){
-			loadFileLevelOverwrites(buildFile)
-		}
-
-		fileLevelOverwrites = fileLevelPropertiesCache.get(buildFile)
-		if (fileLevelOverwrites != null) {
-			fileLevelProperty = fileLevelOverwrites.getProperty(prop)
-			if (fileLevelProperty!=null){
-				if (props.verbose) println("** File level overwrite found for $buildFile - $prop: $fileLevelProperty")
 				// check if overwrite is allowed
 				if (props.whitelistFileLevelOverwrites.split(",").contains(prop))
 					return fileLevelProperty
@@ -437,8 +412,8 @@ static def propertyMissing(String name) {
  */
 def loadFileLevelOverwrites(String buildFile){
 
-	String member = getFileNameWithoutExtension(buildFile)
-	String propertyFile = getAbsolutePath(props.application) + "/$props.propertiesFileLocation/${member}.properties"
+	String buildmember = getFileNameWithExtension(buildFile)
+	String propertyFile = getAbsolutePath(props.application) + "/$props.propertiesFileLocation/${buildmember}.properties"
 	File file = new File (propertyFile)
 	Properties fileProperties = new Properties()
 
@@ -456,13 +431,14 @@ def loadFileLevelOverwrites(String buildFile){
 }
 
 /*
- * get filename without file extension
+ * get filename
  */
-def getFileNameWithoutExtension(String buildFile){
-	int pos = buildFile.lastIndexOf(".");
+def getFileNameWithExtension(String buildFile){
 	int posFolder = buildFile.lastIndexOf("/")
 
-	if (pos > 0) {
-		return buildFile.substring(posFolder+1, pos);
+	if (posFolder > 0) {
+		return buildFile.substring(posFolder+1);
+	} else {
+		if(props.verbose ) println("** Could not retrieve file name from $buildFile")
 	}
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -411,7 +411,7 @@ def getFileProperty(String prop, String buildFile){
 			fileLevelProperty = fileLevelOverwrites.getProperty(prop)
 			if (fileLevelProperty!=null){
 				if (props.verbose) println("** File level overwrite found for $buildFile - $prop: $fileLevelProperty")
-				// check if overwrite is allowed 
+				// check if overwrite is allowed
 				if (props.whitelistFileLevelOverwrites.contains(prop))
 					return fileLevelProperty
 				else
@@ -465,3 +465,4 @@ def getFileNameWithoutExtension(String buildFile){
 	if (pos > 0) {
 		return buildFile.substring(posFolder+1, pos);
 	}
+}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -412,7 +412,7 @@ def getFileProperty(String prop, String buildFile){
 			if (fileLevelProperty!=null){
 				if (props.verbose) println("** File level overwrite found for $buildFile - $prop: $fileLevelProperty")
 				// check if overwrite is allowed
-				if (props.whitelistFileLevelOverwrites.contains(prop))
+				if (props.whitelistFileLevelOverwrites.split(",").contains(prop))
 					return fileLevelProperty
 				else
 				if (props.verbose) println("*! Overwrite for $prop not allowed. Not on whitelist. See build property whitelistFileLevelOverwrites.")


### PR DESCRIPTION
As described in #83 , we would like to provide a new option to allow file level overwrites through a dedicated properties file.

This PR has the following components:
- The application can manage a dedicated property file in a subfolder for each build file. The property file can contain any build property which is retrieved in the language scripts via the `getFileProperty()` Method. `application.properties` defines the location of the property files.
- The build team can activate this feature in build-conf. Additionally, property overwrites are checked against a whitelist of properties. See the readme of build-conf.

Attention: Use this feature with care - if you go with the approach of 1 property file for each source file (and for all source file you have), and one day you have to modify a property, will require to modify hundreds or thousands property files. We recommend to use it for exceptions.

### Sample usage:

For the **application team**: Within the MortgageApplication application, a new subfolder contains property files on a file basis:
![image](https://user-images.githubusercontent.com/28918869/107512524-40743480-6ba7-11eb-84b3-91ee75706dc1.png)

The file name has to match with the file name of the buildfile.

sample contents of `MortgageApplication/properties/epsnbrvl.properties`
```
cobol_compileParms=HUGO
cobol_compilerVersion=V4
```

Additionally, the location of the properties file need to be specified in the `application.properties` in application-conf
```
#
# location for file level overwrites relative to {props.application}
# {props.application}/{propertiesFileLocation}
propertiesFileLocation = properties

```

The **build admins** activates the feature in build-conf as well as defines the whitelist of properties which are allowed to be overwritten.
```
# boolean condition to activate looking for file level property files 
allowFileLevelOverwrites=true

# Comma-separated list of permitted file level properties, which are retrieved via props.getFileProperty api
whitelistFileLevelOverwrites=cobol_compileParms
```

Sample output:

```
MortgageApplication/cobol/epsnbrvl.cbl
** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
** Building files mapped to Cobol.groovy script
required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
** Creating / verifying build dataset DBEHM.DBB.BUILD.COBOL
** Creating / verifying build dataset DBEHM.DBB.BUILD.COPY
** Creating / verifying build dataset DBEHM.DBB.BUILD.OBJ
** Creating / verifying build dataset DBEHM.DBB.BUILD.DBRM
** Creating / verifying build dataset DBEHM.DBB.BUILD.LOAD
*** Building file MortgageApplication/cobol/epsnbrvl.cbl
>>> ** Loaded file level property overwrites for MortgageApplication/cobol/epsnbrvl.cbl:
>>>>   [cobol_compileParms:HUGO, cobol_compilerVersion:V4]
*** Creating dependency resolver for MortgageApplication/cobol/epsnbrvl.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
*** Scanning file with the default scanner
*** Resolution rules for MortgageApplication/cobol/epsnbrvl.cbl:
{"library":"SYSLIB","searchPath":[{"sourceDir":"\/u\/dbehm\/test\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
*** Physical dependencies for MortgageApplication/cobol/epsnbrvl.cbl:
{"sourceDir":"\/u\/dbehm\/test\/dbb-zappbuild\/samples","lname":"EPSNBRPM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","category":"COPY","resolved":true}
>>> ** File level overwrite found for MortgageApplication/cobol/epsnbrvl.cbl - cobol_compileParms: HUGO
Cobol compiler parms for MortgageApplication/cobol/epsnbrvl.cbl = HUGO
>>> ** File level overwrite found for MortgageApplication/cobol/epsnbrvl.cbl - cobol_compilerVersion: V4
>>> *! Overwrite for cobol_compilerVersion not allowed. Not on whitelist. See build property whitelistFileLevelOverwrites.
** Writing build report data to /u/dbehm/test/work/Mortgage/BuildReport.json
```

