### PR TITLE
add buildResultProperties to the build report data

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -473,29 +473,15 @@ def finalizeBuildProcess(Map args) {
 
 	// create build report data file
 	def jsonOutputFile = new File("${props.buildOutDir}/BuildReport.json")
-	println "** Writing build report data to ${jsonOutputFile}"
 	def buildReportEncoding = "UTF-8"
 	def buildReport = BuildReportFactory.getBuildReport()
-	buildReport.save(jsonOutputFile, buildReportEncoding)
-
-	// create build report html file
-	def htmlOutputFile = new File("${props.buildOutDir}/BuildReport.html")
-	println "** Writing build report to ${htmlOutputFile}"
-	def htmlTemplate = null  // Use default HTML template.
-	def css = null       // Use default theme.
-	def renderScript = null  // Use default rendering.
-	def transformer = HtmlTransformer.getInstance()
-	transformer.transform(jsonOutputFile, htmlTemplate, css, renderScript, htmlOutputFile, buildReportEncoding)
+	def buildResult = null
 
 	// update repository artifacts
 	if (repositoryClient) {
 		if (props.verbose)
 			println "** Updating build result BuildGroup:${props.applicationBuildGroup} BuildLabel:${props.applicationBuildLabel}"
-		def buildResult = repositoryClient.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
-		buildResult.setBuildReport(new FileInputStream(htmlOutputFile))
-		buildResult.setBuildReportData(new FileInputStream(jsonOutputFile))
-		buildResult.setProperty("filesProcessed", String.valueOf(args.count))
-		buildResult.setState(buildResult.COMPLETE)
+		buildResult = repositoryClient.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 
 		// add git hashes for each build directory
 		List<String> srcDirs = []
@@ -516,11 +502,43 @@ def finalizeBuildProcess(Map args) {
 			}
 		}
 
-		// save build result
+		// add files processed and set state
+		buildResult.setProperty("filesProcessed", String.valueOf(args.count))
+		buildResult.setState(buildResult.COMPLETE)
+
+		// save updates
 		buildResult.save()
 
+		// store build result properties in BuildReport.json
+		PropertiesRecord buildReportRecord = new PropertiesRecord("DBB.BuildResultProperties")
+		def buildResultProps = buildResult.getPropertyNames()
+		buildResultProps.each { buildResultPropName ->
+			buildReportRecord.addProperty(buildResultPropName, buildResult.getProperty(buildResultPropName))
+		}
+		buildReport.addRecord(buildReportRecord)
 	}
 
+	// create build report html file
+	def htmlOutputFile = new File("${props.buildOutDir}/BuildReport.html")
+	println "** Writing build report to ${htmlOutputFile}"
+	def htmlTemplate = null  // Use default HTML template.
+	def css = null       // Use default theme.
+	def renderScript = null  // Use default rendering.
+	def transformer = HtmlTransformer.getInstance()
+	transformer.transform(jsonOutputFile, htmlTemplate, css, renderScript, htmlOutputFile, buildReportEncoding)
+	
+	// save json file
+	println "** Writing build report data to ${jsonOutputFile}"
+	buildReport.save(jsonOutputFile, buildReportEncoding)
+
+	// attach build report & result
+	if (repositoryClient) {
+		buildReport.save(jsonOutputFile, buildReportEncoding)
+		buildResult.setBuildReport(new FileInputStream(htmlOutputFile))
+		buildResult.setBuildReportData(new FileInputStream(jsonOutputFile))
+		buildResult.save()
+	}
+	
 	// print end build message
 	def endTime = new Date()
 	def duration = TimeCategory.minus(endTime, args.start)

--- a/build.groovy
+++ b/build.groovy
@@ -478,8 +478,6 @@ def finalizeBuildProcess(Map args) {
 
 	// update repository artifacts
 	if (repositoryClient) {
-		if (props.verbose)
-			println "** Updating build result BuildGroup:${props.applicationBuildGroup} BuildLabel:${props.applicationBuildLabel}"
 		buildResult = repositoryClient.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 
 		// add git hashes for each build directory
@@ -546,6 +544,7 @@ def finalizeBuildProcess(Map args) {
 		buildReport.save(jsonOutputFile, buildReportEncoding)
 		buildResult.setBuildReport(new FileInputStream(htmlOutputFile))
 		buildResult.setBuildReportData(new FileInputStream(jsonOutputFile))
+		println "** Updating build result BuildGroup:${props.applicationBuildGroup} BuildLabel:${props.applicationBuildLabel} at ${props.buildResultUrl}"
 		buildResult.save()
 	}
 	

--- a/build.groovy
+++ b/build.groovy
@@ -4,11 +4,11 @@ import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import com.ibm.dbb.build.report.*
 import com.ibm.dbb.build.html.*
+import com.ibm.dbb.build.report.records.*
 import groovy.util.*
 import groovy.transform.*
 import groovy.time.*
 import groovy.xml.*
-import com.ibm.jzos.ZFile
 
 
 // define script properties

--- a/build.groovy
+++ b/build.groovy
@@ -498,7 +498,7 @@ def finalizeBuildProcess(Map args) {
 				if (props.verbose) println "** Setting property $key : $hash"
 				// store gitUrl
 				String url = gitUtils.getCurrentGitUrl(dir)
-				String gitURLkey = "$giturlPrefix$url}"
+				String gitURLkey = "$giturlPrefix${buildUtils.relativizePath(dir)}"
 				buildResult.setProperty(gitURLkey, url)
 				if (props.verbose) println "** Setting property $gitURLkey : $url"
 			}


### PR DESCRIPTION
In case of a build connecting via the repoClient to the dbb web application, we add the build result properties to a generic DBB Record named `DBB.BuildResultProperties`

See sample :
![image](https://user-images.githubusercontent.com/28918869/110509036-f88ef180-8101-11eb-8f32-f79d32f75895.png)
