### PR TITLE
Implemented the creation of Testcase's dependency to program

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -88,6 +88,8 @@ build options:
  -ccp,--cccPort           Headless Code Coverage Collector port (if not specified IDz will be used for reporting)
  -cco,--cccOptions        Headless Code Coverage Collector Options
  
+ -ctd,--crTestcaseDep     Flag to enable the creation of a dependency to program for a Testcase	
+ 
 
 web application credentials
  -url,--url <arg>         DBB repository URL

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -52,6 +52,15 @@ impactBuildOnBuildPropertyChanges=false
 # general pattern: langPrefix_impactPropertyList, optional: langPrefix_impactPropertyListCICS and langPrefix_impactPropertyListSQL
 impactBuildOnBuildPropertyList=[${assembler_impactPropertyList},${assembler_impactPropertyListCICS},${assembler_impactPropertyListSQL},${bms_impactPropertyList},${cobol_impactPropertyList},${cobol_impactPropertyListCICS},${cobol_impactPropertyListSQL},${dbdgen_impactPropertyList},${linkedit_impactPropertyList},${mfs_impactPropertyList},${pli_impactPropertyList},${pli_impactPropertyListCICS},${pli_impactPropertyListSQL},${psbgen_impactPropertyList}]
 
+# createTestcaseDependency controls if a dependency should be set up between the testcase
+# and the corresponding application program. If this property set to true, a dependency
+# to the program is created for the testcase, which is then impacted by a change
+# of the program. In this case, the testcase is recompiled everytime the program is modified.
+# When set to false, the testcase is not impacted by the change of the program.
+# Can be overriden with command-line option
+# Default: false
+createTestcaseDependency=false
+
 # dbb.file.tagging controls compile log and build report file tagging. If true, files
 # written as UTF-8 or ASCII are tagged.
 # If the environment variable _BPXK_AUTOCVT is set ALL, file tagging may have an

--- a/build.groovy
+++ b/build.groovy
@@ -197,7 +197,9 @@ options:
 	cli.ccp(longOpt:'cccPort', args:1, argName:'cccPort', 'Headless Code Coverage Collector port (if not specified IDz will be used for reporting)')
 	cli.cco(longOpt:'cccOptions', args:1, argName:'cccOptions', 'Headless Code Coverage Collector Options')
 
-
+	// createTestcaseDependency
+	cli.ctd(longOpt:'crTestcaseDep', 'Flag to enable the creation of a dependency to program for a Testcase')
+	
 	// utility options
 	cli.help(longOpt:'help', 'Prints this message')
 
@@ -335,6 +337,9 @@ def populateBuildProperties(String[] args) {
 		}
 	}
 
+	// set createTestcaseDependency flag
+	if (opts.ctd) props.createTestcaseDependency = 'true'
+	
 	// set DBB configuration properties
 	if (opts.url) props.'dbb.RepositoryClient.url' = opts.url
 	if (opts.id) props.'dbb.RepositoryClient.userId' = opts.id

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -344,6 +344,11 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 		repositoryClient.deleteLogicalFile(props.applicationOutputsCollectionName, logicalFile)
 	}
 
+	if (props.createTestcaseDependency && props.createTestcaseDependency.toBoolean() && changedFiles && changedFiles.size() > 1) {
+		sortFileList(changedFiles);
+		if (props.verbose) println "*** Sorted list of changed files: $changedFiles"		
+	}
+	
 	// scan changed files
 	changedFiles.each { file ->
 
@@ -609,4 +614,33 @@ def addBuildPropertyDependencies(String buildProperties, LogicalFile logicalFile
 	}
 }
 
+/**
+ * isMappedAsZUnitConfigFile
+ * method to check if a file is mapped with the zUnitConfigScanner, indicating it's a zUnit CFG file
+ */
+def isMappedAsZUnitConfigFile(mapping, file) {
+	return (mapping.isMapped("ZUnitConfigScanner", file))
+}
 
+/**
+ * sortFileList
+ * sort a list, putting the lines that defines files mapped as zUnit CFG files to the end
+ */
+def sortFileList(list) {
+	def mapping = new PropertyMappings("dbb.scannerMapping")
+	list.sort{s1, s2 -> 
+		if (isMappedAsZUnitConfigFile(mapping, s1)) {
+			if (isMappedAsZUnitConfigFile(mapping, s2)) {
+				return 0;
+			} else {
+				return 1;
+			}
+		} else {
+			if (isMappedAsZUnitConfigFile(mapping, s2)) {
+				return -1;
+			} else {
+				return 0;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implementation of the Testcase Dependency creation.
When enabled (through the command line option -ctd/--crTestcaseDep flag or through property createTestcaseDependency in build.conf), the collection is updated and the LogicalFile corresponding to the testcase is updated with a LogicalDependency pointing to the program itself.
For instance, the testcase TLGICDB0 is updated with a dependency to program LGICDB01.
This is performed by scanning the testcase configuration (which contains the definition for both the program and the testcase).

Typically, this solves the problem when a new branch is created using different HLQs: when impact build is performed for the program itself on a new branch that was never built before, the testcase is not be present in the LOAD dataset. With this flag set, the testcase is always recompiled when the program changes, making sure the LOAD for the testcase is always rebuilt.