### PR TITLE
Fix illegal multibyte char

### DIFF
--- a/build-conf/dependencyReport.properties
+++ b/build-conf/dependencyReport.properties
@@ -11,7 +11,7 @@ reportExternalImpacts=false
 
 #
 # AnalysisDepths when performing impact analysis for external impacts
-# Options: simple | deep
+# Options: (simple/deep)
 #  simple will not allow recursion and only find files which have a direct dependency to the changed file 
 #  deep   will recursively resolve impacts, which is more expensive compared to simple mode
 reportExternalImpactsAnalysisDepths=simple

--- a/samples/application-conf/dependencyReport.properties
+++ b/samples/application-conf/dependencyReport.properties
@@ -12,7 +12,7 @@
 
 #
 # AnalysisDepths when performing impact analysis for external impacts
-# Options: simple | deep
+# Options: (simple/deep)
 #  simple will not allow recursion and only find files which have a direct dependency to the changed file 
 #  deep   will recursively resolve impacts, which is more expensive compared to simple mode
 # reportExternalImpactsAnalysisDepths=simple


### PR DESCRIPTION
This fixes #131 when the Rocket Git port clones the dbb-zappbuild repository.

This is fixed with Rocket Git port 2.26. We recommend to upgrade to it.

