### PR TITLE
Advanced scanOnly scenario to scan existing loadmodules

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -36,6 +36,10 @@ $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1
 ```
 $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --fullBuild --scanOnly
 ```
+**Scan source files and existing load modules for the application to collect dependency data for source and outputs without actually creating load modules**
+```
+$DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --fullBuild --scanOnly --scanLoadmodules
+```
 
 ## Command Line Options Summary
 ```
@@ -61,6 +65,7 @@ build options:
  -i,--impactBuild         Flag indicating to build only programs impacted
                           by changed files since last successful build.
  -s,--scanOnly            Flag indicating to only scan files for application
+ -sl,--scanLoadmodules    Flag indicating to scan loadmodules based on provided hlq, mutual to --scanOnly
  -r,--reset               Deletes the application's dependency collections 
                           and build result group from the DBB repository
  -v,--verbose             Flag to turn on script trace

--- a/BUILD.md
+++ b/BUILD.md
@@ -38,7 +38,7 @@ $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1
 ```
 **Scan source files and existing load modules for the application to collect dependency data for source and outputs without actually creating load modules**
 ```
-$DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --fullBuild --scanOnly --scanLoadmodules
+$DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --fullBuild --scanAll
 ```
 
 ## Command Line Options Summary
@@ -64,8 +64,12 @@ build options:
                           the application
  -i,--impactBuild         Flag indicating to build only programs impacted
                           by changed files since last successful build.
- -s,--scanOnly            Flag indicating to only scan files for application
- -sl,--scanLoadmodules    Flag indicating to scan loadmodules based on provided hlq, mutual to --scanOnly
+                          
+ -s,--scanOnly            Flag indicating to only scan source files for application without building anything (deprecated use --scanSource)
+ -ss,--scanSource         Flag indicating to only scan source files for application without building anything
+ -sl,--scanLoad           Flag indicating to only scan load modules for application without building anything
+ -sa,--scanAll            Flag indicating to scan both source files and load modules for application without building anything
+ 
  -r,--reset               Deletes the application's dependency collections 
                           and build result group from the DBB repository
  -v,--verbose             Flag to turn on script trace

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ zAppBuild supports a number of build scenarios:
 * **Full Build** - Build all programs (or buildable files) of an application.
 * **Impact Build** - Build only programs impacted by source files that have changed since the last successful build.
 * **Topic Branch Build** - Detects when building a topic branch for the first time and will automatically clone the dependency data collections from the main build branch in order to avoid having to rescan the entire application.
-* **Scan Only** - Skip the actual building and only scan source files for dependency data.
+* **Scan Only** - Skip the actual building and only scan source files for dependency data (migration scenario).
+* **Scan Only Source + Outputs** - Skip the actual building and only scan source files and existing load modules for dependency data (migration scenario with static linkage scenarios) .
+
 
 Links to additional documentation is provided in the table below.  Instructions on invoking a zAppBuild is included in [BUILD.md](BUILD.md).
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ zAppBuild supports a number of build scenarios:
 * **Full Build** - Build all programs (or buildable files) of an application.
 * **Impact Build** - Build only programs impacted by source files that have changed since the last successful build.
 * **Topic Branch Build** - Detects when building a topic branch for the first time and will automatically clone the dependency data collections from the main build branch in order to avoid having to rescan the entire application.
-* **Scan Only** - Skip the actual building and only scan source files for dependency data (migration scenario).
-* **Scan Only Source + Outputs** - Skip the actual building and only scan source files and existing load modules for dependency data (migration scenario with static linkage scenarios) .
+* **Scan Source** - Skip the actual building and only scan source files to store dependency data in collection (migration scenario).
+* **Scan Source + Outputs** - Skip the actual building and only scan source files and existing load modules to dependency data in source and output collection (migration scenario with static linkage scenarios).
 
 
 Links to additional documentation is provided in the table below.  Instructions on invoking a zAppBuild is included in [BUILD.md](BUILD.md).

--- a/build.groovy
+++ b/build.groovy
@@ -57,7 +57,7 @@ else {
 			}
 			processCounter = processCounter + buildFiles.size()
 		}
-	} else if(props.scanOnly && props.scanLoadmodules && props.scanLoadmodules.toBoolean()){
+	} else if(props.scanLoadmodules && props.scanLoadmodules.toBoolean()){
 		println ("** Scanning loadmodules for static dependencies.")
 		impactUtils.scanOnlyStaticDependencies(buildList, repositoryClient)
 	}
@@ -164,11 +164,15 @@ options:
 	cli.l(longOpt:'logEncoding', args:1, 'Encoding of output logs. Default is EBCDIC')
 	cli.f(longOpt:'fullBuild', 'Flag indicating to build all programs for application')
 	cli.i(longOpt:'impactBuild', 'Flag indicating to build only programs impacted by changed files since last successful build.')
-	cli.s(longOpt:'scanOnly', 'Flag indicating to only scan files for application')
-	cli.sl(longOpt:'scanLoadmodules', 'Flag indicating to scan loadmodules based on provided hlq')
 	cli.r(longOpt:'reset', 'Deletes the dependency collections and build result group from the DBB repository')
 	cli.v(longOpt:'verbose', 'Flag to turn on script trace')
 
+	// scan options
+	cli.s(longOpt:'scanOnly', 'Flag indicating to only scan source files for application without building anything (deprecated use --scanSource)')
+	cli.ss(longOpt:'scanSource', 'Flag indicating to only scan source files for application without building anything')
+	cli.sl(longOpt:'scanLoad', 'Flag indicating to only scan load modules for application without building anything')
+	cli.sa(longOpt:'scanAll', 'Flag indicating to scan both source files and load modules for application without building anything')
+	
 	// web application credentials (overrides properties in build.properties)
 	cli.url(longOpt:'url', args:1, 'DBB repository URL')
 	cli.id(longOpt:'id', args:1, 'DBB repository id')
@@ -296,12 +300,16 @@ def populateBuildProperties(String[] args) {
 	if (opts.l) props.logEncoding = opts.l
 	if (opts.f) props.fullBuild = 'true'
 	if (opts.i) props.impactBuild = 'true'
-	if (opts.s) props.scanOnly = 'true'
 	if (opts.r) props.reset = 'true'
 	if (opts.v) props.verbose = 'true'
-	if (opts.sl) {
+
+	// scan options
+	if (opts.s) props.scanOnly = 'true'
+	if (opts.ss) props.scanOnly = 'true'
+	if (opts.sl) props.scanLoadmodules = 'true'
+	if (opts.sa) {
+		props.scanOnly = 'true'
 		props.scanLoadmodules = 'true'
-		buildUtils.assertBuildProperties('scanOnly') // scanLoadmodules should only be used along with scanOnly buildtype
 	}
 
 	if (opts.url) props.url = opts.url

--- a/build.groovy
+++ b/build.groovy
@@ -59,7 +59,7 @@ else {
 		}
 	} else if(props.scanOnly && props.scanLoadmodules && props.scanLoadmodules.toBoolean()){
 		println ("** Scanning loadmodules for static dependencies.")
-		impactUtils.scanOnlyStaticDependencies(buildList)
+		impactUtils.scanOnlyStaticDependencies(buildList, repositoryClient)
 	}
 }
 

--- a/build.groovy
+++ b/build.groovy
@@ -58,7 +58,7 @@ else {
 			processCounter = processCounter + buildFiles.size()
 		}
 	} else if(props.scanLoadmodules && props.scanLoadmodules.toBoolean()){
-		println ("** Scanning loadmodules for static dependencies.")
+		println ("** Scanning load modules.")
 		impactUtils.scanOnlyStaticDependencies(buildList, repositoryClient)
 	}
 }
@@ -461,6 +461,7 @@ def createBuildList() {
 	// since impact build list creation already scanned the incoming changed files
 	// we do not need to scan them again
 	if (!props.impactBuild && !props.userBuild && props.scanOnly) {
+		println "** Scanning source code."
 		impactUtils.updateCollection(buildList, null, null, repositoryClient)
 	}
 

--- a/build.groovy
+++ b/build.groovy
@@ -36,7 +36,7 @@ def scriptPath = ""
 if (buildList.size() == 0)
 	println("*! No files in build list.  Nothing to do.")
 else {
-	if (!props.scanOnly) {
+	if (!props.scanOnly && !props.scanLoadmodules) {
 		println("** Invoking build scripts according to build order: ${props.buildOrder}")
 		String[] buildOrderList = props.buildOrder.split(',')
 		String[] testOrderList;
@@ -384,7 +384,7 @@ def createBuildList() {
 	Set<String> buildSet = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 
-	String action = (props.scanOnly) ? 'Scanning' : 'Building'
+	String action = (props.scanOnly) || (props.scanLoadmodules) ? 'Scanning' : 'Building'
 
 	// check if full build
 	if (props.fullBuild) {
@@ -460,7 +460,7 @@ def createBuildList() {
 	// scan and update source collection with build list files for non-impact builds
 	// since impact build list creation already scanned the incoming changed files
 	// we do not need to scan them again
-	if (!props.impactBuild && !props.userBuild) {
+	if (!props.impactBuild && !props.userBuild && props.scanOnly) {
 		impactUtils.updateCollection(buildList, null, null, repositoryClient)
 	}
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -370,3 +370,28 @@ def createDatasets(String[] datasets, String options) {
 	}
 }
 
+/*
+ * returns languagePrefix for language script name or null if not defined.
+ */
+def getLangPrefix(String scriptName){
+	def langPrefix = null
+	switch(scriptName) {
+		case "Cobol.groovy":
+			langPrefix = 'cobol'
+			break;
+		case "LinkEdit.groovy" :
+			langPrefix = 'linkedit'
+			break;
+		case "PLI.groovy":
+			langPrefix = 'pli'
+			break;
+		case "Assembler.groovy":
+			langPrefix = 'assembler'
+			break;
+		default:
+			if (props.verbose) println ("*** No language prefix defined for $scriptName.")
+			break;
+	}
+	return langPrefix
+}
+

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -208,7 +208,7 @@ def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient
 	buildList.each { buildFile ->
 		def scriptMapping = ScriptMappings.getScriptName(buildFile)
 		if(scriptMapping != null){
-			langPrefix = getLangPrefix(scriptMapping)
+			langPrefix = buildUtils.getLangPrefix(scriptMapping)
 			if(langPrefix != null){
 				String isLinkEdited = props.getFileProperty("${langPrefix}_linkEdit", buildFile)
 				String rules = props.getFileProperty("${langPrefix}_resolutionRules", buildFile)
@@ -232,32 +232,6 @@ def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient
 		}
 	}
 }
-
-/*
- * returns languagePrefix for language script name or null if not defined.
- */
-def getLangPrefix(String scriptName){
-	def langPrefix = null
-	switch(scriptName) {
-		case "Cobol.groovy":
-			langPrefix = 'cobol'
-			break;
-		case "LinkEdit.groovy" :
-			langPrefix = 'linkedit'
-			break;
-		case "PLI.groovy":
-			langPrefix = 'pli'
-			break;
-		case "Assembler.groovy":
-			langPrefix = 'assembler'
-			break;
-		default:
-			if (props.verbose) println ("*** No language prefix defined for $scriptName.")
-			break;
-	}
-	return langPrefix
-}
-
 
 def createImpactResolver(String changedFile, String rules, RepositoryClient repositoryClient) {
 	if (props.verbose) println "*** Creating impact resolver for $changedFile with $rules rules"

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -238,7 +238,7 @@ def scanOnlyStaticDependencies(List buildList){
  */
 def getLangPrefix(String scriptName){
 	def langPrefix = null
-	switch(scriptMapping) {
+	switch(scriptName) {
 		case "Cobol.groovy":
 			langPrefix = 'cobol'
 			break;

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -204,7 +204,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
  * Scenario: Migrate Source to Git and scan against existing set of loadmodules.
  * Limitation: Sample for cobol
  */
-def scanOnlyStaticDependencies(List buildList){
+def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient){
 	buildList.each { buildFile ->
 		def scriptMapping = ScriptMappings.getScriptName(buildFile)
 		if(scriptMapping != null){

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -252,7 +252,7 @@ def getLangPrefix(String scriptName){
 			langPrefix = 'assembler'
 			break;
 		default:
-			if (props.verbose) println ("*** No language prefix defined for $scriptMapping.")
+			if (props.verbose) println ("*** No language prefix defined for $scriptName.")
 			break;
 	}
 	return langPrefix

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -204,7 +204,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
  * Scenario: Migrate Source to Git and scan against existing set of loadmodules.
  * Limitation: Sample for cobol
  */
-def scanOnlyStaticDependencies(){
+def scanOnlyStaticDependencies(List buildList){
 	buildList.each { buildFile ->
 		def scriptMapping = ScriptMappings.getScriptName(buildFile)
 		if(scriptMapping != null){

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -221,7 +221,7 @@ def scanOnlyStaticDependencies(List buildList){
 				if (isLinkEdited && isLinkEdited.toBoolean()){
 					try{
 						if (props.verbose) println ("*** Scanning loadmodule $loadPDSMember of $buildFile")
-						impactUtils.saveStaticLinkDependencies(buildFile, props."${langPrefix}_loadPDS", logicalFile, repositoryClient)
+						saveStaticLinkDependencies(buildFile, props."${langPrefix}_loadPDS", logicalFile, repositoryClient)
 					}
 					catch (com.ibm.dbb.build.ValidationException e){
 						println ("!* Error scanning output file for $buildFile  : $loadPDSMember")

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -211,16 +211,16 @@ def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient
 			langPrefix = buildUtils.getLangPrefix(scriptMapping)
 			if(langPrefix != null){
 				String isLinkEdited = props.getFileProperty("${langPrefix}_linkEdit", buildFile)
-				String rules = props.getFileProperty("${langPrefix}_resolutionRules", buildFile)
-				DependencyResolver dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
 
-				LogicalFile logicalFile = dependencyResolver.getLogicalFile()
+				def scanner = buildUtils.getScanner(buildFile)
+				LogicalFile logicalFile = scanner.scan(buildFile, props.workspace)
+				
 				String member = CopyToPDS.createMemberName(buildFile)
 				String loadPDSMember = props."${langPrefix}_loadPDS"+"($member)"
 
-				if (isLinkEdited && isLinkEdited.toBoolean()){
+				if ((isLinkEdited && isLinkEdited.toBoolean()) || scriptMapping == "LinkEdit.groovy"){
 					try{
-						if (props.verbose) println ("*** Scanning loadmodule $loadPDSMember of $buildFile")
+						if (props.verbose) println ("*** Scanning load module $loadPDSMember of $buildFile")
 						saveStaticLinkDependencies(buildFile, props."${langPrefix}_loadPDS", logicalFile, repositoryClient)
 					}
 					catch (com.ibm.dbb.build.ValidationException e){
@@ -228,6 +228,11 @@ def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient
 						println e
 					}
 				}
+				else {
+					if (props.verbose) println ("*** Skipped scanning module $loadPDSMember of $buildFile.")
+				}
+			} else {
+				if (props.verbose) println ("*** Skipped scanning outputs of $buildFile. No language prefix found.")
 			}
 		}
 	}


### PR DESCRIPTION
This is the PR for issue: #85 

With this enhancement, it is possible to populate the _collection for build outputs (aka output collection)_ in a scanOnly scenario without rebuilding the modules. This is crucial for migration scenarios, which include **static linkage** and would like to skip a read full build at the beginning. 

It introduces a new cmdline option `--scanLoadmodules` which can only be used along with `-scanOnly`.

Sample invocation to invoke a scanOnly and scanLoadmodules:
```
groovyz /u/dbehm/test/dbb-zappbuild/build.groovy --sourceDir /u/dbehm/test/dbb-zappbuild/samples --workDir /u/dbehm/test/work/Mortgage --hlq DBEHM.DBB.BUILD --application MortgageApplication --scanOnly --fullBuild --scanLoadmodules
```

Sample output. Note: Output files not being  found will be documented.
```
** Build start at 20210223.094610.046
** Repository client created for https://10.3.20.96:10443/dbb
** Build output located at /u/dbehm/test/work/Mortgage/build.20210223.094610.046
** Build result created for BuildGroup:MortgageApplication-scanLoadModule BuildLabel:build.20210223.094610.046 at https://10.3.20.96:10443/dbb/rest/buildResult/39421
** --fullBuild option selected. Scanning all programs for application MortgageApplication
** Writing build list file to /u/dbehm/test/work/Mortgage/build.20210223.094610.046/buildList.txt
** Scanning loadmodules for static dependencies.
!* Error scanning output file for MortgageApplication/cobol/epscsmrd.cbl  : DBEHM.DBB.BUILD.LOAD(EPSCSMRD)
com.ibm.dbb.build.ValidationException: BGZTK0046E Could not scan load module //'DBEHM.DBB.BUILD.LOAD(EPSCSMRD)' because it does not exist.
** Writing build report data to /u/dbehm/test/work/Mortgage/build.20210223.094610.046/BuildReport.json
** Writing build report to /u/dbehm/test/work/Mortgage/build.20210223.094610.046/BuildReport.html
** Build ended at Tue Feb 23 09:46:28 GMT+01:00 2021
** Build State : CLEAN
** Total files processed : 15
** Total build time  : 17.894 seconds
```