### PR TITLE
configuration option to create subfolder for buildLabel

### DIFF
--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -39,6 +39,9 @@ buildListFileExt | File extension that indicates the build file is really a buil
 languagePropertyQualifiers | List of language script property qualifiers. Each language script property has a unique qualifier to avoid collision with other language script properties.
 applicationConfRootDir | Alternate root directory for application-conf location.  Allows for the deployment of the application-conf directories to a static location.  Defaults to ${workspace}/${application}
 requiredBuildProperties | Comma separated list of required build properties for zAppBuild/build.groovy. Build and language scripts will validate that *required* build properties have been set before the script runs.  If any are missing or empty, then a validation error will be thrown.
+continueOnScanFailure | Determine the behavior when facing a scanner failure. true (default) to continue scanning. false will terminate the process. 
+createBuildOutputSubfolder | Option to create a subfolder with the build label within the build output dir (outDir). Default: true. 
+dbb.file.tagging | Controls compile log and build report file tagging. Default: true.
 dbb.LinkEditScanner.excludeFilter | DBB configuration property used by the link edit scanner to exclude load module entries
 dbb.RepositoryClient.url | DBB configuration property for web application URL.  ***Can be overridden by build.groovy option -url, --url***
 dbb.RepositoryClient.userId | DBB configuration property for web application logon id.  ***Can be overridden by build.groovy option -id, --id***

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -41,10 +41,10 @@ applicationConfRootDir=
 requiredBuildProperties=buildOrder,buildListFileExt
 
 # dbb.file.tagging controls compile log and build report file tagging. If true, files 
-# written as UTF-8 or ASCII are tagged. The default value is false. If the environment
-# variable _BPXK_AUTOCVT is set ALL, file tagging may have an adverse effect if viewing
-# log files and build report via Jenkins. In this case, set dbb.file.tagging to false or
-# comment out the line. Default: true
+# written as UTF-8 or ASCII are tagged. 
+# If the environment variable _BPXK_AUTOCVT is set ALL, file tagging may have an
+# adverse effect if viewing log files and build report via Jenkins.
+# In this case, set dbb.file.tagging to false or comment out the line. Default: true
 dbb.file.tagging=true
 
 # Set filter used to exclude certain information from the link edit scanning.
@@ -61,6 +61,12 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 # 'true' proceeds with the build and report the a warning (default)
 # 'false' will terminate the build process
 continueOnScanFailure=true
+
+#
+# Determine if a subfolder with a timestamp should be created in the buildOutDir location.
+# Applies to all build types except userBuild
+# Default: true
+createBuildOutputSubfolder=true
 
 #
 # default DBB Repository Web Application authentication properties

--- a/build.groovy
+++ b/build.groovy
@@ -364,9 +364,13 @@ def populateBuildProperties(String[] args) {
 	props.applicationCollectionName = ((props.applicationCurrentBranch) ? "${props.application}-${props.applicationCurrentBranch}" : "${props.application}") as String
 	props.applicationOutputsCollectionName = "${props.applicationCollectionName}-outputs" as String
 
-	// do not create a subfolder for user builds
-	props.buildOutDir = ((props.userBuild) ? "${props.outDir}" : "${props.outDir}/${props.applicationBuildLabel}") as String
 
+	if (props.userBuild) {	// do not create a subfolder for user builds
+		props.buildOutDir = "${props.outDir}" as String }
+	else {// validate createBuildOutputSubfolder build property
+		props.buildOutDir = ((props.createBuildOutputSubfolder && props.createBuildOutputSubfolder.toBoolean()) ? "${props.outDir}/${props.applicationBuildLabel}" : "${props.outDir}") as String
+	}
+	
 	if (props.verbose) {
 		println("java.version="+System.getProperty("java.runtime.version"))
 		println("java.home="+System.getProperty("java.home"))


### PR DESCRIPTION
The pipeline orchestrator typically manages the build workspace. In a pipeline script / config you can pass the build to the `workDir`/`outDir` parameter. Artificially creating a subfolder makes it difficult for post build scripts.

Please see issue #100 