### PR TITLE
Set deployTypes according to file attributes

### DIFF
--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -305,10 +305,8 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// add DD statements to the linkedit command
 	String assembler_loadPDS = props.getFileProperty('assembler_loadPDS', buildFile)
-	String assembler_deployType = props.getFileProperty('assembler_deployType', buildFile)
-	if ( assembler_deployType == null )
-		assembler_deployType = 'LOAD'
-	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${assembler_loadPDS}($member)").options('shr').output(true).deployType(assembler_deployType))
+	String deployType = buildUtils.getDeployType("linkedit", buildFile, logicalFile)
+	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${assembler_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.assembler_tempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.assembler_tempOptions))
 

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -124,7 +124,7 @@ def createLinkEditCommand(String buildFile, String member, File logFile) {
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(props.bms_linkEditor).parm(parameters)
 	
 	// add DD statements to the linkedit command
-	String deployType = buildUtils.getDeployType("bms", buildFile, logicalFile)
+	String deployType = buildUtils.getDeployType("bms", buildFile, null)
 	linkedit.dd(new DDStatement().name("SYSLIN").dsn("&&TEMPOBJ").options("shr"))
 	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.bms_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.bms_tempOptions))

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -74,7 +74,8 @@ def createCopyGenCommand(String buildFile, String member, File logFile) {
 	// add DD statements to the compile command
 	compile.dd(new DDStatement().name("SYSIN").dsn("${props.bms_srcPDS}($member)").options('shr').report(true))
 	compile.dd(new DDStatement().name("SYSPRINT").options(props.bms_tempOptions))
-	compile.dd(new DDStatement().name("SYSPUNCH").dsn("${props.bms_cpyPDS}($member)").options('shr').output(true))
+	String deployType = buildUtils.getDeployType("bms_copy", buildFile, null)
+	compile.dd(new DDStatement().name("SYSPUNCH").dsn("${props.bms_cpyPDS}($member)").options('shr').output(true).deployType(deployType))
 	[1,2,3].each { num ->
 		compile.dd(new DDStatement().name("SYSUT$num").options(props.bms_tempOptions))
 	}

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -124,8 +124,9 @@ def createLinkEditCommand(String buildFile, String member, File logFile) {
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(props.bms_linkEditor).parm(parameters)
 	
 	// add DD statements to the linkedit command
+	String deployType = buildUtils.getDeployType("bms", buildFile, logicalFile)
 	linkedit.dd(new DDStatement().name("SYSLIN").dsn("&&TEMPOBJ").options("shr"))
-	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.bms_loadPDS}($member)").options('shr').output(true).deployType('MAPLOAD'))
+	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.bms_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.bms_tempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.bms_tempOptions))
 	

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -286,7 +286,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	}
 
 	// add DD statements to the linkedit command
-	String deployType = buildUtils.getDeployType('${langQualifier}_deployType', buildFile)
+	String deployType = buildUtils.getDeployType('${langQualifier}_deployType', logicalFile)
 	if(isZUnitTestCase){
 		linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.cobol_testcase_loadPDS}($member)").options('shr').output(true).deployType('ZUNIT-TESTCASE'))
 	}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -286,7 +286,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	}
 
 	// add DD statements to the linkedit command
-	String deployType = buildUtils.getDeployType('${langQualifier}_deployType', buildFile, logicalFile)
+	String deployType = buildUtils.getDeployType(langQualifier, buildFile, logicalFile)
 	if(isZUnitTestCase){
 		linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.cobol_testcase_loadPDS}($member)").options('shr').output(true).deployType('ZUNIT-TESTCASE'))
 	}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -286,14 +286,12 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	}
 
 	// add DD statements to the linkedit command
-	String linkedit_deployType = props.getFileProperty('linkedit_deployType', buildFile)
-	if ( linkedit_deployType == null )
-		linkedit_deployType = 'LOAD'
+	String deployType = buildUtils.getDeployType('${langQualifier}_deployType', buildFile)
 	if(isZUnitTestCase){
 		linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.cobol_testcase_loadPDS}($member)").options('shr').output(true).deployType('ZUNIT-TESTCASE'))
 	}
 	else {
-		linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.cobol_loadPDS}($member)").options('shr').output(true).deployType(linkedit_deployType))
+		linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.cobol_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	}
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.cobol_printTempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.cobol_tempOptions))

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -286,7 +286,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	}
 
 	// add DD statements to the linkedit command
-	String deployType = buildUtils.getDeployType('${langQualifier}_deployType', logicalFile)
+	String deployType = buildUtils.getDeployType('${langQualifier}_deployType', buildFile, logicalFile)
 	if(isZUnitTestCase){
 		linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.cobol_testcase_loadPDS}($member)").options('shr').output(true).deployType('ZUNIT-TESTCASE'))
 	}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -19,7 +19,7 @@ println("** Building files mapped to ${this.class.getName()}.groovy script")
 buildUtils.assertBuildProperties(props.cobol_requiredBuildProperties)
 
 // create language datasets
-@Field def langQualifier = "cobol"
+def langQualifier = "cobol"
 buildUtils.createLanguageDatasets(langQualifier)
 
 // sort the build list based on build file rank if provided
@@ -286,7 +286,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	}
 
 	// add DD statements to the linkedit command
-	String deployType = buildUtils.getDeployType(langQualifier, buildFile, logicalFile)
+	String deployType = buildUtils.getDeployType("cobol", buildFile, logicalFile)
 	if(isZUnitTestCase){
 		linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.cobol_testcase_loadPDS}($member)").options('shr').output(true).deployType('ZUNIT-TESTCASE'))
 	}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -19,7 +19,7 @@ println("** Building files mapped to ${this.class.getName()}.groovy script")
 buildUtils.assertBuildProperties(props.cobol_requiredBuildProperties)
 
 // create language datasets
-def langQualifier = "cobol"
+@Field def langQualifier = "cobol"
 buildUtils.createLanguageDatasets(langQualifier)
 
 // sort the build list based on build file rank if provided

--- a/languages/DBDgen.groovy
+++ b/languages/DBDgen.groovy
@@ -148,10 +148,8 @@ def createDBDLinkEditCommand(String buildFile, String member, File logFile) {
 
 	// add DD statements to the linkedit command
 	String dbdgen_loadPDS = props.getFileProperty('dbdgen_loadPDS', buildFile)
-	String dbdgen_deployType = props.getFileProperty('dbdgen_deployType', buildFile)
-	if ( dbdgen_deployType == null )
-		dbdgen_deployType = 'LOAD'
-	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${dbdgen_loadPDS}($member)").options('shr').output(true).deployType(dbdgen_deployType))
+	String deployType = buildUtils.getDeployType('dbdgen', buildFile, logicalFile)
+	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${dbdgen_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.dbdgen_tempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.dbdgen_tempOptions))
 

--- a/languages/DBDgen.groovy
+++ b/languages/DBDgen.groovy
@@ -148,7 +148,7 @@ def createDBDLinkEditCommand(String buildFile, String member, File logFile) {
 
 	// add DD statements to the linkedit command
 	String dbdgen_loadPDS = props.getFileProperty('dbdgen_loadPDS', buildFile)
-	String deployType = buildUtils.getDeployType('dbdgen', buildFile, logicalFile)
+	String deployType = buildUtils.getDeployType('dbdgen', buildFile, null)
 	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${dbdgen_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.dbdgen_tempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.dbdgen_tempOptions))

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -82,11 +82,10 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(linker).parm(parms)
 
 	// add DD statements to the linkedit command
-	String linkedit_deployType = props.getFileProperty('linkedit_deployType', buildFile)
-	if ( linkedit_deployType == null )
-		linkedit_deployType = 'LOAD'
+	// deployType requires a file level overwrite to define isCICS and isDLI, while the linkcard does not carry isCICS, isDLI attributes
+	String deployType = buildUtils.getDeployType("linkedit", buildFile, logicalFile)
 	linkedit.dd(new DDStatement().name("SYSLIN").dsn("${props.linkedit_srcPDS}($member)").options("shr").report(true))
-	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.linkedit_loadPDS}($member)").options('shr').output(true).deployType(linkedit_deployType))
+	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.linkedit_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.linkedit_tempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.linkedit_tempOptions))
 

--- a/languages/MFS.groovy
+++ b/languages/MFS.groovy
@@ -130,7 +130,7 @@ def createPhase2Command(String buildFile, String member, File logFile) {
 	MVSExec mfsPhase2 = new MVSExec().file(buildFile).pgm(props.mfs_phase2processor).parm(parameters)
 	
 	// add DD statements to the mfsPhase2 command
-	String deployType = buildUtils.getDeployType("mfs", buildFile, logicalFile)
+	String deployType = buildUtils.getDeployType("mfs", buildFile, null)
 	
 	mfsPhase2.dd(new DDStatement().name("FORMAT").dsn(props.mfs_tformatPDS).options("shr").output(true).deployType(deployType))
 	// mfsPhase2.dd(new DDStatement().name("DUMMY").dsn("${props.PROCLIB}(FMTCPY)").options("shr"))

--- a/languages/MFS.groovy
+++ b/languages/MFS.groovy
@@ -130,11 +130,9 @@ def createPhase2Command(String buildFile, String member, File logFile) {
 	MVSExec mfsPhase2 = new MVSExec().file(buildFile).pgm(props.mfs_phase2processor).parm(parameters)
 	
 	// add DD statements to the mfsPhase2 command
-	String mfs_deployType = props.getFileProperty('mfs_deployType', buildFile)
-	if ( mfs_deployType == null )
-		mfs_deployType = 'LOAD'
+	String deployType = buildUtils.getDeployType("mfs", buildFile, logicalFile)
 	
-	mfsPhase2.dd(new DDStatement().name("FORMAT").dsn(props.mfs_tformatPDS).options("shr").output(true).deployType(mfs_deployType))
+	mfsPhase2.dd(new DDStatement().name("FORMAT").dsn(props.mfs_tformatPDS).options("shr").output(true).deployType(deployType))
 	// mfsPhase2.dd(new DDStatement().name("DUMMY").dsn("${props.PROCLIB}(FMTCPY)").options("shr"))
 	mfsPhase2.dd(new DDStatement().name("TASKLIB").dsn(props.SDFSRESL).options("shr"))
 	

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -217,7 +217,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(linker).parm(parms)
 
 	// add DD statements to the linkedit command
-	String deployType = buildUtils.getDeployType("cobol", buildFile, logicalFile)
+	String deployType = buildUtils.getDeployType("pli", buildFile, logicalFile)
 	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.pli_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.pli_tempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.pli_tempOptions))

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -217,10 +217,8 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(linker).parm(parms)
 
 	// add DD statements to the linkedit command
-	String linkedit_deployType = props.getFileProperty('linkedit_deployType', buildFile)
-	if ( linkedit_deployType == null )
-		linkedit_deployType = 'LOAD'
-	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.pli_loadPDS}($member)").options('shr').output(true).deployType(linkedit_deployType))
+	String deployType = buildUtils.getDeployType("cobol", buildFile, logicalFile)
+	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.pli_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.pli_tempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.pli_tempOptions))
 

--- a/languages/PSBgen.groovy
+++ b/languages/PSBgen.groovy
@@ -170,7 +170,7 @@ def createPSBLinkEditCommand(String buildFile, String member, File logFile) {
 
 	// add DD statements to the linkedit command
 	String psbgen_loadPDS = props.getFileProperty('psbgen_loadPDS', buildFile)
-	String deployType = buildUtils.getDeployType("psbgen", buildFile, logicalFile)
+	String deployType = buildUtils.getDeployType("psbgen", buildFile, null)
 	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${psbgen_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.psbgen_tempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.psbgen_tempOptions))

--- a/languages/PSBgen.groovy
+++ b/languages/PSBgen.groovy
@@ -170,10 +170,8 @@ def createPSBLinkEditCommand(String buildFile, String member, File logFile) {
 
 	// add DD statements to the linkedit command
 	String psbgen_loadPDS = props.getFileProperty('psbgen_loadPDS', buildFile)
-	String psbgen_deployType = props.getFileProperty('psbgen_deployType', buildFile)
-	if ( psbgen_deployType == null )
-		psbgen_deployType = 'LOAD'
-	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${psbgen_loadPDS}($member)").options('shr').output(true).deployType(psbgen_deployType))
+	String deployType = buildUtils.getDeployType("psbgen", buildFile, logicalFile)
+	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${psbgen_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.psbgen_tempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.psbgen_tempOptions))
 
@@ -223,10 +221,8 @@ def createACBgenCommand(String buildFile, String member, File logFile) {
 
 	// retrieve target pds and deploytype
 	String acbgen_loadPDS = props.getFileProperty('acbgen_loadPDS', buildFile)
-	String acbgen_deployType = props.getFileProperty('acbgen_deployType', buildFile)
-	if ( acbgen_deployType == null )
-		acbgen_deployType = 'LOAD'
-	acbgen.dd(new DDStatement().name("IMSACB").dsn("${acbgen_loadPDS}").options('shr').output(true).deployType(acbgen_deployType))
+	String deployType = buildUtils.getDeployType("acbgen", buildFile, logicalFile)
+	acbgen.dd(new DDStatement().name("IMSACB").dsn("${acbgen_loadPDS}").options('shr').output(true).deployType(deployType))
 
 	// addional allocations
 	acbgen.dd(new DDStatement().name("SYSPRINT").options(props.psbgen_tempOptions))

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -116,7 +116,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	String linkDebugExit = props.getFileProperty('rexx_linkDebugExit', buildFile)
 
 	compile.dd(new DDStatement().name("SYSPUNCH").dsn("${props.rexx_objPDS}($member)").options('shr').output(true))
-	String deployType = buildUtils.getDeployType("rexx_exec", buildFile, logicalFile)
+	String deployType = buildUtils.getDeployType("rexx_exec", buildFile, null)
 	compile.dd(new DDStatement().name("SYSCEXEC").dsn("${props.rexx_cexecPDS}($member)").options('shr').output(true).deployType(deployType))
 	
 	// add a syslib to the compile command with optional bms output copybook and CICS concatenation

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -116,7 +116,8 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	String linkDebugExit = props.getFileProperty('rexx_linkDebugExit', buildFile)
 
 	compile.dd(new DDStatement().name("SYSPUNCH").dsn("${props.rexx_objPDS}($member)").options('shr').output(true))
-	compile.dd(new DDStatement().name("SYSCEXEC").dsn("${props.rexx_cexecPDS}($member)").options('shr').output(true).deployType('LOAD'))
+	String deployType = buildUtils.getDeployType("rexx_exec", buildFile, logicalFile)
+	compile.dd(new DDStatement().name("SYSCEXEC").dsn("${props.rexx_cexecPDS}($member)").options('shr').output(true).deployType(deployType))
 	
 	// add a syslib to the compile command with optional bms output copybook and CICS concatenation
 	compile.dd(new DDStatement().name("SYSLIB").dsn(props.rexx_srcPDS).options("shr"))
@@ -187,10 +188,8 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	}
 
 	// add DD statements to the linkedit command
-	String linkedit_deployType = props.getFileProperty('linkedit_deployType', buildFile)
-	if ( linkedit_deployType == null )
-		linkedit_deployType = 'LOAD'
-	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.rexx_loadPDS}($member)").options('shr').output(true).deployType(linkedit_deployType))
+	String deployType = buildUtils.getDeployType("rexx", buildFile, logicalFile)
+	linkedit.dd(new DDStatement().name("SYSLMOD").dsn("${props.rexx_loadPDS}($member)").options('shr').output(true).deployType(deployType))
 	
 	linkedit.dd(new DDStatement().name("SYSPRINT").options(props.rexx_printTempOptions))
 	linkedit.dd(new DDStatement().name("SYSUT1").options(props.rexx_tempOptions))

--- a/samples/MortgageApplication/application-conf/Assembler.properties
+++ b/samples/MortgageApplication/application-conf/Assembler.properties
@@ -1,4 +1,4 @@
-# Project properties used by zAppBuild/language/Assembler.groovy
+# Application properties used by zAppBuild/language/Assembler.groovy
 
 #
 # default Assemble program build rank - used to sort language build file list
@@ -6,9 +6,52 @@
 assembler_fileBuildRank=
 
 #
-# default Assembler maximum RC allowed
+# default Assembler parameters
 # can be overridden by file properties
-assembler_maxRC=0
+assembler_pgmParms=LIST
+assembler_linkEditParms=MAP,RENT,COMPAT(PM5)
+assembler_compileErrorPrefixParms=ADATA,EX(ADX(ELAXHASM))
+assembler_db2precompilerParms=HOST(ASM)
+assembler_cicsprecompilerParms=
+
+#
+# execute link edit step
+# can be overridden by file properties
+assembler_linkEdit=true
+
+#
+# default Assembler maximum RCs allowed
+# can be overridden by file properties
+assembler_maxRC=4
+assembler_linkEditMaxRC=0
+
+#
+# lists of properties which should cause a rebuild after being changed
+assembler_impactPropertyList=assembler_pgmParms
+assembler_impactPropertyListCICS=assembler_db2precompilerParms
+assembler_impactPropertyListSQL=assembler_cicsprecompilerParms
+
+#
+# ASM Dependency resolution rules
+# Rules defined in app-properties file
+assembler_resolutionRules=[${maclibRule},${asmCopyRule}]
+
+#
+# default deployType
+assembler_deployType=LOAD
+
+#
+# deployType for build files with isCICS=true
+assembler_deployTypeCICS=CICSLOAD
+
+#
+# deployType for build files with isDLI=true
+assembler_deployTypeDLI=IMSLOAD
+
+#
+# scan link edit load module for link dependencies
+# can be overridden by file properties
+assembler_scanLoadModule=true
 
 #
 # additional libraries for assembler SYSLIB concatenation, comma-separated

--- a/samples/MortgageApplication/application-conf/BMS.properties
+++ b/samples/MortgageApplication/application-conf/BMS.properties
@@ -1,4 +1,4 @@
-# Project properties used by zAppBuild/language/Assembler.groovy
+# Application properties used by zAppBuild/language/Assembler.groovy
 
 #
 # default BMS map build rank - used to sort language build file list
@@ -6,7 +6,7 @@
 bms_fileBuildRank=
 
 #
-# default BMS maximun RC allowed
+# default BMS maximum RC allowed
 # can be overridden by file properties
 bms_maxRC=0
 
@@ -17,9 +17,10 @@ bms_copyGenParms=SYSPARM(DSECT),DECK,NOOBJECT
 bms_compileParms=SYSPARM(MAP),DECK,NOOBJECT
 bms_linkEditParms=MAP,RENT,COMPAT(PM5)
 
+#
+# lists of properties which should cause a rebuild after being changed
+bms_impactPropertyList=bms_copyGenParms,bms_compileParms,bms_linkEditParms
 
-
-
-
-
-
+#
+# default deployType
+bms_deployType=LOAD

--- a/samples/MortgageApplication/application-conf/BMS.properties
+++ b/samples/MortgageApplication/application-conf/BMS.properties
@@ -23,4 +23,4 @@ bms_impactPropertyList=bms_copyGenParms,bms_compileParms,bms_linkEditParms
 
 #
 # default deployType
-bms_deployType=LOAD
+bms_deployType=MAPLOAD

--- a/samples/MortgageApplication/application-conf/BMS.properties
+++ b/samples/MortgageApplication/application-conf/BMS.properties
@@ -24,3 +24,7 @@ bms_impactPropertyList=bms_copyGenParms,bms_compileParms,bms_linkEditParms
 #
 # default deployType
 bms_deployType=MAPLOAD
+
+#
+# default deployType for generated copybooks
+bms_copy_deployType=MAPCOPY

--- a/samples/MortgageApplication/application-conf/Cobol.properties
+++ b/samples/MortgageApplication/application-conf/Cobol.properties
@@ -60,6 +60,18 @@ cobol_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT
 cobol_linkEdit=true
 
 #
+# default deployType
+cobol_deployType=LOAD
+
+#
+# default deployType
+cobol_deployTypeCICS=CICSLOAD
+
+#
+# default deployType
+cobol_deployTypeDLI=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 cobol_scanLoadModule=true

--- a/samples/MortgageApplication/application-conf/LinkEdit.properties
+++ b/samples/MortgageApplication/application-conf/LinkEdit.properties
@@ -16,6 +16,18 @@ linkedit_maxRC=0
 linkEdit_parms=MAP,RENT,COMPAT(PM5)
 
 #
+# default deployType
+linkedit_deployType=LOAD
+
+#
+# deployType for build files with isCICS=true
+linkedit_deployTypeCICS=CICSLOAD
+
+#
+# deployType for build files with isDLI=true
+linkedit_deployTypeDLI=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 linkedit_scanLoadModule=true

--- a/samples/MortgageApplication/application-conf/PLI.properties
+++ b/samples/MortgageApplication/application-conf/PLI.properties
@@ -46,6 +46,18 @@ pli_linkEditParms=MAP,RENT,COMPAT(PM5)
 pli_linkEdit=true
 
 #
+# default deployType
+pli_deployType=LOAD
+
+#
+# default deployType
+pli_deployTypeCICS=CICSLOAD
+
+#
+# default deployType
+pli_deployTypeDLI=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 pli_scanLoadModule=true

--- a/samples/MortgageApplication/application-conf/README.md
+++ b/samples/MortgageApplication/application-conf/README.md
@@ -30,22 +30,6 @@ dbb.scriptMapping | DBB configuration file properties association build files to
 dbb.scannerMapping | DBB scanner mapping to overwrite the file scanner. File property
 cobol_testcase | File property to indicate a generated zUnit cobol test case to use a different set of source and output libraries
 
-### Assembler.properties
-Application properties used by zAppBuild/language/Assembler.groovy
-
-Property | Description | Overridable
---- | --- | ---
-assembler_fileBuildRank | Default Assemble program build rank. Used to sort Assembler build file sub-list. Leave empty. | true
-assembler_pgmParms | Default Assembler parameters. | true
-assembler_linkEditParms | Default parameters for the link edit step. | true
-assembler_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
-assembler_maxRC | Default Assembler maximum RC allowed. | true
-assembler_linkEditMaxRC | Default link edit maximum RC allowed. | true
-assembler_resolutionRules | Assembler dependency resolution rules used to create a Assmebler dependency resolver.  Format is a JSON array of resolution rule property keys.  Resolution rule properties are defined in `application-conf/application.properties`. | true
-assembler_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
-assembler_assemblySyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during assembly step | true
-assembler_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
-
 ### BMS.properties
 Application properties used by zAppBuild/language/BMS.groovy
 
@@ -56,6 +40,9 @@ bms_maxRC | Default BMS maximum RC allowed. | true
 bms_copyGenParms | Default parameters for the copybook generation step. | true
 bms_compileParms | Default parameters for the compilation step. | true
 bms_linkEditParms | Default parameters for the link edit step. | true
+bms_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+bms_deployType | deployType for build output | true
+bms_copy_deployType | deployType for generated copybooks | true
 
 ### Cobol.properties
 Application properties used by zAppBuild/language/Cobol.groovy
@@ -72,11 +59,17 @@ cobol_compileCICSParms | Default CICS compile parameters. Appended to base param
 cobol_compileSQLParms | Default SQL compile parameters. Appended to base parameters if has value. | true
 cobol_compileErrorPrefixParms | IDz user build parameters. Appended to base parameters if has value. | true
 cobol_linkEditParms | Default link edit parameters. | true
+cobol_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+cobol_impactPropertyListCICS | List of CICS build properties causing programs to rebuild when changed | false
+cobol_impactPropertyListSQL | List of SQL build properties causing programs to rebuild when changed | false
 cobol_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
 cobol_isMQ | Flag indicating that the program contains MQ calls | true
+cobol_deployType | default deployType for build output | true
+cobol_deployTypeCICS | deployType for build output for build files where isCICS=true | true
+cobol_deployTypeDLI | deployType for build output for build files with isDLI=true | true
 cobol_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
 cobol_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
-cobol_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
+cobol_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### LinkEdit.properties
 Application properties used by zAppBuild/language/LinkEdit.groovy
@@ -86,25 +79,10 @@ Property | Description | Overridable
 linkedit_fileBuildRank | Default link card build rank. Used to sort link card build sub-list. Leave empty. | true
 linkedit_maxRC | Default link edit maximum RC allowed. | true
 linkedit_parms | Default link edit parameters. | true
+linkedit_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+linkedit_deployType | default deployType for build output | true
+linkedit_deployTypeCICS | deployType for build output for build files where isCICS=true set as file property | true
+linkedit_deployTypeDLI | deployType for build output for build files with isDLI=true set as file property | true
 linkedit_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
-linkEdit_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
+linkEdit_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
-### PLI.properties
-Application properties used by zAppBuild/language/LinkEdit.groovy
-
-Property | Description | Overridable
---- | --- | ---
-pli_fileBuildRank | Default PLI program build rank. Used to sort PLI program sub-list. Leave empty. | true
-pli_resolutionRules | PLI dependency resolution rules used to create a PLI dependency resolver.  Format is a JSON array of resolution rule property keys.  Resolution rule properties are defined in `application-conf/application.properties`. | true
-pli_compilerVersion | Default PLI compiler version. | true
-pli_compileMaxRC | Default compile maximum RC allowed. | true
-pli_linkEditMaxRC | Default link edit maximum RC allowed. | true
-pli_compileParms | Default base compile parameters. | true
-pli_compileCICSParms | Default CICS compile parameters. Appended to base parameters if has value.| true
-pli_compileSQLParms | Default SQL compile parameters. Appended to base parameters if has value. | true
-pli_compileErrorPrefixParms | IDz user build parameters. Appended to base parameters if has value. | true
-pli_linkEditParms | Default link edit parameters. | true
-pli_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
-pli_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
-pli_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
-pli_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true

--- a/samples/MortgageApplication/application-conf/file.properties
+++ b/samples/MortgageApplication/application-conf/file.properties
@@ -19,4 +19,4 @@ cobol_linkEdit = false :: **/cobol/epsnbrvl.cbl, **/cobol/epsmlist.cbl
 #
 # epsmlist needs to compile as CICS but does not have EXEC CICS statements
 # so is not automatically flagged as CICS by dependency scanner
-isCICS = true :: **/cobol/epsmlist.cbl, **/cobol/epscsmrt.cbl
+isCICS = true :: **/cobol/epsmlist.cbl, **/link/epsmlist.lnk, **/cobol/epscsmrt.cbl

--- a/samples/application-conf/ACBgen.properties
+++ b/samples/application-conf/ACBgen.properties
@@ -10,3 +10,6 @@ acbgen_pgmParms=UPB
 # can be overridden by file properties
 acbgen_pgmMaxRC=8
 
+#
+# default deployType
+acbgen_deployType=ACB

--- a/samples/application-conf/Assembler.properties
+++ b/samples/application-conf/Assembler.properties
@@ -37,6 +37,18 @@ assembler_impactPropertyListSQL=assembler_cicsprecompilerParms
 assembler_resolutionRules=[${maclibRule},${asmCopyRule}]
 
 #
+# default deployType
+assembler_deployType=LOAD
+
+#
+# deployType for build files with isCICS=true
+assembler_deployTypeCICS=CICSLOAD
+
+#
+# deployType for build files with isDLI=true
+assembler_deployTypeDLI=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 assembler_scanLoadModule=true

--- a/samples/application-conf/BMS.properties
+++ b/samples/application-conf/BMS.properties
@@ -21,4 +21,6 @@ bms_linkEditParms=MAP,RENT,COMPAT(PM5)
 # lists of properties which should cause a rebuild after being changed
 bms_impactPropertyList=bms_copyGenParms,bms_compileParms,bms_linkEditParms
 
-
+#
+# default deployType
+bms_deployType=LOAD

--- a/samples/application-conf/BMS.properties
+++ b/samples/application-conf/BMS.properties
@@ -23,4 +23,4 @@ bms_impactPropertyList=bms_copyGenParms,bms_compileParms,bms_linkEditParms
 
 #
 # default deployType
-bms_deployType=LOAD
+bms_deployType=MAPLOAD

--- a/samples/application-conf/BMS.properties
+++ b/samples/application-conf/BMS.properties
@@ -24,3 +24,7 @@ bms_impactPropertyList=bms_copyGenParms,bms_compileParms,bms_linkEditParms
 #
 # default deployType
 bms_deployType=MAPLOAD
+
+#
+# default deployType for generated copybooks
+bms_copy_deployType=MAPCOPY

--- a/samples/application-conf/Cobol.properties
+++ b/samples/application-conf/Cobol.properties
@@ -60,6 +60,18 @@ cobol_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT
 cobol_linkEdit=true
 
 #
+# default deployType
+cobol_deployType=LOAD
+
+#
+# default deployType
+cobol_deployTypeCICS=CICSLOAD
+
+#
+# default deployType
+cobol_deployTypeDLI=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 cobol_scanLoadModule=true

--- a/samples/application-conf/Cobol.properties
+++ b/samples/application-conf/Cobol.properties
@@ -64,11 +64,11 @@ cobol_linkEdit=true
 cobol_deployType=LOAD
 
 #
-# default deployType
+# deployType for build files with isCICS=true
 cobol_deployTypeCICS=CICSLOAD
 
 #
-# default deployType
+# deployType for build files with isDLI=true
 cobol_deployTypeDLI=IMSLOAD
 
 #

--- a/samples/application-conf/DBDgen.properties
+++ b/samples/application-conf/DBDgen.properties
@@ -27,4 +27,7 @@ dbdgen_linkEditMaxRC=0
 # lists of properties which should cause a rebuild after being changed
 dbdgen_impactPropertyList=dbdgen_pgmParms
 
+#
+# default deployType
+dbdgen_deployType=DBD
 

--- a/samples/application-conf/LinkEdit.properties
+++ b/samples/application-conf/LinkEdit.properties
@@ -24,11 +24,11 @@ linkEdit_parms=MAP,RENT,COMPAT(PM5)
 linkedit_deployType=LOAD
 
 #
-# deployType for build files with isCICS=true
+# deployType for build files with isCICS=true set in file properties
 linkedit_deployTypeCICS=CICSLOAD
 
 #
-# deployType for build files with isDLI=true
+# deployType for build files with isDLI=true set in file properties
 linkedit_deployTypeDLI=IMSLOAD
 
 #

--- a/samples/application-conf/LinkEdit.properties
+++ b/samples/application-conf/LinkEdit.properties
@@ -20,6 +20,18 @@ linkedit_impactPropertyList=linkEdit_parms
 linkEdit_parms=MAP,RENT,COMPAT(PM5)
 
 #
+# default deployType
+linkedit_deployType=LOAD
+
+#
+# deployType for build files with isCICS=true
+linkedit_deployTypeCICS=CICSLOAD
+
+#
+# deployType for build files with isDLI=true
+linkedit_deployTypeDLI=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 linkedit_scanLoadModule=true

--- a/samples/application-conf/MFS.properties
+++ b/samples/application-conf/MFS.properties
@@ -21,3 +21,7 @@ mfs_phase2Parms=COMPRESS,NOCOMPREND,UPDATE,DEVCHAR=I
 #
 # lists of properties which should cause a rebuild after being changed
 mfs_impactPropertyList=mfs_phase1Parms,mfs_phase2Parms
+
+#
+# default deployType
+mfs_deployType=MFSMAPLOAD

--- a/samples/application-conf/PLI.properties
+++ b/samples/application-conf/PLI.properties
@@ -46,6 +46,18 @@ pli_linkEditParms=MAP,RENT,COMPAT(PM5)
 pli_linkEdit=true
 
 #
+# default deployType
+pli_deployType=LOAD
+
+#
+# default deployType
+pli_deployTypeCICS=CICSLOAD
+
+#
+# default deployType
+pli_deployTypeDLI=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 pli_scanLoadModule=true

--- a/samples/application-conf/PLI.properties
+++ b/samples/application-conf/PLI.properties
@@ -50,11 +50,11 @@ pli_linkEdit=true
 pli_deployType=LOAD
 
 #
-# default deployType
+# deployType for build files with isCICS=true
 pli_deployTypeCICS=CICSLOAD
 
 #
-# default deployType
+# deployType for build files with isDLI=true
 pli_deployTypeDLI=IMSLOAD
 
 #

--- a/samples/application-conf/PSBgen.properties
+++ b/samples/application-conf/PSBgen.properties
@@ -28,3 +28,6 @@ psbgen_impactPropertyList=acbgen_pgmParms,psbgen_pgmParms,psbgen_linkEditParms
 psbgen_assemblerMaxRC=4
 psbgen_linkEditMaxRC=0
 
+#
+# default deployType
+psbgen_deployType=PSB

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -222,3 +222,20 @@ zunit_resolutionRules | Default resolution rules for zUnit. | true
 zunit_CodeCoverageHost | Headless Code Coverage Collector host (if not specified IDz will be used for reporting) | true 
 zunit_CodeCoveragePort | Headless Code Coverage Collector port (if not specified IDz will be used for reporting) | true 
 zunit_CodeCoverageOptions | Headless Code Coverage Collector Options | true
+
+### REXX.properties
+Application properties used by zAppBuild/language/REXX.groovy
+
+Property | Description | Overridable
+--- | --- | ---
+rexx_compileMaxRC | Default compile maximum RC allowed. | true
+rexx_linkEditMaxRC | Default link edit maximum RC allowed. | true
+rexx_resolutionRules | Default resolution rules for zUnit. | true
+rexx_compileParms | Default base compile parameters. | true
+rexx_compiler | Default REXX compiler | true
+rexx_linkEdit | Flag indicating to execute the link edit step to produce a compiled rexx for the source file. | true
+rexx_linkEditParms | Default link edit parameters. | true
+rexx_deployType | default deployType | true
+rexx_cexec_deployType | default deployType CEXEC | true
+rexx_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
+rexx_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -52,6 +52,9 @@ assembler_impactPropertyList | List of build properties causing programs to rebu
 assembler_impactPropertyListCICS | List of CICS build properties causing programs to rebuild when changed | false
 assembler_impactPropertyListSQL | List of SQL build properties causing programs to rebuild when changed | false
 assembler_resolutionRules | Assembler dependency resolution rules used to create a Assmebler dependency resolver.  Format is a JSON array of resolution rule property keys.  Resolution rule properties are defined in `application-conf/application.properties`. | true
+assembler_deployType | default deployType for build output | true
+assembler_deployTypeCICS | deployType for build output for build files where isCICS=true | true
+assembler_deployTypeDLI | deployType for build output for build files with isDLI=true | true
 assembler_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
 assembler_assemblySyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during assembly step | true
 assembler_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
@@ -67,6 +70,8 @@ bms_copyGenParms | Default parameters for the copybook generation step. | true
 bms_compileParms | Default parameters for the compilation step. | true
 bms_linkEditParms | Default parameters for the link edit step. | true
 bms_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+bms_deployType | deployType for build output | true
+bms_copy_deployType | deployType for generated copybooks | true
 
 
 ### Cobol.properties
@@ -89,9 +94,12 @@ cobol_impactPropertyListCICS | List of CICS build properties causing programs to
 cobol_impactPropertyListSQL | List of SQL build properties causing programs to rebuild when changed | false
 cobol_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
 cobol_isMQ | Flag indicating that the program contains MQ calls | true
+cobol_deployType | default deployType for build output | true
+cobol_deployTypeCICS | deployType for build output for build files where isCICS=true | true
+cobol_deployTypeDLI | deployType for build output for build files with isDLI=true | true
 cobol_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
 cobol_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
-cobol_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
+cobol_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### LinkEdit.properties
 Application properties used by zAppBuild/language/LinkEdit.groovy
@@ -102,8 +110,11 @@ linkedit_fileBuildRank | Default link card build rank. Used to sort link card bu
 linkedit_maxRC | Default link edit maximum RC allowed. | true
 linkedit_parms | Default link edit parameters. | true
 linkedit_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+linkedit_deployType | default deployType for build output | true
+linkedit_deployTypeCICS | deployType for build output for build files where isCICS=true set as file property | true
+linkedit_deployTypeDLI | deployType for build output for build files with isDLI=true set as file property | true
 linkedit_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
-linkEdit_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
+linkEdit_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### PLI.properties
 Application properties used by zAppBuild/language/LinkEdit.groovy
@@ -127,9 +138,12 @@ pli_impactPropertyList | List of build properties causing programs to rebuild wh
 pli_impactPropertyListCICS | List of CICS build properties causing programs to rebuild when changed | false
 pli_impactPropertyListSQL | List of SQL build properties causing programs to rebuild when changed | false
 pli_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
+pli_deployType | default deployType for build output | true
+pli_deployTypeCICS | deployType for build output for build files where isCICS=true | true
+pli_deployTypeDLI | deployType for build output for build files with isDLI=true | true
 pli_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
 pli_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
-pli_linkEditSyslibConcatenation |  A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
+pli_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### bind.properties
 Application properties used by zAppBuild/language/COBOL.groovy
@@ -155,6 +169,7 @@ mfs_phase2MaxRC | Default MFS Phase 2 maximum RC allowed. | true
 mfs_phase1Parms | Default parameters for the phase 1 step. | true
 mfs_phase2Parms | Default parameters for the phase 2 step. | true
 mfs_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+mfs_deployType | default deployType for build output | true
 
 ### DBDgen.properties
 Application properties used by zAppBuild/language/DBDgen.groovy
@@ -168,6 +183,7 @@ dbdgen_compileErrorPrefixParms | Default parameters to support remote error feed
 dbdgen_assemblerMaxRC | Default link edit maximum RC allowed. | true
 dbdgen_linkEditMaxRC | Default link edit maximum RC allowed. | true
 dbdgen_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+dbdgen_deployType | default deployType for build output | true
 
 
 ### PSBgen.properties
@@ -183,14 +199,16 @@ psbgen_runACBgen | Parameter if ACBgen should be executed right after PSBgen (de
 psbgen_assemblerMaxRC | Default link edit maximum RC allowed. | true
 psbgen_linkEditMaxRC | Default link edit maximum RC allowed. | true
 psbgen_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+psbgen_deployType | default deployType for build output | true
 
 ### ACBgen.properties
-Application properties used by zAppBuild/language/ACBgen.groovy
+Application properties used by zAppBuild/language/PSBgen.groovy
 
 Property | Description | Overridable
 --- | --- | ---
 acbgen_pgmParms | Default ACBgen parameters. | true
 acbgen_pgmMaxRC | Default ACBgen maximum RC allowed. | true
+acbgen_deployType | default deployType for build output | true
 
 ### ZunitConfig.properties
 Application properties used by zAppBuild/language/ZunitConfig.groovy
@@ -200,4 +218,7 @@ Property | Description | Overridable
 zunit_maxPassRC | Default zUnit maximum RC allowed for a Pass. | true
 zunit_maxWarnRC | Default zUnit maximum RC allowed for a Warninig (everything beyond this value will Fail). | true
 zunit_playbackFileExtension | Default zUnit Playback File Extension. | true
-zunit_resolutionRules | Default resolution rules for zUnit. | true 
+zunit_resolutionRules | Default resolution rules for zUnit. | true
+zunit_CodeCoverageHost | Headless Code Coverage Collector host (if not specified IDz will be used for reporting) | true 
+zunit_CodeCoveragePort | Headless Code Coverage Collector port (if not specified IDz will be used for reporting) | true 
+zunit_CodeCoverageOptions | Headless Code Coverage Collector Options | true

--- a/samples/application-conf/REXX.properties
+++ b/samples/application-conf/REXX.properties
@@ -45,6 +45,14 @@ rexx_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
 rexx_linkEdit=true
 
 #
+# default deployType
+rexx_deployType=CLIST
+
+#
+# default deployType CEXEC
+rexx_cexec_deployType=CEXEC
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 rexx_scanLoadModule=true

--- a/test/applications/MortgageApplication/copybook/epsmtout.cpy
+++ b/test/applications/MortgageApplication/copybook/epsmtout.cpy
@@ -1,4 +1,4 @@
-* OUTPUTS
+      * OUTPUTS
           10 EPSPCOM-RETURN-MONTH-PAYMENT
                                       PIC S9(7)V99 COMP.
           10 EPSPCOM-ERRMSG           PIC X(80).

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -421,7 +421,7 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 	if (props."${langQualifier}_deployType" != deployType){ // check if a file level overwrite was used
 		if(isCICS(logicalFile)){ // if CICS
 			String cicsDeployType = props.getFileProperty("${langQualifier}_deployTypeCICS", buildFile)
-			println "xxxx + $cicsDeployType"
+			println "xxxx + ${langQualifier}_deployTypeCICS + $cicsDeployType"
 			if (cicsDeployType != null) deployType = cicsDeployType
 		} else if (isDLI(logicalFile)){
 			String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -160,7 +160,7 @@ def sortBuildList(List<String> buildList, String rankPropertyName) {
 def updateBuildResult(Map args) {
 	// args : errorMsg / warningMsg, logs[logName:logFile], client:repoClient
 
-	// update build results only in non-userbuild scenarios 
+	// update build results only in non-userbuild scenarios
 	if (args.client && !props.userBuild) {
 		def buildResult = args.client.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 		if (!buildResult) {
@@ -348,13 +348,13 @@ def getScanner(String buildFile){
 def createLanguageDatasets(String lang) {
 	if (props."${lang}_srcDatasets")
 		createDatasets(props."${lang}_srcDatasets".split(','), props."${lang}_srcOptions")
-		
+
 	if (props."${lang}_loadDatasets")
 		createDatasets(props."${lang}_loadDatasets".split(','), props."${lang}_loadOptions")
-	
+
 	if (props."${lang}_reportDatasets")
 		createDatasets(props."${lang}_reportDatasets".split(','), props."${lang}_reportOptions")
-		
+
 	if (props."${lang}_cexecDatasets")
 		createDatasets(props."${lang}_cexecDatasets".split(','), props."${lang}_cexecOptions")
 }
@@ -407,4 +407,27 @@ def getLangPrefix(String scriptName){
 			break;
 	}
 	return langPrefix
+}
+
+/*
+ * returns the deployType for a logicalFile depending on the isCICS, isDLI setting
+ */
+def getDeployType(String langQualifier, LogicalFile logicalFile){
+	// getDefault
+	String deployType = props.getFileProperty('${langQualifier}_deployType', buildFile)
+	if(deployType == null )
+		deployType = 'LOAD'
+
+	if (props.'${langQualifier}_deployType' != deployType){ // check if a file level overwrite was used
+		if(isCICS(buildFile)){ // if CICS
+			String cicsDeployType = props.getFileProperty('${langQualifier}_deployTypeCICS', buildFile)
+			if (cicsDeployType != null) deployType = cicsDeployType
+		} else if (isDLI(buildFile)){
+			String dliDeployType = props.getFileProperty('${langQualifier}_deployTypeDLI', buildFile)
+			if (dliDeployType != null) deployType = dliDeployType
+		}
+	}
+	
+	return deployType
+
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -418,7 +418,7 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 	if(deployType == null )
 		deployType = 'LOAD'
 
-	if (props."${langQualifier}_deployType" != deployType){ // check if a file level overwrite was used
+	if (props."${langQualifier}_deployType" == deployType){ // check if a file level overwrite was used
 		if(isCICS(logicalFile)){ // if CICS
 			String cicsDeployType = props.getFileProperty("${langQualifier}_deployTypeCICS", buildFile)
 			print "xxxx + ${langQualifier}_deployTypeCICS + $cicsDeployType"
@@ -427,6 +427,8 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 			String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)
 			if (dliDeployType != null) deployType = dliDeployType
 		}
+	} else{
+		// a file level overwrite was used
 	}
 	
 	return deployType

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -419,10 +419,10 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 		deployType = 'LOAD'
 
 	if (props.'${langQualifier}_deployType' != deployType){ // check if a file level overwrite was used
-		if(isCICS(buildFile)){ // if CICS
+		if(isCICS(logicalFile)){ // if CICS
 			String cicsDeployType = props.getFileProperty('${langQualifier}_deployTypeCICS', buildFile)
 			if (cicsDeployType != null) deployType = cicsDeployType
-		} else if (isDLI(buildFile)){
+		} else if (isDLI(logicalFile)){
 			String dliDeployType = props.getFileProperty('${langQualifier}_deployTypeDLI', buildFile)
 			if (dliDeployType != null) deployType = dliDeployType
 		}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -412,7 +412,7 @@ def getLangPrefix(String scriptName){
 /*
  * returns the deployType for a logicalFile depending on the isCICS, isDLI setting
  */
-def getDeployType(String langQualifier, LogicalFile logicalFile){
+def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFile){
 	// getDefault
 	String deployType = props.getFileProperty('${langQualifier}_deployType', buildFile)
 	if(deployType == null )

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -414,16 +414,17 @@ def getLangPrefix(String scriptName){
  */
 def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFile){
 	// getDefault
-	String deployType = props.getFileProperty('${langQualifier}_deployType', buildFile)
+	String deployType = props.getFileProperty("${langQualifier}_deployType", buildFile)
 	if(deployType == null )
 		deployType = 'LOAD'
 
-	if (props.'${langQualifier}_deployType' != deployType){ // check if a file level overwrite was used
+	if (props."${langQualifier}_deployType" != deployType){ // check if a file level overwrite was used
 		if(isCICS(logicalFile)){ // if CICS
-			String cicsDeployType = props.getFileProperty('${langQualifier}_deployTypeCICS', buildFile)
+			String cicsDeployType = props.getFileProperty("${langQualifier}_deployTypeCICS", buildFile)
+			println "xxxx + $cicsDeployType"
 			if (cicsDeployType != null) deployType = cicsDeployType
 		} else if (isDLI(logicalFile)){
-			String dliDeployType = props.getFileProperty('${langQualifier}_deployTypeDLI', buildFile)
+			String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)
 			if (dliDeployType != null) deployType = dliDeployType
 		}
 	}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -421,7 +421,6 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 	if (props."${langQualifier}_deployType" != deployType){ // check if a file level overwrite was used
 		if(isCICS(logicalFile)){ // if CICS
 			String cicsDeployType = props.getFileProperty("${langQualifier}_deployTypeCICS", buildFile)
-			println "xxxx + ${langQualifier}_deployTypeCICS + $cicsDeployType"
 			if (cicsDeployType != null) deployType = cicsDeployType
 		} else if (isDLI(logicalFile)){
 			String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -421,6 +421,7 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 	if (props."${langQualifier}_deployType" != deployType){ // check if a file level overwrite was used
 		if(isCICS(logicalFile)){ // if CICS
 			String cicsDeployType = props.getFileProperty("${langQualifier}_deployTypeCICS", buildFile)
+			print "xxxx + ${langQualifier}_deployTypeCICS + $cicsDeployType"
 			if (cicsDeployType != null) deployType = cicsDeployType
 		} else if (isDLI(logicalFile)){
 			String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -422,7 +422,6 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 		if (logicalFile != null){
 			if(isCICS(logicalFile)){ // if CICS
 				String cicsDeployType = props.getFileProperty("${langQualifier}_deployTypeCICS", buildFile)
-				print "xxxx + ${langQualifier}_deployTypeCICS + $cicsDeployType"
 				if (cicsDeployType != null) deployType = cicsDeployType
 			} else if (isDLI(logicalFile)){
 				String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -419,18 +419,20 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 		deployType = 'LOAD'
 
 	if (props."${langQualifier}_deployType" == deployType){ // check if a file level overwrite was used
-		if(isCICS(logicalFile)){ // if CICS
-			String cicsDeployType = props.getFileProperty("${langQualifier}_deployTypeCICS", buildFile)
-			print "xxxx + ${langQualifier}_deployTypeCICS + $cicsDeployType"
-			if (cicsDeployType != null) deployType = cicsDeployType
-		} else if (isDLI(logicalFile)){
-			String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)
-			if (dliDeployType != null) deployType = dliDeployType
+		if (logicalFile != null){
+			if(isCICS(logicalFile)){ // if CICS
+				String cicsDeployType = props.getFileProperty("${langQualifier}_deployTypeCICS", buildFile)
+				print "xxxx + ${langQualifier}_deployTypeCICS + $cicsDeployType"
+				if (cicsDeployType != null) deployType = cicsDeployType
+			} else if (isDLI(logicalFile)){
+				String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)
+				if (dliDeployType != null) deployType = dliDeployType
+			}
 		}
 	} else{
 		// a file level overwrite was used
 	}
-	
+
 	return deployType
 
 }


### PR DESCRIPTION
This enhancement leverages the metadata of the logicalFile to set a deployType for the outputs. It evaluates the isCICS and isDLI attributes to either set the default deployType or the deployType for a CICS or IMS runtime.  File level overrides are considered.

For build files, which don't carry the attributes the default deployType is returned.

For BMS, MFS and REXX additional deployTypes are introduced.

If the property is not specified, the default deployType `LOAD` is returned.

A sample report based on the MortgageSample:

![image](https://user-images.githubusercontent.com/28918869/125255368-a0f4d280-e2fb-11eb-8e13-7f6305eedd5c.png)
