### PR TITLE
Feature to report external impacts

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -55,51 +55,53 @@ If buildFile is a text file (*.txt), then it is assumed to be a build list file.
 Options:
 
 required options:
- -w,--workspace <arg>     Absolute path to workspace (root) directory
-                          containing all required source directories
- -a,--application <arg>   Application directory name (relative to workspace)
- -o,--outDir <arg>        Absolute path to the build output root directory
- -h,--hlq <arg>           High level qualifier for partition data sets
+ -w,--workspace <arg>         Absolute path to workspace (root) directory
+                              containing all required source directories
+ -a,--application <arg>       Application directory name (relative to workspace)
+ -o,--outDir <arg>            Absolute path to the build output root directory
+ -h,--hlq <arg>               High level qualifier for partition data sets
 
 build options:
- -p,--propFiles           Comma separated list of additional property files 
-                          to load. Absolute paths or relative to workspace
- -f,--fullBuild           Flag indicating to build all programs for
-                          the application
- -i,--impactBuild         Flag indicating to build only programs impacted
-                          by changed files since last successful build.
+ -p,--propFiles               Comma separated list of additional property files 
+                              to load. Absolute paths or relative to workspace
+ -f,--fullBuild               Flag indicating to build all programs for
+                              the application
+ -i,--impactBuild             Flag indicating to build only programs impacted
+                              by changed files since last successful build.
                           
- -s,--scanOnly            Flag indicating to only scan source files for application without building anything (deprecated use --scanSource)
- -ss,--scanSource         Flag indicating to only scan source files for application without building anything
- -sl,--scanLoad           Flag indicating to only scan load modules for application without building anything
- -sa,--scanAll            Flag indicating to scan both source files and load modules for application without building anything
+ -s,--scanOnly                Flag indicating to only scan source files for application without building anything (deprecated use --scanSource)
+ -ss,--scanSource             Flag indicating to only scan source files for application without building anything
+ -sl,--scanLoad               Flag indicating to only scan load modules for application without building anything
+ -sa,--scanAll                Flag indicating to scan both source files and load modules for application without building anything
  
- -r,--reset               Deletes the application's dependency collections 
-                          and build result group from the DBB repository
- -v,--verbose             Flag to turn on script trace
- -d,--debug               Flag to build modules for debugging with
-                          IBM Debug for z/OS
- -l,--logEncoding <arg>   Encoding of output logs. Default is EBCDIC 
-                             directory for user build
- -zTest,--runzTests       Specify if zUnit Tests should be run
+ -r,--reset                   Deletes the application's dependency collections 
+                              and build result group from the DBB repository
+ -v,--verbose                 Flag to turn on script trace
+ -d,--debug                   Flag to build modules for debugging with
+                              IBM Debug for z/OS
+ -l,--logEncoding <arg>       Encoding of output logs. Default is EBCDIC 
+                              directory for user build
+ -zTest,--runzTests           Specify if zUnit Tests should be run
  
- -cc,--ccczUnit           Flag to indicate to collect code coverage reports during zUnit step
- -cch,--cccHost           Headless Code Coverage Collector host (if not specified IDz will be used for reporting)
- -ccp,--cccPort           Headless Code Coverage Collector port (if not specified IDz will be used for reporting)
- -cco,--cccOptions        Headless Code Coverage Collector Options
+ -cc,--ccczUnit               Flag to indicate to collect code coverage reports during zUnit step
+ -cch,--cccHost               Headless Code Coverage Collector host (if not specified IDz will be used for reporting)
+ -ccp,--cccPort               Headless Code Coverage Collector port (if not specified IDz will be used for reporting)
+ -cco,--cccOptions            Headless Code Coverage Collector Options
+
+ -re,--reportExternalImpacts  Flag to activate analysis and report of external impacted files within DBB collections
  
 
 web application credentials
- -url,--url <arg>         DBB repository URL
- -id,--id <arg>           DBB repository id
- -pw,--pw <arg>           DBB repository password
- -pf,--pwFile <arg>       Absolute or relative (from workspace) path to
-                          file containing DBB password
+ -url,--url <arg>             DBB repository URL
+ -id,--id <arg>               DBB repository id
+ -pw,--pw <arg>               DBB repository password
+ -pf,--pwFile <arg>           Absolute or relative (from workspace) path to
+                              file containing DBB password
 
 IDz/ZOD User Build options
- -u,--userBuild           Flag indicating running a user build
- -e,--errPrefix <arg>     Unique id used for IDz error message datasets
+ -u,--userBuild               Flag indicating running a user build
+ -e,--errPrefix <arg>         Unique id used for IDz error message datasets
 
 utility options
- -help,--help             Prints this message
+ -help,--help                 Prints this message
  ```

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -55,7 +55,7 @@ Propertes used by the impact utilities to generate a report of external impacted
 
 --- | ---
 reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and report external impacted files in other collections ***Can be overridden by build.groovy option -re, --reportExternalImpacts***
-reportExternalImpactsAnaylsisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep) *** Can be overridden by application-conf *** 
+reportExternalImpactsAnalysisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep) *** Can be overridden by application-conf *** 
 reportExternalImpactsAnalysisFileFilter | Comma-separated list of pathMatcher filters to limit the analysis of external impacts to a subset of the changed files *** Can be overridden by application-conf *** 
 reportExternalImpactsCollectionPatterns | comma-separated list of regex patterns of DBB collection names for which external impacts should be documented *** Can be overridden by application-conf *** 
 

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -48,6 +48,14 @@ dbb.RepositoryClient.userId | DBB configuration property for web application log
 dbb.RepositoryClient.password | DBB configuration property for web application logon password.  ***Can be overridden by build.groovy option -pw, --pw***
 dbb.RepositoryClient.passwordFile | DBB configuration property for web application logon password file.  ***Can be overridden by build.groovy option -pf, --pf***
 
+### dependencyReport.properties
+Propertes used by the impact utilities to generate a report of external impacted files
+
+--- | ---
+reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and report external impacted files in other collections ***Can be overridden by build.groovy option -re, --reportExternalImpacts***
+reportExternalImpactsAnaylsisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep) *** Can be overridden by application-conf *** 
+reportExternalImpactsAnalysisFileFilter | Comma-separated list of pathMatcher filters to limit the analysis of external impacts to a subset of the changed files *** Can be overridden by application-conf *** 
+reportExternalImpactsCollectionPatterns | comma-separated list of regex patterns of DBB collection names for which external impacts should be documented *** Can be overridden by application-conf *** 
 
 ### Assembler.properties
 Build properties used by zAppBuild/language/Assembler.groovy

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -51,7 +51,7 @@ dbb.RepositoryClient.password | DBB configuration property for web application l
 dbb.RepositoryClient.passwordFile | DBB configuration property for web application logon password file.  ***Can be overridden by build.groovy option -pf, --pf***
 
 ### dependencyReport.properties
-Propertes used by the impact utilities to generate a report of external impacted files
+Properties used by the impact utilities to generate a report of external impacted files
 
 --- | ---
 reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and report external impacted files in other collections ***Can be overridden by build.groovy option -re, --reportExternalImpacts***

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -57,7 +57,7 @@ Properties used by the impact utilities to generate a report of external impacte
 reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and report external impacted files in other collections ***Can be overridden by build.groovy option -re, --reportExternalImpacts***
 reportExternalImpactsAnalysisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep) *** Can be overridden by application-conf *** 
 reportExternalImpactsAnalysisFileFilter | Comma-separated list of pathMatcher filters to limit the analysis of external impacts to a subset of the changed files *** Can be overridden by application-conf *** 
-reportExternalImpactsCollectionPatterns | comma-separated list of regex patterns of DBB collection names for which external impacts should be documented *** Can be overridden by application-conf *** 
+reportExternalImpactsCollectionPatterns | Comma-separated list of regex patterns of DBB collection names for which external impacts should be documented *** Can be overridden by application-conf *** 
 
 ### Assembler.properties
 Build properties used by zAppBuild/language/Assembler.groovy

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of additional build property files to load
 # Supports both relative path (to zAppBuild/build-conf/) and absolute path
-buildPropFiles=datasets.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,ZunitConfig.properties
+buildPropFiles=datasets.properties,dependencyReport.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,ZunitConfig.properties
 
 #
 # file extension that indicates the build file is really a build list or build list filter
@@ -114,7 +114,4 @@ dbb.gateway.regionSize=
 # 8 - Log time information
 # 16 - Log information to the system console
 dbb.gateway.logLevel=2
-
-
-
 

--- a/build-conf/dependencyReport.properties
+++ b/build-conf/dependencyReport.properties
@@ -1,0 +1,28 @@
+# Build properties to configure analysis and reporting of external dependencies
+
+#
+# Flag to indicate if an *impactBuild* should analyze and report external impacted files
+# in other collections 
+# 
+# For further configuration see reportExternalImpacts* properties
+# 
+# Default: false
+reportExternalImpacts=false
+
+#
+# AnalysisDepths when performing impact analysis for external impacts
+# Options: simple | deep
+#  simple will not allow recursion and only find files which have a direct dependency to the changed file 
+#  deep   will recursively resolve impacts, which is more expensive compared to simple mode
+reportExternalImpactsAnalysisDepths=simple
+
+# comma-separated list of pathMatcher filters to limit the analysis
+# of external impacts to a subset of the changed files 
+#  Default setting: excludeFileList=**/* (all)
+#  sample only files with file extension cpy: reportExternalImpactsAnalysisFilter=**/*.cpy
+reportExternalImpactsAnalysisFileFilter=**/*
+
+#
+# comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
+# Uses regex patterns sample: collectionPatternsReportExternalImpacts=.*-dev.* --> all collections which contain "-dev"
+reportExternalImpactsCollectionPatterns=.*-master.*

--- a/build.groovy
+++ b/build.groovy
@@ -197,7 +197,9 @@ options:
 	cli.ccp(longOpt:'cccPort', args:1, argName:'cccPort', 'Headless Code Coverage Collector port (if not specified IDz will be used for reporting)')
 	cli.cco(longOpt:'cccOptions', args:1, argName:'cccOptions', 'Headless Code Coverage Collector Options')
 
-
+	// build framework options
+	cli.re(longOpt:'reportExternalImpacts', 'Flag to activate analysis and report of external impacted files within DBB collections')
+	
 	// utility options
 	cli.help(longOpt:'help', 'Prints this message')
 
@@ -334,6 +336,9 @@ def populateBuildProperties(String[] args) {
 			props.codeCoverageOptions = opts.cco
 		}
 	}
+	
+	// set buildframe options
+	if (opts.re) props.reportExternalImpacts = 'true'
 
 	// set DBB configuration properties
 	if (opts.url) props.'dbb.RepositoryClient.url' = opts.url

--- a/build.groovy
+++ b/build.groovy
@@ -369,13 +369,16 @@ def populateBuildProperties(String[] args) {
 	props.applicationCollectionName = ((props.applicationCurrentBranch) ? "${props.application}-${props.applicationCurrentBranch}" : "${props.application}") as String
 	props.applicationOutputsCollectionName = "${props.applicationCollectionName}-outputs" as String
 
-
 	if (props.userBuild) {	// do not create a subfolder for user builds
 		props.buildOutDir = "${props.outDir}" as String }
 	else {// validate createBuildOutputSubfolder build property
 		props.buildOutDir = ((props.createBuildOutputSubfolder && props.createBuildOutputSubfolder.toBoolean()) ? "${props.outDir}/${props.applicationBuildLabel}" : "${props.outDir}") as String
 	}
 	
+	// Validate Build Properties  
+	if(props.reportExternalImpactsAnalysisDepths) assert (props.reportExternalImpactsAnalysisDepths == 'simple' || props.reportExternalImpactsAnalysisDepths == 'deep' ) : "*! Build Property props.reportExternalImpactsAnalysisDepths has an invalid value"
+		
+	// Print all build properties + some envionment variables 
 	if (props.verbose) {
 		println("java.version="+System.getProperty("java.runtime.version"))
 		println("java.home="+System.getProperty("java.home"))

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -32,7 +32,7 @@ skipImpactCalculationList=
 #
 # comma-separated list of DBB collection name patterns for which external impacts should be documebted
 # Uses glob file patterns sample: skipImpactCalculationList=**/epsmtout.cpy,**/centralCopybooks/*.cpy
-collectionPatternsReportExternalImpacts=*-dev*
+collectionPatternsReportExternalImpacts=.*-dev.*
 
 #
 # Impact analysis resolution rules (JSON format)

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -30,8 +30,15 @@ excludeFileList=.*,**/*.properties,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/app
 skipImpactCalculationList=
 
 #
-# comma-separated list of DBB collection name patterns for which external impacts should be documebted
-# Uses glob file patterns sample: skipImpactCalculationList=**/epsmtout.cpy,**/centralCopybooks/*.cpy
+# Boolean value to indicate if an *impactBuild* should analyze external impacts
+# in other collections and produce a report, which can be used as a build list.
+# See also props.collectionPatternsReportExternalImpacts
+# default: false
+reportExternalImpacts=true
+
+#
+# comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
+# Uses regex patterns sample: collectionPatternsReportExternalImpacts=.*-dev.* --> all collections which contain "-dev"
 collectionPatternsReportExternalImpacts=.*-dev.*
 
 #

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -30,6 +30,11 @@ excludeFileList=.*,**/*.properties,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/app
 skipImpactCalculationList=
 
 #
+# comma-separated list of DBB collection name patterns for which external impacts should be documebted
+# Uses glob file patterns sample: skipImpactCalculationList=**/epsmtout.cpy,**/centralCopybooks/*.cpy
+collectionPatternsReportExternalImpacts=*-dev*
+
+#
 # Impact analysis resolution rules (JSON format)
 impactResolutionRules=[${copybookRule},${bmsRule},${linkRule}]
 

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -30,18 +30,6 @@ excludeFileList=.*,**/*.properties,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/app
 skipImpactCalculationList=
 
 #
-# Boolean value to indicate if an *impactBuild* should analyze external impacts
-# in other collections and produce a report, which can be used as a build list.
-# See also props.collectionPatternsReportExternalImpacts
-# default: false
-reportExternalImpacts=true
-
-#
-# comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
-# Uses regex patterns sample: collectionPatternsReportExternalImpacts=.*-dev.* --> all collections which contain "-dev"
-collectionPatternsReportExternalImpacts=.*-dev.*
-
-#
 # Impact analysis resolution rules (JSON format)
 impactResolutionRules=[${copybookRule},${bmsRule},${linkRule},${propertyRule}]
 

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -37,6 +37,16 @@ isMQ | File property overwrite to indicate that a file requires to include MQ pa
 isDLI | File property overwrite to indicate that a file requires to include DLI parameters
 cobol_testcase | File property to indicate a generated zUnit cobol test case to use a different set of source and output libraries
 
+### dependencyReport.properties
+Properties used by the impact utilities to generate a report of external impacted files. Sample properties file to all application-conf to overwrite central build-conf configuration.
+
+--- | ---
+reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and report external impacted files in other collections 
+reportExternalImpactsAnalysisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep) 
+reportExternalImpactsAnalysisFileFilter | Comma-separated list of pathMatcher filters to limit the analysis of external impacts to a subset of the changed files 
+reportExternalImpactsCollectionPatterns | Comma-separated list of regex patterns of DBB collection names for which external impacts should be documented 
+
+
 ### Assembler.properties
 Application properties used by zAppBuild/language/Assembler.groovy
 

--- a/samples/application-conf/dependencyReport.properties
+++ b/samples/application-conf/dependencyReport.properties
@@ -1,4 +1,5 @@
-# Build properties to configure analysis and reporting of external dependencies
+# Application properties to configure analysis and reporting of external dependencies
+# Sample to override the configuration  
 
 #
 # Flag to indicate if an *impactBuild* should analyze and report external impacted files
@@ -7,22 +8,22 @@
 # For further configuration see reportExternalImpacts* properties
 # 
 # Default: false
-reportExternalImpacts=false
+# reportExternalImpacts=false
 
 #
 # AnalysisDepths when performing impact analysis for external impacts
 # Options: simple | deep
 #  simple will not allow recursion and only find files which have a direct dependency to the changed file 
 #  deep   will recursively resolve impacts, which is more expensive compared to simple mode
-reportExternalImpactsAnalysisDepths=simple
+# reportExternalImpactsAnalysisDepths=simple
 
 # comma-separated list of pathMatcher filters to limit the analysis
 # of external impacts to a subset of the changed files 
 #  Default setting: excludeFileList=**/* (all)
 #  sample only files with file extension cpy: reportExternalImpactsAnalysisFilter=**/*.cpy
-reportExternalImpactsAnalysisFileFilter=**/*
+# reportExternalImpactsAnalysisFileFilter=**/*
 
 #
 # comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
 # Uses regex patterns sample: collectionPatternsReportExternalImpacts=.*-dev.* --> all collections which contain "-dev"
-reportExternalImpactsCollectionPatterns=.*-master.*
+# reportExternalImpactsCollectionPatterns=.*-master.*

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -97,7 +97,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			repositoryClient.getAllCollections().each{ collection ->
 				def Set<String> externalImpactedFiles = new HashSet<String>()
 				if (collection != props.applicationCollectionName){
-					externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
+					def externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
 					externalImpactedFiles.each{ externalImpact ->
 						def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t $collection}"
 						println(impactRecord);

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -285,7 +285,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		def externalImpactedFiles = impactResolver.resolve()
 		
 		// report scanning results
-		if (externalImpactedFiles.size()!=0) if (props.verbose) println("*** Identified impacts for changed file $changedFile")
+		if (externalImpactedFiles.size()!=0) if (props.verbose) println("*** Identified external impacted files for changed file $changedFile")
 		externalImpactedFiles.each{ externalImpact ->
 			def Set<String> externalImpactList = collectionImpactsSetMap.get(externalImpact.getCollection()) ?: new HashSet<String>()
 			def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t ${externalImpact.getCollection()}"
@@ -301,7 +301,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		if (externalImpactList.size()!=0){
 			// write impactedFiles per application to build workspace
 			String impactListFileLoc = "${props.buildOutDir}/externalImpacts_${entry.key}.${props.buildListFileExt}"
-			if (props.verbose) println("** Writing external impacts to file $impactListFileLoc")
+			if (props.verbose) println("*** Writing report of external impacts to file $impactListFileLoc")
 			File impactListFile = new File(impactListFileLoc)
 			String enc = props.logEncoding ?: 'IBM-1047'
 			impactListFile.withWriter(enc) { writer ->

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -263,7 +263,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		String memberName = CopyToPDS.createMemberName(changedFile)
 		
 		// build resolver
-		ImpactResolver impactResolver = new ImpactResolver().file(changedFile).repositoryClient(repositoryClient).setResolutionRules(buildUtils.parseResolutionRules(props.impactResolutionRules))
+		ImpactResolver impactResolver = new ImpactResolver().file(changedFile).repositoryClient(repositoryClient)
 		
 		List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
 		repositoryClient.getAllCollections().each{ collection ->
@@ -277,6 +277,9 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 				if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
 			}
 		}
+		
+		impactResolver.setResolutionRules(buildUtils.parseResolutionRules(props.impactResolutionRules))
+		
 		// resolve
 		
 		impactResolver.getCollections().each{println "$it"}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -269,12 +269,12 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 			String cName = collection.getName()
 			if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
 				if (cName != props.applicationCollectionName && cName != props.applicationOutputsCollectionName){
-					def logicalFiles = repositoryClient.getAllLogicalFiles(collection.getName(), ldepFile);
+					def logicalFiles = repositoryClient.getAllLogicalFiles(cName, ldepFile);
 					logicalFiles.each{ logicalFile ->
-						def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${logicalFile.getCollection()}"
+						def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"
 						// if (props.verbose) println("*** $impactRecord")
 						externalImpactList.add(impactRecord)
-						collectionImpactsSetMap.put(collection.getName(), externalImpactList) // <collection,list of impacted files>
+						collectionImpactsSetMap.put(cName, externalImpactList) // <collection,list of impacted files>
 					}
 				}
 			}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -263,7 +263,8 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		String memberName = CopyToPDS.createMemberName(changedFile)
 		
 		// build resolver
-		ImpactResolver impactResolver = new ImpactResolver().file(changedFile)
+		ImpactResolver impactResolver = new ImpactResolver().file(changedFile).repositoryClient(repositoryClient)
+		
 		List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
 		repositoryClient.getAllCollections().each{ collection ->
 			String cName = collection.getName()
@@ -277,6 +278,9 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 			}
 		}
 		// resolve
+		
+		println impactResolver
+		
 		externalImpactedFiles = impactResolver.resolve()
 		
 		// report scanning results

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -262,7 +262,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 	// caluclated and collect external impacts
 	changedFiles.each{ changedFile ->
 
-		List<PathMatcher> fileMatchers = createPathMatcherPattern(props.reportExternalImpactsAnalysisFilter)
+		List<PathMatcher> fileMatchers = createPathMatcherPattern(props.reportExternalImpactsAnalysisFileFilter)
 		
 		if(matches(changedFile, fileMatchers)){
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -257,16 +257,6 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 
 	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>()
 
-
-	ImpactResolver resolver = new ImpactResolver().file(changedFile)
-			.collection(props.applicationCollectionName)
-			.collection(props.applicationOutputsCollectionName)
-			.repositoryClient(repositoryClient)
-	// add resolution rules
-	if (rules)
-		resolver.setResolutionRules(buildUtils.parseResolutionRules(rules))
-
-
 	// caluclated and collect external impacts
 	changedFiles.each{ changedFile ->
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -150,7 +150,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 
 	// Perform analysis and build report of external impacts
 	if (props.reportExternalImpacts && props.reportExternalImpacts.toBoolean()){
-		if (props.verbose) println "** Analyze and report external impacted files."
+		if (props.verbose) println "*** Analyze and report external impacted files."
 		reportExternalImpacts(repositoryClient, changedFiles)
 	}
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -270,7 +270,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 			String cName = collection.getName()
 			if(matchesPattern(cName,collectionMatcherPatterns)){
 				if (cName != props.applicationCollectionName){
-					if (props.verbose) println("** Adding $cName to analysis of external impacts")
+					//if (props.verbose) println("** Adding $cName to analysis of external impacts")
 					impactResolver.addCollection(cName)
 				}
 			}
@@ -283,19 +283,18 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		
 		// resolve
 		def externalImpactedFiles = impactResolver.resolve()
-		println externalImpactedFiles.size()
 		// report scanning results
+		if (externalImpactedFiles.size()!=0) if (props.verbose) println("*** Identified following external impacts for $changedFile")
 		externalImpactedFiles.each{ externalImpact ->
 			def Set<String> externalImpactList = collectionImpactsSetMap.get(externalImpact.getCollection()) ?: new HashSet<String>()
 			def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t ${externalImpact.getCollection()}"
-			if (props.verbose) println("** Identified following external impacts : $impactRecord")
+			if (props.verbose) println("*** $impactRecord")
 			externalImpactList.add(impactRecord)
 			
 			collectionImpactsSetMap.put(externalImpact.getCollection(), externalImpactList)
 		}
 	}
 
-	println collectionImpactsSetMap
 
 	// print external impacts output found external impacts
 	collectionImpactsSetMap.each{ entry ->
@@ -303,6 +302,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		if (externalImpactList.size()!=0){
 			// write impactedFiles per application
 			String impactListFileLoc = "${props.buildOutDir}/externalImpacts_${entry.key}.${props.buildListFileExt}"
+			if (props.verbose) println("** Writing external impacts to file $impactListFileLoc")
 			File impactListFile = new File(impactListFileLoc)
 			String enc = props.logEncoding ?: 'IBM-1047'
 			impactListFile.withWriter(enc) { writer ->

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -99,7 +99,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 				if (collection != props.applicationCollectionName){
 					externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
 					externalImpactedFiles.each{ externalImpact ->
-						def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t ${externalImpact.getCollection()}"
+						def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t $collection}"
 						println(impactRecord);
 						externalImpactedFiles.add(impactRecord)
 					}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -263,7 +263,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		String memberName = CopyToPDS.createMemberName(changedFile)
 		
 		// build resolver
-		ImpactResolver impactResolver = new ImpactResolver().file(changedFile).repositoryClient(repositoryClient).setResolutionRules(buildUtils.parseResolutionRules(props.impactResolutionRules)
+		ImpactResolver impactResolver = new ImpactResolver().file(changedFile).repositoryClient(repositoryClient).setResolutionRules(buildUtils.parseResolutionRules(props.impactResolutionRules))
 		
 		List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
 		repositoryClient.getAllCollections().each{ collection ->

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -266,7 +266,9 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 			if(matchesPattern(cName,collectionMatcherPatterns)){
 				def Set<String> externalImpactList = collectionImpactsSetMap.get(cName) ?: new HashSet<String>()
 				if (cName != props.applicationCollectionName){
-					externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
+					ImpactResolver impactResolver = createImpactResolver(changedFile, impactResolutionRules, repositoryClient)
+					//externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
+					externalImpactedFiles = impactResolver.resolve()
 					externalImpactedFiles.each{ externalImpact ->
 						def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t $cName"
 						println(impactRecord);
@@ -276,7 +278,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 				}
 			}
 			else{
-				println("$cName does not match pattern: $collectionMatcherPatterns")
+				if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
 			}
 		}
 	}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -99,7 +99,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			repositoryClient.getAllCollections().each{ collection ->
 				def Set<String> externalImpactList = new HashSet<String>()
 				String cName = collection.getName()
-				if(createMatcherPatterns(cName,collectionMatcherPatterns)){
+				if(matchesCollectionPattern(cName,collectionMatcherPatterns)){
 					if (cName != props.applicationCollectionName){
 						externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
 						externalImpactedFiles.each{ externalImpact ->

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -263,7 +263,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		String memberName = CopyToPDS.createMemberName(changedFile)
 		
 		// build resolver
-		ImpactResolver impactResolver = new ImpactResolver().file(changedFile).repositoryClient(repositoryClient)
+		ImpactResolver impactResolver = new ImpactResolver().file(changedFile).repositoryClient(repositoryClient).setResolutionRules(buildUtils.parseResolutionRules(props.impactResolutionRules)
 		
 		List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
 		repositoryClient.getAllCollections().each{ collection ->

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -263,13 +263,13 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		String memberName = CopyToPDS.createMemberName(changedFile)
 		
 		// build resolver
-		ImpactResolver resolver = new ImpactResolver().file(changedFile)
+		ImpactResolver impactResolver = new ImpactResolver().file(changedFile)
 		List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
 		repositoryClient.getAllCollections().each{ collection ->
 			String cName = collection.getName()
 			if(matchesPattern(cName,collectionMatcherPatterns)){
 				if (cName != props.applicationCollectionName){
-					resolver.addCollection(cName)
+					impactResolver.addCollection(cName)
 				}
 			}
 			else{

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -7,6 +7,7 @@ import java.nio.file.Path
 import java.nio.file.PathMatcher
 import groovy.json.JsonSlurper
 import groovy.transform.*
+import java.util.regex.*
 
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -100,7 +100,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 
 	if (props.reportExternalImpacts && props.reportExternalImpacts.toBoolean()){
 		if (props.verbose) println "** Create reports of external impacts."
-		reportExternalImpacts(changedFiles)
+		reportExternalImpacts(repositoryClient, changedFiles)
 	}
 
 
@@ -252,7 +252,7 @@ def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient
  * 
  */
 
-def reportExternalImpacts(Set<String> changedFiles){
+def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changedFiles){
 	// query external collections to produce externalImpactList
 
 	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>()

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -270,28 +270,27 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 			String cName = collection.getName()
 			if(matchesPattern(cName,collectionMatcherPatterns)){
 				if (cName != props.applicationCollectionName){
+					if (props.verbose) println("** Adding $cName to analysis of external impacts")
 					impactResolver.addCollection(cName)
 				}
 			}
 			else{
-				if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
+				//if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
 			}
 		}
 		
 		impactResolver.setResolutionRules(buildUtils.parseResolutionRules(props.impactResolutionRules))
 		
 		// resolve
-		
-		impactResolver.getCollections().each{println "$it"}
-		
 		def externalImpactedFiles = impactResolver.resolve()
 		println externalImpactedFiles.size()
 		// report scanning results
 		externalImpactedFiles.each{ externalImpact ->
 			def Set<String> externalImpactList = collectionImpactsSetMap.get(externalImpact.getCollection()) ?: new HashSet<String>()
 			def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t ${externalImpact.getCollection()}"
-			println(impactRecord);
+			if (props.verbose) println("** Identified following external impacts : $impactRecord")
 			externalImpactList.add(impactRecord)
+			
 			collectionImpactsSetMap.put(externalImpact.getCollection(), externalImpactList)
 		}
 	}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -328,7 +328,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 			}
 		}
 		else {
-			if (props.verbose) println("*** Analysis and reporting has been skipped for changed file $changedFile due to build framework configuration (build property reportExternalImpactsAnalysisFilter)")
+			if (props.verbose) println("*** Analysis and reporting has been skipped for changed file $changedFile due to build framework configuration (see configuration of build property reportExternalImpactsAnalysisFileFilter)")
 		}
 	}
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -262,8 +262,8 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		String memberName = CopyToPDS.createMemberName(changedFile)
 		List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
 		repositoryClient.getAllCollections().each{ collection ->
+			String cName = collection.getName()
 			if(matchesPattern(cName,collectionMatcherPatterns)){
-				String cName = collection.getName()
 				def Set<String> externalImpactList = collectionImpactsSetMap.get(cName) ?: new HashSet<String>()
 				if (cName != props.applicationCollectionName){
 					externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -95,23 +95,23 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			// query external collections to produce externalImpactList
 			String memberName = CopyToPDS.createMemberName(changedFile)
 			repositoryClient.getAllCollections().each{ collection ->
-				def Set<String> externalImpactedFiles = new HashSet<String>()
+				def Set<String> externalImpactList = new HashSet<String>()
 				if (collection != props.applicationCollectionName){
-					def externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
+					externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
 					externalImpactedFiles.each{ externalImpact ->
 						def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t $collection}"
 						println(impactRecord);
-						externalImpactedFiles.add(impactRecord)
+						externalImpactList.add(impactRecord)
 					}
 				}
 				// output found external impacts
-				if (externalImpactedFiles.size()!=0){
+				if (externalImpactList.size()!=0){
 					// write impactedFiles per application
 					String impactListFileLoc = "${props.buildOutDir}/externalImpacts_${collection}.${props.buildListFileExt}"
 					File impactListFile = new File(impactListFileLoc)
 					String enc = props.logEncoding ?: 'IBM-1047'
 					impactListFile.withWriter(enc) { writer ->
-						externalImpactedFiles.each { file ->
+						externalImpactList.each { file ->
 							if (props.verbose) println file
 							writer.write("$file\n")
 						}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -269,7 +269,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 			String cName = collection.getName()
 			if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
 				if (cName != props.applicationCollectionName && cName != props.applicationOutputsCollectionName){
-					def Set<String> externalImpactList = collectionImpactsSetMap.get(externalImpact.getCollection()) ?: new HashSet<String>()
+					def Set<String> externalImpactList = collectionImpactsSetMap.get(cName) ?: new HashSet<String>()
 					def logicalFiles = repositoryClient.getAllLogicalFiles(cName, ldepFile);
 					logicalFiles.each{ logicalFile ->
 						def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -255,7 +255,7 @@ def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient
 def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changedFiles){
 	// query external collections to produce externalImpactList
 
-	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>()
+	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>() // <collection><List impactRecords> 
 
 	// caluclated and collect external impacts
 	changedFiles.each{ changedFile ->
@@ -269,13 +269,14 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 			String cName = collection.getName()
 			if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
 				if (cName != props.applicationCollectionName && cName != props.applicationOutputsCollectionName){
+					def Set<String> externalImpactList = collectionImpactsSetMap.get(externalImpact.getCollection()) ?: new HashSet<String>()
 					def logicalFiles = repositoryClient.getAllLogicalFiles(cName, ldepFile);
 					logicalFiles.each{ logicalFile ->
 						def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"
 						// if (props.verbose) println("*** $impactRecord")
 						externalImpactList.add(impactRecord)
-						collectionImpactsSetMap.put(cName, externalImpactList) // <collection,list of impacted files>
 					}
+					collectionImpactsSetMap.put(cName, externalImpactList)
 				}
 			}
 			else{

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -279,10 +279,10 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		}
 		// resolve
 		
-		println impactResolver
+		impactResolver.getCollections().each{println "$it"}
 		
-		externalImpactedFiles = impactResolver.resolve()
-		
+		def externalImpactedFiles = impactResolver.resolve()
+		println externalImpactedFiles.size()
 		// report scanning results
 		externalImpactedFiles.each{ externalImpact ->
 			def Set<String> externalImpactList = collectionImpactsSetMap.get(externalImpact.getCollection()) ?: new HashSet<String>()

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -680,7 +680,6 @@ def createPathMatcherPattern(String property) {
 }
 
 /**
-<<<<<<< HEAD
  * create List of Regex Patterns
  */
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -266,7 +266,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 		
 		if(matches(changedFile, fileMatchers)){
 
-			if (props.reportExternalImpactsAnaylsisDepths == "simple"){
+			if (props.reportExternalImpactsAnalysisDepths == "simple"){
 				// Simple resolution without recursive resolution
 				String memberName = CopyToPDS.createMemberName(changedFile)
 
@@ -290,7 +290,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 					}
 				}
 			}
-			else if(props.reportExternalImpactsAnaylsisDepths == "deep"){
+			else if(props.reportExternalImpactsAnalysisDepths == "deep"){
 				// Recursive analysis to support nested scenarios
 
 				// Configure impact resolver
@@ -324,7 +324,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 				}
 			}
 			else {
-				println("*! props.reportExternalImpactsAnaylsisDepths has in invalid value. Set: ${props.reportExternalImpactsAnaylsisDepths} , Valid: simple | deep")
+				println("*! build property reportExternalImpactsAnalysisDepths has in invalid value : ${props.reportExternalImpactsAnaylsisDepths} , valid: simple | deep")
 			}
 		}
 		else {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -549,6 +549,7 @@ def createMatcherPatterns(String property) {
 	if (property) {
 		property.split(',').each{ patternString ->
 			Pattern pattern = Pattern.compile(patternString);
+			patterns.add(pattern)
 		}
 	}
 	return patterns

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -96,10 +96,11 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			String memberName = CopyToPDS.createMemberName(changedFile)
 			repositoryClient.getAllCollections().each{ collection ->
 				def Set<String> externalImpactList = new HashSet<String>()
-				if (collection != props.applicationCollectionName){
+				String cName = collection.getName()
+				if (cName != props.applicationCollectionName){
 					externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
 					externalImpactedFiles.each{ externalImpact ->
-						def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t $collection}"
+						def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t $cName}"
 						println(impactRecord);
 						externalImpactList.add(impactRecord)
 					}
@@ -107,7 +108,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 				// output found external impacts
 				if (externalImpactList.size()!=0){
 					// write impactedFiles per application
-					String impactListFileLoc = "${props.buildOutDir}/externalImpacts_${collection}.${props.buildListFileExt}"
+					String impactListFileLoc = "${props.buildOutDir}/externalImpacts_${cName}.${props.buildListFileExt}"
 					File impactListFile = new File(impactListFileLoc)
 					String enc = props.logEncoding ?: 'IBM-1047'
 					impactListFile.withWriter(enc) { writer ->

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -95,12 +95,13 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			// query external collections to produce externalImpactList
 			String memberName = CopyToPDS.createMemberName(changedFile)
 			repositoryClient.getAllCollections().each{ collection ->
-				Set<String> externalImpactedFiles = new HashSet<String>()
+				def Set<String> externalImpactedFiles = new HashSet<String>()
 				if (collection != props.applicationCollectionName){
 					externalImpactedFiles = repositoryClient.getAllLogicalFiles(collection.getName(),memberName)
 					externalImpactedFiles.each{ externalImpact ->
-						println("\t${externalImpact.getLname()}");
-						externalImpactedFiles.add(externalImpact.getLname())
+						def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t ${externalImpact.getCollection()}"
+						println(impactRecord);
+						externalImpactedFiles.add(impactRecord)
 					}
 				}
 				// output found external impacts

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -260,7 +260,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 	// caluclated and collect external impacts
 	changedFiles.each{ changedFile ->
 
-		if (props.reportExternalImpactsAnaylsisDepths == "simple"){ 	
+		if (props.reportExternalImpactsAnaylsisDepths == "simple"){
 			// Simple resolution without recursive resolution
 			String memberName = CopyToPDS.createMemberName(changedFile)
 
@@ -319,9 +319,9 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 				collectionImpactsSetMap.put(externalImpact.getCollection(), externalImpactList) // <collection,list of impacted files>
 			}
 		}
-	}
-	else {
-		println("*! props.reportExternalImpactsAnaylsisDepths has in invalid value. Set: ${props.reportExternalImpactsAnaylsisDepths} , Valid: simple | deep")
+		else {
+			println("*! props.reportExternalImpactsAnaylsisDepths has in invalid value. Set: ${props.reportExternalImpactsAnaylsisDepths} , Valid: simple | deep")
+		}
 	}
 	
 	// generate reports by collection / application

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -255,69 +255,75 @@ def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient
 def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changedFiles){
 	// query external collections to produce externalImpactList
 
-	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>() // <collection><List impactRecords> 
+	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>() // <collection><List impactRecords>
 
 	// caluclated and collect external impacts
 	changedFiles.each{ changedFile ->
 
-		String memberName = CopyToPDS.createMemberName(changedFile)
+		if (props.reportExternalImpactsAnaylsisDepths == "simple"){ 	
+			// Simple resolution without recursive resolution
+			String memberName = CopyToPDS.createMemberName(changedFile)
 
-		// Simple resolution without recursive resolution
-		def ldepFile = new LogicalDependency(memberName, null, null);
-		List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
-		repositoryClient.getAllCollections().each{ collection ->
-			String cName = collection.getName()
-			if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
-				if (cName != props.applicationCollectionName && cName != props.applicationOutputsCollectionName){
-					def Set<String> externalImpactList = collectionImpactsSetMap.get(cName) ?: new HashSet<String>()
-					def logicalFiles = repositoryClient.getAllLogicalFiles(cName, ldepFile);
-					logicalFiles.each{ logicalFile ->
-						def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"
-						// if (props.verbose) println("*** $impactRecord")
-						externalImpactList.add(impactRecord)
+			def ldepFile = new LogicalDependency(memberName, null, null);
+			List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
+			repositoryClient.getAllCollections().each{ collection ->
+				String cName = collection.getName()
+				if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
+					if (cName != props.applicationCollectionName && cName != props.applicationOutputsCollectionName){
+						def Set<String> externalImpactList = collectionImpactsSetMap.get(cName) ?: new HashSet<String>()
+						def logicalFiles = repositoryClient.getAllLogicalFiles(cName, ldepFile);
+						logicalFiles.each{ logicalFile ->
+							def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"
+							// if (props.verbose) println("*** $impactRecord")
+							externalImpactList.add(impactRecord)
+						}
+						collectionImpactsSetMap.put(cName, externalImpactList)
 					}
-					collectionImpactsSetMap.put(cName, externalImpactList)
+				}
+				else{
+					//if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
 				}
 			}
-			else{
-				//if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
+		}
+		else if(props.reportExternalImpactsAnaylsisDepths == "deep"){
+			// Recursive analysis to support nested scenarios
+
+			// Configure impact resolver
+			ImpactResolver impactResolver = new ImpactResolver().file(changedFile).repositoryClient(repositoryClient)
+
+			String impactResolutionRules = props.getFileProperty('impactResolutionRules', changedFile)
+			impactResolver.setResolutionRules(buildUtils.parseResolutionRules(impactResolutionRules))
+
+			List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
+			repositoryClient.getAllCollections().each{ collection ->
+				String cName = collection.getName()
+				if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
+					if (cName != props.applicationCollectionName && cName != props.applicationOutputsCollectionName){
+						impactResolver.addCollection(cName) // add collection of foreign application
+					}
+				}
+				else{
+					//if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
+				}
+			}
+			// resolve external impacted files
+			def externalImpactedFiles = impactResolver.resolve()
+
+			// report scanning results
+			if (externalImpactedFiles.size()!=0) if (props.verbose) println("*** Identified external impacted files for changed file $changedFile")
+			externalImpactedFiles.each{ externalImpact ->
+				def Set<String> externalImpactList = collectionImpactsSetMap.get(externalImpact.getCollection()) ?: new HashSet<String>()
+				def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t ${externalImpact.getCollection()}"
+				// if (props.verbose) println("*** $impactRecord")
+				externalImpactList.add(impactRecord)
+				collectionImpactsSetMap.put(externalImpact.getCollection(), externalImpactList) // <collection,list of impacted files>
 			}
 		}
-
-		// Leverage: ImpactResolver for recursive analysis
-
-		//		// Configure impact resolver
-		//		ImpactResolver impactResolver = new ImpactResolver().file(changedFile).repositoryClient(repositoryClient)
-		//
-		//		String impactResolutionRules = props.getFileProperty('impactResolutionRules', changedFile)
-		//		impactResolver.setResolutionRules(buildUtils.parseResolutionRules(impactResolutionRules))
-		//
-		//		List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.collectionPatternsReportExternalImpacts)
-		//		repositoryClient.getAllCollections().each{ collection ->
-		//			String cName = collection.getName()
-		//			if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
-		//				if (cName != props.applicationCollectionName && cName != props.applicationOutputsCollectionName){
-		//					impactResolver.addCollection(cName) // add collection of foreign application
-		//				}
-		//			}
-		//			else{
-		//				//if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
-		//			}
-		//		}
-		//		// resolve external impacted files
-		//		def externalImpactedFiles = impactResolver.resolve()
-		//
-		//		// report scanning results
-		//		if (externalImpactedFiles.size()!=0) if (props.verbose) println("*** Identified external impacted files for changed file $changedFile")
-		//		externalImpactedFiles.each{ externalImpact ->
-		//			def Set<String> externalImpactList = collectionImpactsSetMap.get(externalImpact.getCollection()) ?: new HashSet<String>()
-		//			def impactRecord = "${externalImpact.getLname()} \t ${externalImpact.getFile()} \t ${externalImpact.getCollection()}"
-		//			// if (props.verbose) println("*** $impactRecord")
-		//			externalImpactList.add(impactRecord)
-		//			collectionImpactsSetMap.put(externalImpact.getCollection(), externalImpactList) // <collection,list of impacted files>
-		//		}
 	}
-
+	else {
+		println("*! props.reportExternalImpactsAnaylsisDepths has in invalid value. Set: ${props.reportExternalImpactsAnaylsisDepths} , Valid: simple | deep")
+	}
+	
 	// generate reports by collection / application
 	collectionImpactsSetMap.each{ entry ->
 		externalImpactList = entry.value


### PR DESCRIPTION
This enhancement enables the build framework to query for a subset of changed files (see `reportExternalImpactsAnalysisFileFilter`) a set of external collections (see `reportExternalImpactsCollectionPatterns`)  with a given granularity and depth (see `reportExternalImpactsAnalysisDepths`) to generate reports to document cross application impacts.

In this sample, the MortgageApplication was split into two applications App-EPSC and App-EPSM.

App-EPSM provides a shared copybook `epsmtcom.cpy`, which is leveraged by App-EPSC. This enhancement will report this dependency, but will not force App-EPSC to rebuild the program which includes the shared copybook.

The build of App-EPSM contains this reporting (with `--verbose`):

```
** Analyse and report external impacted files.
*** Identified external impacted files for changed file App-EPSM/copybooks-public/epsmtcom.cpy
*** Writing report of external impacts to file /var/jenkins/workspace/App-EPSM-S4/outputs/build.20210722.032455.024/externalImpacts_App-EPSC-master.txt
```

The report (here `externalImpacts_App-EPSC-master.txt`) is written to `workdir` and will contain three columns (logicalFile, filePath and collectionName) with the external impacted files: 

```
EPSCMORT 	 App-EPSC/cobol/epscmort.cbl 	 App-EPSC-master
```

**Important considerations**
- Use the pattern configuration to limit the query to those collections which are relevant
- Running in deep impact analysis mode is an expensive calculation and does recursively identifies impacted files. Please check if this is necessary for you.
- In many cases it should be sufficient to run with the **simple** mode, which performs much faster, because it does not resolve recursively.
