### PR TITLE
fix test framework template for simulating a change to impactBuilds

### DIFF
--- a/test/applications/MortgageApplication/copybook/epsmtout.cpy
+++ b/test/applications/MortgageApplication/copybook/epsmtout.cpy
@@ -1,4 +1,4 @@
-* OUTPUTS
+      * OUTPUTS
           10 EPSPCOM-RETURN-MONTH-PAYMENT
                                       PIC S9(7)V99 COMP.
           10 EPSPCOM-ERRMSG           PIC X(80).


### PR DESCRIPTION
The test framework fails due to a wrong template definition -> Wrong indentation. 

