### PR TITLE
Support for REXX implementation

### DIFF
--- a/build-conf/REXX.properties
+++ b/build-conf/REXX.properties
@@ -21,18 +21,24 @@ REXX_objPDS=${hlq}.OBJ
 
 #
 # REXX load data sets
+REXX_REXXLoadPDS=${hlq}.REXXLOAD
 REXX_loadPDS=${hlq}.LOAD
 
 #
 # List the data sets that need to be created and their creation options
-REXX_srcDatasets=${REXX_srcPDS},${REXX_cpyPDS},${REXX_objPDS},${REXX_dbrmPDS}
+REXX_srcDatasets=${REXX_srcPDS},${REXX_objPDS}
 REXX_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
+
+REXX_REXXLoadDatasets=${REXX_REXXLoadPDS}
+REXX_REXXLoadOptions=cyl space(1,1) lrecl(80) recfm(F,B) blksize(27920) DSORG(PO) dsntype(pds) dir(10)
 
 REXX_loadDatasets=${REXX_loadPDS}
 REXX_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library)
 
 REXX_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
+REXX_REXXPrintTempOptions=cyl space(5,5) unit(vio) blksize(121) lrecl(121) recfm(f,a) new
 REXX_printTempOptions=cyl space(5,5) unit(vio) blksize(133) lrecl(133) recfm(f,b) new
+
 
 #
 # REXX scanner language hint
@@ -47,3 +53,4 @@ dbb.DependencyScanner.languageHint=REXX :: **/*.rexx
 #          will match any member in the data set TEST.REXX.
 # The following filter excludes CICS and LE Library references.
 dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
+

--- a/build-conf/REXX.properties
+++ b/build-conf/REXX.properties
@@ -1,0 +1,49 @@
+# Releng properties used by language/REXX.groovy
+
+#
+# Comma separated list of required build properties for REXX.groovy
+REXX_requiredBuildProperties=REXX_srcPDS,REXX_objPDS,REXX_loadPDS,\
+  REXX_compiler,REXX_linkEditor,REXX_tempOptions,applicationOutputsCollectionName,\
+  SCEELKED,SFANLMD
+
+#
+# REXX compiler name
+REXX_compiler=REXXCOMP
+
+#
+# linker name
+REXX_linkEditor=IEWBLINK
+
+#
+# REXX source data sets
+REXX_srcPDS=${hlq}.REXX
+REXX_objPDS=${hlq}.OBJ
+
+#
+# REXX load data sets
+REXX_loadPDS=${hlq}.LOAD
+
+#
+# List the data sets that need to be created and their creation options
+REXX_srcDatasets=${REXX_srcPDS},${REXX_cpyPDS},${REXX_objPDS},${REXX_dbrmPDS}
+REXX_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
+
+REXX_loadDatasets=${REXX_loadPDS}
+REXX_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library)
+
+REXX_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
+REXX_printTempOptions=cyl space(5,5) unit(vio) blksize(133) lrecl(133) recfm(f,b) new
+
+#
+# REXX scanner language hint
+dbb.DependencyScanner.languageHint=REXX :: **/*.rexx
+
+#
+# Set filter used to exclude certain information from the link edit scanning.
+# The value contains a comma separated list of patterns.
+# example: A filter of *.SUB1, *.SUB2 will exclude modules SUB1 and SUB2
+#          from any dataset. To exclude member HELLO in PDS TEST.REXX will
+#          be matched by the pattern TEST.REXX.HELLO. The pattern TEST.REXX.*
+#          will match any member in the data set TEST.REXX.
+# The following filter excludes CICS and LE Library references.
+dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*

--- a/build-conf/REXX.properties
+++ b/build-conf/REXX.properties
@@ -2,55 +2,55 @@
 
 #
 # Comma separated list of required build properties for REXX.groovy
-REXX_requiredBuildProperties=REXX_srcPDS,REXX_objPDS,REXX_loadPDS,\
-  REXX_compiler,REXX_linkEditor,REXX_tempOptions,applicationOutputsCollectionName,\
-  SCEELKED,SFANLMD
+rexx_requiredBuildProperties=rexx_srcPDS,rexx_objPDS,rexx_loadPDS,\
+  rexx_cexecPDS, rexx_compiler,rexx_linkEditor,rexx_tempOptions, \
+  SFANLMD
 
 #
-# REXX compiler name
-REXX_compiler=REXXCOMP
+# rexx compiler name
+rexx_compiler=REXXCOMP
 
 #
 # linker name
-REXX_linkEditor=IEWBLINK
+rexx_linkEditor=IEWBLINK
 
 #
-# REXX source data sets
-REXX_srcPDS=${hlq}.REXX
-REXX_objPDS=${hlq}.OBJ
+# rexx source data sets
+rexx_srcPDS=${hlq}.REXX
+rexx_objPDS=${hlq}.OBJ
 
 #
-# REXX load data sets
-REXX_REXXLoadPDS=${hlq}.REXXLOAD
-REXX_loadPDS=${hlq}.LOAD
+# rexx load data sets
+rexx_cexecPDS=${hlq}.CEXEC
+rexx_loadPDS=${hlq}.LOAD
 
 #
 # List the data sets that need to be created and their creation options
-REXX_srcDatasets=${REXX_srcPDS},${REXX_objPDS}
-REXX_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
+rexx_srcDatasets=${rexx_srcPDS},${rexx_objPDS}
+rexx_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
 
-REXX_REXXLoadDatasets=${REXX_REXXLoadPDS}
-REXX_REXXLoadOptions=cyl space(1,1) lrecl(80) recfm(F,B) blksize(27920) DSORG(PO) dsntype(pds) dir(10)
+rexx_cexecDatasets=${rexx_cexecPDS}
+rexx_cexecOptions=cyl space(1,1) lrecl(80) recfm(F,B) blksize(27920) DSORG(PO) dsntype(pds) dir(10)
 
-REXX_loadDatasets=${REXX_loadPDS}
-REXX_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library)
+rexx_loadDatasets=${rexx_loadPDS}
+rexx_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library)
 
-REXX_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
-REXX_REXXPrintTempOptions=cyl space(5,5) unit(vio) blksize(121) lrecl(121) recfm(f,a) new
-REXX_printTempOptions=cyl space(5,5) unit(vio) blksize(133) lrecl(133) recfm(f,b) new
+rexx_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
+rexx_rexxPrintTempOptions=cyl space(5,5) unit(vio) blksize(121) lrecl(121) recfm(f,a) new
+rexx_printTempOptions=cyl space(5,5) unit(vio) blksize(133) lrecl(133) recfm(f,b) new
 
 
 #
-# REXX scanner language hint
-dbb.DependencyScanner.languageHint=REXX :: **/*.rexx
+# rexx scanner language hint
+dbb.DependencyScanner.languageHint=rexx :: **/*.rexx
 
 #
 # Set filter used to exclude certain information from the link edit scanning.
 # The value contains a comma separated list of patterns.
 # example: A filter of *.SUB1, *.SUB2 will exclude modules SUB1 and SUB2
-#          from any dataset. To exclude member HELLO in PDS TEST.REXX will
-#          be matched by the pattern TEST.REXX.HELLO. The pattern TEST.REXX.*
-#          will match any member in the data set TEST.REXX.
+#          from any dataset. To exclude member HELLO in PDS TEST.rexx will
+#          be matched by the pattern TEST.rexx.HELLO. The pattern TEST.rexx.*
+#          will match any member in the data set TEST.rexx.
 # The following filter excludes CICS and LE Library references.
 dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of additional build property files to load
 # Supports both relative path (to zAppBuild/build-conf/) and absolute path
-buildPropFiles=datasets.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,ZunitConfig.properties,REXX.properties
+buildPropFiles=datasets.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,REXX.properties,ZunitConfig.properties
 
 #
 # file extension that indicates the build file is really a build list or build list filter
@@ -42,18 +42,18 @@ requiredBuildProperties=buildOrder,buildListFileExt
 
 #
 # impactBuildOnBuildPropertyChanges controls if impact calculation should analyze
-# build property changes for COBOL, PLI, ASM. 
+# build property changes for COBOL, PLI, ASM.
 # default = false
 impactBuildOnBuildPropertyChanges=false
 
-# 
+#
 # list of build property lists referencing which language properties should cause an impact build when the given property is changed
-# properties need to be managed in property files within the application repository to detect the change; applies only to impact builds 
+# properties need to be managed in property files within the application repository to detect the change; applies only to impact builds
 # general pattern: langPrefix_impactPropertyList, optional: langPrefix_impactPropertyListCICS and langPrefix_impactPropertyListSQL
 impactBuildOnBuildPropertyList=[${assembler_impactPropertyList},${assembler_impactPropertyListCICS},${assembler_impactPropertyListSQL},${bms_impactPropertyList},${cobol_impactPropertyList},${cobol_impactPropertyListCICS},${cobol_impactPropertyListSQL},${dbdgen_impactPropertyList},${linkedit_impactPropertyList},${mfs_impactPropertyList},${pli_impactPropertyList},${pli_impactPropertyListCICS},${pli_impactPropertyListSQL},${psbgen_impactPropertyList}]
 
-# dbb.file.tagging controls compile log and build report file tagging. If true, files 
-# written as UTF-8 or ASCII are tagged. 
+# dbb.file.tagging controls compile log and build report file tagging. If true, files
+# written as UTF-8 or ASCII are tagged.
 # If the environment variable _BPXK_AUTOCVT is set ALL, file tagging may have an
 # adverse effect if viewing log files and build report via Jenkins.
 # In this case, set dbb.file.tagging to false or comment out the line. Default: true

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of additional build property files to load
 # Supports both relative path (to zAppBuild/build-conf/) and absolute path
-buildPropFiles=datasets.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,ZunitConfig.properties
+buildPropFiles=datasets.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,ZunitConfig.properties,REXX.properties
 
 #
 # file extension that indicates the build file is really a build list or build list filter

--- a/build-conf/datasets.properties
+++ b/build-conf/datasets.properties
@@ -59,3 +59,6 @@ SFELLOAD=
 
 # Optional IDZ zUnit / WAZI VTP library containing necessary copybooks. Example : FEL.V14R2.SBZUSAMP
 SBZUSAMP=
+
+# REXX Compiler Data Sets. Example: REXX.V1R4.SFANLMD
+SFANLMD=

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -1,0 +1,263 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import com.ibm.dbb.repository.*
+import com.ibm.dbb.dependency.*
+import com.ibm.dbb.build.*
+import groovy.transform.*
+import com.ibm.jzos.ZFile
+
+
+// define script properties
+@Field BuildProperties props = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+@Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
+@Field def bindUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BindUtilities.groovy"))
+@Field RepositoryClient repositoryClient
+
+println("** Building files mapped to ${this.class.getName()}.groovy script")
+
+// verify required build properties
+buildUtils.assertBuildProperties(props.cobol_requiredBuildProperties)
+
+// create language datasets
+def langQualifier = "REXX"
+buildUtils.createLanguageDatasets(langQualifier)
+
+// sort the build list based on build file rank if provided
+List<String> sortedList = buildUtils.sortBuildList(argMap.buildList, 'REXX_fileBuildRank')
+
+// iterate through build list
+sortedList.each { buildFile ->
+	println "*** Building file $buildFile"
+
+	// copy build file and dependency files to data sets
+	String rules = props.getFileProperty('REXX_resolutionRules', buildFile)
+	DependencyResolver dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
+	buildUtils.copySourceFiles(buildFile, props.REXX_srcPDS, props.REXX_srcPDS, dependencyResolver)
+	// create mvs commands
+	LogicalFile logicalFile = dependencyResolver.getLogicalFile()
+	String member = CopyToPDS.createMemberName(buildFile)
+	File logFile = new File( props.userBuild ? "${props.buildOutDir}/${member}.log" : "${props.buildOutDir}/${member}.REXX.log")
+	if (logFile.exists())
+		logFile.delete()
+	MVSExec compile = createCompileCommand(buildFile, logicalFile, member, logFile)
+	MVSExec linkEdit = createLinkEditCommand(buildFile, logicalFile, member, logFile)
+
+	// execute mvs commands in a mvs job
+	MVSJob job = new MVSJob()
+	job.start()
+
+	// compile the cobol program
+	int rc = compile.execute()
+	int maxRC = props.getFileProperty('REXX_compileMaxRC', buildFile).toInteger()
+
+	boolean bindFlag = true
+
+	if (rc > maxRC) {
+		bindFlag = false
+		String errorMsg = "*! The compile return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
+		println(errorMsg)
+		props.error = "true"
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+	}
+	else {
+		// if this program needs to be link edited . . .
+		String needsLinking = props.getFileProperty('REXX_linkEdit', buildFile)
+		if (needsLinking.toBoolean()) {
+			rc = linkEdit.execute()
+			maxRC = props.getFileProperty('REXX_linkEditMaxRC', buildFile).toInteger()
+
+			if (rc > maxRC) {
+				String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
+				println(errorMsg)
+				props.error = "true"
+				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+			}
+			else {
+				if (!props.userBuild){
+					// only scan the load module if load module scanning turned on for file
+					String scanLoadModule = props.getFileProperty('REXX_scanLoadModule', buildFile)
+					if (scanLoadModule && scanLoadModule.toBoolean() && getRepositoryClient())
+						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile, repositoryClient)
+				}
+			}
+		}
+	}
+
+	// clean up passed DD statements
+	job.stop()
+}
+
+// end script
+
+
+//********************************************************************
+//* Method definitions
+//********************************************************************
+
+/*
+ * createREXXParms - Builds up the REXX compiler parameter list from build and file properties
+ */
+def createREXXParms(String buildFile, LogicalFile logicalFile) {
+	def parms = props.getFileProperty('REXX_compileParms', buildFile) ?: ""
+	def cics = props.getFileProperty('REXX_compileCICSParms', buildFile) ?: ""
+	def sql = props.getFileProperty('REXX_compileSQLParms', buildFile) ?: ""
+	def errPrefixOptions = props.getFileProperty('REXX_compileErrorPrefixParms', buildFile) ?: ""
+	def compileDebugParms = props.getFileProperty('REXX_compileDebugParms', buildFile)
+
+	if (props.errPrefix)
+		parms = "$parms,$errPrefixOptions"
+
+	// add debug options
+	if (props.debug)  {
+		parms = "$parms,$compileDebugParms"
+	}
+
+	if (parms.startsWith(','))
+		parms = parms.drop(1)
+
+	if (props.verbose) println "REXX compiler parms for $buildFile = $parms"
+	return parms
+}
+
+/*
+ * createCompileCommand - creates a MVSExec command for compiling the REXX program (buildFile)
+ */
+def createCompileCommand(String buildFile, LogicalFile logicalFile, String member, File logFile) {
+	String parms = createREXXParms(buildFile, logicalFile)
+	String compiler = props.getFileProperty('REXX_compiler', buildFile)
+
+	// define the MVSExec command to compile the program
+	MVSExec compile = new MVSExec().file(buildFile).pgm(compiler).parm(parms)
+
+	// add DD statements to the compile command
+	
+	compile.dd(new DDStatement().name("SYSIN").dsn("${props.REXX_srcPDS}($member)").options('shr').report(true))
+	
+	compile.dd(new DDStatement().name("SYSPRINT").options(props.REXX_printTempOptions))
+	compile.dd(new DDStatement().name("SYSTERM").options(props.REXX_printTempOptions))
+
+	// Write SYSLIN to temporary dataset if performing link edit or to physical dataset
+	String doLinkEdit = props.getFileProperty('REXX_linkEdit', buildFile)
+	String linkEditStream = props.getFileProperty('REXX_linkEditStream', buildFile)
+	String linkDebugExit = props.getFileProperty('REXX_linkDebugExit', buildFile)
+
+	if (props.debug && linkDebugExit && doLinkEdit.toBoolean()){
+		compile.dd(new DDStatement().name("SYSPUNCH").dsn("${props.REXX_objPDS}($member)").options('shr').output(true))
+	} else if (doLinkEdit && doLinkEdit.toBoolean() && ( !linkEditStream || linkEditStream.isEmpty())) {
+		compile.dd(new DDStatement().name("SYSPUNCH").dsn("&&TEMPOBJ").options(props.cobol_tempOptions).pass(true))
+	} else {
+		compile.dd(new DDStatement().name("SYSPUNCH").dsn("${props.REXX_objPDS}($member)").options('shr').output(true))
+	}
+	compile.dd(new DDStatement().name("CEXEC").dsn("${props.REXX_loadPDS}($member)").options('shr').output(true))
+	
+	// add a syslib to the compile command with optional bms output copybook and CICS concatenation
+	compile.dd(new DDStatement().name("SYSLIB").dsn(props.REXX_srcPDS).options("shr"))
+		
+	// add custom concatenation
+	def compileSyslibConcatenation = props.getFileProperty('REXX_compileSyslibConcatenation', buildFile) ?: ""
+	if (compileSyslibConcatenation) {
+		def String[] syslibDatasets = compileSyslibConcatenation.split(',');
+		for (String syslibDataset : syslibDatasets )
+		compile.dd(new DDStatement().dsn(syslibDataset).options("shr"))
+	}
+		
+	// add a tasklib to the compile command 
+	compile.dd(new DDStatement().name("TASKLIB").dsn(props."SFANLMD").options("shr"))
+
+	if (props.SFELLOAD)
+		compile.dd(new DDStatement().dsn(props.SFELLOAD).options("shr"))
+
+	// add IDz User Build Error Feedback DDs
+	if (props.errPrefix) {
+		compile.dd(new DDStatement().name("SYSADATA").options("DUMMY"))
+		// SYSXMLSD.XML suffix is mandatory for IDZ/ZOD to populate remote error list
+		compile.dd(new DDStatement().name("SYSXMLSD").dsn("${props.hlq}.${props.errPrefix}.SYSXMLSD.XML").options(props.cobol_compileErrorFeedbackXmlOptions))
+	}
+
+	// add a copy command to the compile command to copy the SYSPRINT from the temporary dataset to an HFS log file
+	compile.copy(new CopyToHFS().ddName("SYSPRINT").file(logFile).hfsEncoding(props.logEncoding))
+
+	return compile
+}
+
+
+/*
+ * createLinkEditCommand - creates a MVSExec command for link editing the REXX object module produced by the compile
+ */
+def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String member, File logFile) {
+	String parms = props.getFileProperty('REXX_linkEditParms', buildFile)
+	String linker = props.getFileProperty('REXX_linkEditor', buildFile)
+	String linkEditStream = props.getFileProperty('REXX_linkEditStream', buildFile)
+	String linkDebugExit = props.getFileProperty('REXX_linkDebugExit', buildFile)
+
+	// define the MVSExec command to link edit the program
+	MVSExec linkedit = new MVSExec().file(buildFile).pgm(linker).parm(parms)
+
+	// Create a physical link card
+	if ( (linkEditStream) || (props.debug && linkDebugExit!= null)) {
+		def langQualifier = "linkedit"
+		buildUtils.createLanguageDatasets(langQualifier)
+		def lnkFile = new File("${props.buildOutDir}/linkCard.lnk")
+		if (lnkFile.exists())
+			lnkFile.delete()
+
+		if 	(linkEditStream)
+			lnkFile << "  " + linkEditStream.replace("\\n","\n").replace('@{member}',member)
+		else
+			lnkFile << "  " + linkDebugExit.replace("\\n","\n").replace('@{member}',member)
+
+		if (props.verbose)
+			println("Copying ${props.buildOutDir}/linkCard.lnk to ${props.linkedit_srcPDS}($member)")
+		new CopyToPDS().file(lnkFile).dataset(props.linkedit_srcPDS).member(member).execute()
+		// Alloc SYSLIN
+		linkedit.dd(new DDStatement().name("SYSLIN").dsn("${props.linkedit_srcPDS}($member)").options("shr"))
+		// add the obj DD
+		linkedit.dd(new DDStatement().name("OBJECT").dsn("${props.REXX_objPDS}($member)").options('shr'))
+
+	} else { // no debug && no link card
+		// Use &&TEMP from Compile
+	}
+
+	// add DD statements to the linkedit command
+	String linkedit_deployType = props.getFileProperty('linkedit_deployType', buildFile)
+	if ( linkedit_deployType == null )
+		linkedit_deployType = 'LOAD'
+	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.REXX_loadPDS}($member)").options('shr').output(true).deployType(linkedit_deployType))
+	
+	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.REXX_printTempOptions))
+	linkedit.dd(new DDStatement().name("SYSUT1").options(props.REXX_tempOptions))
+
+	// add RESLIB if needed
+	if ( props.RESLIB ) {
+		linkedit.dd(new DDStatement().name("RESLIB").dsn(props.RESLIB).options("shr"))
+	}
+
+	// add a syslib to the compile command with optional CICS concatenation
+	linkedit.dd(new DDStatement().name("SYSLIB").dsn(props.REXX_objPDS).options("shr"))
+	
+	// add custom concatenation
+	def linkEditSyslibConcatenation = props.getFileProperty('REXX_linkEditSyslibConcatenation', buildFile) ?: ""
+	if (linkEditSyslibConcatenation) {
+		def String[] syslibDatasets = linkEditSyslibConcatenation.split(',');
+		for (String syslibDataset : syslibDatasets )
+		linkedit.dd(new DDStatement().dsn(syslibDataset).options("shr"))
+	}
+	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
+
+	// Add Debug Dataset to find the debug exit to SYSLIB
+	if (props.debug && props.SEQAMOD)
+		linkedit.dd(new DDStatement().dsn(props.SEQAMOD).options("shr"))
+
+	// add a copy command to the linkedit command to append the SYSPRINT from the temporary dataset to the HFS log file
+	linkedit.copy(new CopyToHFS().ddName("SYSPRINT").file(logFile).hfsEncoding(props.logEncoding).append(true))
+
+	return linkedit
+}
+
+
+def getRepositoryClient() {
+	if (!repositoryClient && props."dbb.RepositoryClient.url")
+		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
+
+	return repositoryClient
+}

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -95,42 +95,16 @@ sortedList.each { buildFile ->
 //********************************************************************
 
 /*
- * createREXXParms - Builds up the REXX compiler parameter list from build and file properties
- */
-def createREXXParms(String buildFile, LogicalFile logicalFile) {
-	def parms = props.getFileProperty('REXX_compileParms', buildFile) ?: ""
-	def cics = props.getFileProperty('REXX_compileCICSParms', buildFile) ?: ""
-	def sql = props.getFileProperty('REXX_compileSQLParms', buildFile) ?: ""
-	def errPrefixOptions = props.getFileProperty('REXX_compileErrorPrefixParms', buildFile) ?: ""
-	def compileDebugParms = props.getFileProperty('REXX_compileDebugParms', buildFile)
-
-	if (props.errPrefix)
-		parms = "$parms,$errPrefixOptions"
-
-	// add debug options
-	if (props.debug)  {
-		parms = "$parms,$compileDebugParms"
-	}
-
-	if (parms.startsWith(','))
-		parms = parms.drop(1)
-
-	if (props.verbose) println "REXX compiler parms for $buildFile = $parms"
-	return parms
-}
-
-/*
  * createCompileCommand - creates a MVSExec command for compiling the REXX program (buildFile)
  */
 def createCompileCommand(String buildFile, LogicalFile logicalFile, String member, File logFile) {
-	String parms = createREXXParms(buildFile, logicalFile)
+	def parms = props.getFileProperty('REXX_compileParms', buildFile) ?: ""
 	String compiler = props.getFileProperty('REXX_compiler', buildFile)
 
 	// define the MVSExec command to compile the program
 	MVSExec compile = new MVSExec().file(buildFile).pgm(compiler).parm(parms)
 
 	// add DD statements to the compile command
-	
 	compile.dd(new DDStatement().name("SYSIN").dsn("${props.REXX_srcPDS}($member)").options('shr').report(true))
 	
 	compile.dd(new DDStatement().name("SYSPRINT").options(props.REXX_printTempOptions))

--- a/samples/MortgageApplication/application-conf/REXX.properties
+++ b/samples/MortgageApplication/application-conf/REXX.properties
@@ -1,0 +1,63 @@
+# Application properties used by zAppBuild/language/REXX.groovy
+
+#
+# default REXX program build rank - used to sort language build file list
+# leave empty - overridden by file properties if sorting needed
+REXX_fileBuildRank=
+
+#
+# REXX dependency resolution rules
+# Rules defined in application.properties
+REXX_resolutionRules=[${REXXRule}]
+
+#
+# default REXX maximum RCs allowed
+# can be overridden by file properties
+REXX_compileMaxRC=4
+REXX_linkEditMaxRC=4
+
+#
+# lists of properties which should cause a rebuild after being changed
+REXX_impactPropertyList=REXX_compileParms
+
+#
+# default REXX compiler parameters
+# can be overridden by file properties
+REXX_compileParms=LIB
+
+# Compile Options for IBM Debugger. Assuming to keep Dwarf Files inside the load.
+# If you would like to separate debug info, additional allocations needed (See REXX + Debugger libraries)
+REXX_compileDebugParms=TEST
+
+#
+# default LinkEdit parameters
+# can be overridden by file properties
+REXX_linkEditParms=MAP,RENT,COMPAT(PM5)
+
+# If you would like to have a physical link card, we generated it for you given the below pattern
+# This property has priority over REXX_linkDebugExit
+# REXX_linkEditStream=    INCLUDE OBJECT(@{member})
+REXX_linkEditStream=
+
+# If using a debug exit, provide the SYSLIN instream DD
+# Samp: REXX_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
+REXX_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
+
+
+#
+# execute link edit step
+# can be overridden by file properties
+REXX_linkEdit=true
+
+#
+# scan link edit load module for link dependencies
+# can be overridden by file properties
+REXX_scanLoadModule=true
+
+#
+# additional libraries for compile SYSLIB concatenation, comma-separated
+REXX_compileSyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+REXX_linkEditSyslibConcatenation=

--- a/samples/application-conf/REXX.properties
+++ b/samples/application-conf/REXX.properties
@@ -23,11 +23,7 @@ REXX_impactPropertyList=REXX_compileParms
 #
 # default REXX compiler parameters
 # can be overridden by file properties
-REXX_compileParms=LIB
-
-# Compile Options for IBM Debugger. Assuming to keep Dwarf Files inside the load.
-# If you would like to separate debug info, additional allocations needed (See REXX + Debugger libraries)
-REXX_compileDebugParms=TEST
+REXX_compileParms=OBJECT PRINT XREF CEXEC
 
 #
 # default LinkEdit parameters
@@ -42,7 +38,6 @@ REXX_linkEditStream=
 # If using a debug exit, provide the SYSLIN instream DD
 # Samp: REXX_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
 REXX_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
-
 
 #
 # execute link edit step
@@ -61,3 +56,4 @@ REXX_compileSyslibConcatenation=
 #
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated
 REXX_linkEditSyslibConcatenation=
+

--- a/samples/application-conf/REXX.properties
+++ b/samples/application-conf/REXX.properties
@@ -3,57 +3,57 @@
 #
 # default REXX program build rank - used to sort language build file list
 # leave empty - overridden by file properties if sorting needed
-REXX_fileBuildRank=
+rexx_fileBuildRank=
 
 #
 # REXX dependency resolution rules
 # Rules defined in application.properties
-REXX_resolutionRules=[${REXXRule}]
+rexx_resolutionRules=[${rexxRule}]
 
 #
 # default REXX maximum RCs allowed
 # can be overridden by file properties
-REXX_compileMaxRC=4
-REXX_linkEditMaxRC=4
+rexx_compileMaxRC=4
+rexx_linkEditMaxRC=4
 
 #
 # lists of properties which should cause a rebuild after being changed
-REXX_impactPropertyList=REXX_compileParms
+rexx_impactPropertyList=rexx_compileParms
 
 #
 # default REXX compiler parameters
 # can be overridden by file properties
-REXX_compileParms=OBJECT PRINT XREF CEXEC
+rexx_compileParms=OBJECT PRINT XREF CEXEC
 
 #
 # default LinkEdit parameters
 # can be overridden by file properties
-REXX_linkEditParms=MAP,RENT,COMPAT(PM5)
+rexx_linkEditParms=MAP,RENT,COMPAT(PM5)
 
 # If you would like to have a physical link card, we generated it for you given the below pattern
 # This property has priority over REXX_linkDebugExit
 # REXX_linkEditStream=    INCLUDE OBJECT(@{member})
-REXX_linkEditStream=
+rexx_linkEditStream=
 
 # If using a debug exit, provide the SYSLIN instream DD
 # Samp: REXX_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
-REXX_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
+rexx_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
 
 #
 # execute link edit step
 # can be overridden by file properties
-REXX_linkEdit=true
+rexx_linkEdit=true
 
 #
 # scan link edit load module for link dependencies
 # can be overridden by file properties
-REXX_scanLoadModule=true
+rexx_scanLoadModule=true
 
 #
 # additional libraries for compile SYSLIB concatenation, comma-separated
-REXX_compileSyslibConcatenation=
+rexx_compileSyslibConcatenation=
 
 #
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated
-REXX_linkEditSyslibConcatenation=
+rexx_linkEditSyslibConcatenation=
 

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -48,7 +48,7 @@ jobCard=
 #
 # Impact analysis resolution rules (JSON format).
 # Defaults to just looking for local application dependency folders
-impactResolutionRules=[${copybookRule},${plincRule},${maclibRule},${asmCopyRule},${linkRule},${testcaseRule},${testconfigRule}]
+impactResolutionRules=[${copybookRule},${plincRule},${maclibRule},${asmCopyRule},${rexxRule},${linkRule},${testcaseRule},${testconfigRule}]
 
 # Rule to locate Cobol copy books. This rule defaults to the local copybook folder
 # in the main application folder.
@@ -85,7 +85,7 @@ asmCopyRule = {"library": "SYSLIB", "category": "COPY", \
 
 # Rule to locate REXX includes. This rule defaults to the local maclib folder
 # in the main application folder.
-REXXRule = {"library": "SYSLIB", "category": "COPY", \
+rexxRule = {"library": "SYSLIB", "category": "COPY", \
                   "searchPath": [ \
                     {"sourceDir": "${workspace}", "directory": "${application}/rexx"} \
                  ] \

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -8,7 +8,7 @@
 #
 # Comma separated list of additional application property files to load
 # Supports both relative path (to ${application}/application-conf/) and absolute path
-applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,ZunitConfig.properties
+applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,REXX.properties,ZunitConfig.properties
 
 #
 # Comma separated list all source directories included in application build. Supports both absolute
@@ -83,12 +83,20 @@ asmCopyRule = {"library": "SYSLIB", "category": "COPY", \
                  ] \
               }
 
-# Rule to locate Link files for rebuilding statically linked load modules 
+# Rule to locate REXX includes. This rule defaults to the local maclib folder
+# in the main application folder.
+REXXRule = {"library": "SYSLIB", "category": "COPY", \
+                  "searchPath": [ \
+                    {"sourceDir": "${workspace}", "directory": "${application}/rexx"} \
+                 ] \
+              }
+
+# Rule to locate Link files for rebuilding statically linked load modules
 linkRule =   {"category": "LINK", \
               "searchPath": [ \
                  {"sourceDir": "${workspace}", "directory": "${application}/link"} \
               ] \
-            } 
+            }
 
 # Rule to locate the zUnit test configuration file
 testconfigRule =   {"library": "SYSPROG", \
@@ -97,7 +105,7 @@ testconfigRule =   {"library": "SYSPROG", \
               ] \
             }
 
-# Rule to locate the zUnit playback file            
+# Rule to locate the zUnit playback file
 testcaseRule =   {"library": "SYSPLAY", \
               "searchPath": [ \
                  {"sourceDir": "${workspace}", "directory": "${application}/testplayfiles"} \

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -355,8 +355,8 @@ def createLanguageDatasets(String lang) {
 	if (props."${lang}_reportDatasets")
 		createDatasets(props."${lang}_reportDatasets".split(','), props."${lang}_reportOptions")
 		
-	if (props."${lang}_REXXLoadDatasets")
-		createDatasets(props."${lang}_REXXLoadDatasets".split(','), props."${lang}_REXXLoadOptions")
+	if (props."${lang}_cexecDatasets")
+		createDatasets(props."${lang}_cexecDatasets".split(','), props."${lang}_cexecOptions")
 }
 
 /*

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -354,7 +354,9 @@ def createLanguageDatasets(String lang) {
 	
 	if (props."${lang}_reportDatasets")
 		createDatasets(props."${lang}_reportDatasets".split(','), props."${lang}_reportOptions")
-	
+		
+	if (props."${lang}_REXXLoadDatasets")
+		createDatasets(props."${lang}_REXXLoadDatasets".split(','), props."${lang}_REXXLoadOptions")
 }
 
 /*


### PR DESCRIPTION
Added few files to support the compilation/link-edition of REXX language.

1. in build-conf folder:
- build.properties to add the reference to REXX.properties
- datasets.properties to reference the dataset which contains the REXX compiler
- REXX.properties for entreprise-level properties
2. in languages folder, REXX.groovy
3. in utilities folder, buildUtilities.groovy was changed to support the creation of specific datasets
4. in samples/application-conf:
- application.properties, to add the reference to REXX.properties and the resolution rules
- REXX.properties for application-level properties

Tested with OBJECT and CEXEC options, with and without linkedit. Impact build works as well, the DBB scanner understans the %INCLUDE statement correctly.