### PR TITLE
Enhance file renaming scenario

### DIFF
--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,resetBuild.groovy
+test_testOrder=fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy
 
 
 #############################

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy
+test_testOrder=reset.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,reset.groovy
 
 
 #############################

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -25,7 +25,7 @@ fullBuild_datasetsToCleanUp = BMS,COBOL,LINK
 impactBuild_changedFiles = bms/epsmort.bms,cobol/epsmlist.cbl,copybook/epsmtout.cpy,link/epsmlist.lnk
 #
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
-impactBuild_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
+impactBuild_datasetsToCleanUp = BMS,COBOL,LINK
 #
 # Use file properties to associate expected files built to changed files
 impactBuild_expectedFilesBuilt = epsmort.bms,epscmort.cbl :: bms/epsmort.bms
@@ -37,11 +37,11 @@ impactBuild_expectedFilesBuilt = epsmlist.lnk :: link/epsmlist.lnk
 # impactBuild_rename.groovy properties
 ###############################
 # list of changed source files to test impact builds
-impactBuild_rename_renameFiles = cobol/epscmort.cbl
+impactBuild_rename_renameFiles = cobol/epscsmrt.cbl
 # Use file properties to associate new filename 
-impactBuild_rename_renameFilesMapping = cobol/epscmor2.cbl :: cobol/epscmort.cbl
+impactBuild_rename_renameFilesMapping = cobol/epscsmr2.cbl :: cobol/epscsmrt.cbl
 # Use file properties to associate expected files built to renamed files
-impactBuild_rename_expectedFilesBuilt = epscmor2.cbl :: cobol/epscmort.cbl
+impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: cobol/epscsmrt.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=fullBuild.groovy,impactBuild.groovy,resetBuild.groovy
+test_testOrder=fullBuild.groovy,impactBuild.groovy,impactBuild_rename.groovy,resetBuild.groovy
 
 
 #############################
@@ -32,3 +32,16 @@ impactBuild_expectedFilesBuilt = epsmort.bms,epscmort.cbl :: bms/epsmort.bms
 impactBuild_expectedFilesBuilt = epsmlist.cbl,epsmlist.lnk :: cobol/epsmlist.cbl
 impactBuild_expectedFilesBuilt = epsmlist.cbl,epscsmrt.cbl,epscmort.cbl,epsmlist.lnk :: copybook/epsmtout.cpy
 impactBuild_expectedFilesBuilt = epsmlist.lnk :: link/epsmlist.lnk
+
+###############################
+# impactBuild_rename.groovy properties
+###############################
+# list of changed source files to test impact builds
+impactBuild_rename_renameFiles = cobol/epsmort.cbl
+# Use file properties to associate new filename 
+impactBuild_rename_renameFilesMapping = cobol/epsmor2.cbl :: cobol/epsmort.cbl
+# Use file properties to associate expected files built to renamed files
+impactBuild_rename_expectedFilesBuilt = epsmor2.cbl :: cobol/epsmort.cbl
+# list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
+impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
+

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=reset.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,reset.groovy
+test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,resetBuild.groovy
 
 
 #############################

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -37,11 +37,11 @@ impactBuild_expectedFilesBuilt = epsmlist.lnk :: link/epsmlist.lnk
 # impactBuild_rename.groovy properties
 ###############################
 # list of changed source files to test impact builds
-impactBuild_rename_renameFiles = cobol/epsmort.cbl
+impactBuild_rename_renameFiles = cobol/epscmort.cbl
 # Use file properties to associate new filename 
-impactBuild_rename_renameFilesMapping = cobol/epsmor2.cbl :: cobol/epsmort.cbl
+impactBuild_rename_renameFilesMapping = cobol/epscmor2.cbl :: cobol/epscmort.cbl
 # Use file properties to associate expected files built to renamed files
-impactBuild_rename_expectedFilesBuilt = epsmor2.cbl :: cobol/epsmort.cbl
+impactBuild_rename_expectedFilesBuilt = epscmor2.cbl :: cobol/epscmort.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=fullBuild.groovy,impactBuild.groovy,impactBuild_rename.groovy,resetBuild.groovy
+test_testOrder=fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,resetBuild.groovy
 
 
 #############################

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -92,6 +92,8 @@ def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, 
 	println "** Validating impact build results"
 	def expectedFilesBuiltList = filesBuiltMappings.getValue(renameFile).split(',')
 
+	println("*** Outputstream: $outputStream")
+	
 	try{
 		// Validate clean build
 		assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $renameFile\nOUTPUT STREAM:\n$outputStream\n"
@@ -113,7 +115,7 @@ def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, 
 	}
 }
 def cleanUpDatasets() {
-	def segments = props.impactBuild_datasetsToCleanUp.split(',')
+	def segments = props.impactBuild_rename_datasetsToCleanUp.split(',')
 
 	println "Deleting impact build PDSEs ${segments}"
 	segments.each { segment ->

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -24,7 +24,7 @@ impactBuildCommand << "--logEncoding UTF-8"
 impactBuildCommand << "--url ${props.url}"
 impactBuildCommand << "--id ${props.id}"
 impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
-impactBuildCommand << (props.verbose ? "--verbose" : "")
+impactBuildCommand << "--verbose"
 impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles}" : "")
 impactBuildCommand << "--impactBuild"
 
@@ -105,6 +105,9 @@ def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, 
 		// Validate expected built files in output stream
 		assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FOR $renameFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
 
+		// Validate message that file renamed was deleted from collections
+		assert outputStream.contains("*** Deleting renamed logical file for ${props.app}/${renameFile}") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
+				
 		println "**"
 		println "** IMPACT BUILD TEST RENAME : PASSED FOR $renameFile **"
 		println "**"

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -109,7 +109,7 @@ def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, 
 		assert outputStream.contains("*** Deleting renamed logical file for ${props.app}/${renameFile}") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
 				
 		println "**"
-		println "** IMPACT BUILD TEST RENAME : PASSED FOR $renameFile **"
+		println "** IMPACT BUILD TEST - FILE RENAME : PASSED FOR RENAMING $renameFile **"
 		println "**"
 	}
 	catch(AssertionError e) {

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -1,0 +1,126 @@
+
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+import com.ibm.dbb.*
+import com.ibm.dbb.build.*
+import com.ibm.jzos.ZFile
+
+@Field BuildProperties props = BuildProperties.getInstance()
+println "\n** Executing test script impactBuild_renaming.groovy"
+
+// Get the DBB_HOME location
+def dbbHome = EnvVars.getHome()
+if (props.verbose) println "** DBB_HOME = ${dbbHome}"
+
+// create impact build command
+def impactBuildCommand = []
+impactBuildCommand << "${dbbHome}/bin/groovyz"
+impactBuildCommand << "${props.zAppBuildDir}/build.groovy"
+impactBuildCommand << "--workspace ${props.workspace}"
+impactBuildCommand << "--application ${props.app}"
+impactBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+impactBuildCommand << "--hlq ${props.hlq}"
+impactBuildCommand << "--logEncoding UTF-8"
+impactBuildCommand << "--url ${props.url}"
+impactBuildCommand << "--id ${props.id}"
+impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+impactBuildCommand << (props.verbose ? "--verbose" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles}" : "")
+impactBuildCommand << "--impactBuild"
+
+// iterate through change files to test impact build
+@Field def assertionList = []
+PropertyMappings filesBuiltMappings = new PropertyMappings('impactBuild_rename_expectedFilesBuilt')
+
+PropertyMappings renamedFilesMapping = new PropertyMappings('impactBuild_rename_renameFilesMapping')
+
+def renameFiles = props.impactBuild_rename_renameFiles.split(',')
+try {
+	renameFiles.each{ renameFile ->
+		
+		newFilename=renamedFilesMapping.getValue(renameFile)
+
+		// update changed file in Git repo test branch
+		renameAndCommit(renameFile, newFilename)
+
+		println "\n** Running impact after renaming file $renameFile to $newFilename"
+				
+		// run impact build
+		println "** Executing ${impactBuildCommand.join(" ")}"
+		def outputStream = new StringBuffer()
+		def process = [
+			'bash',
+			'-c',
+			impactBuildCommand.join(" ")
+		].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+
+		// validate build results
+		validateImpactBuild(renameFile, filesBuiltMappings, outputStream)
+	}
+}
+finally {
+	cleanUpDatasets()
+	if (assertionList.size()>0) {
+		println "\n***"
+		println "**START OF FAILED IMPACT BUILD TEST RESULTS**\n"
+		println "*FAILED IMPACT BUILD TEST RESULTS*\n" + assertionList
+		println "\n**END OF FAILED IMPACT BUILD TEST RESULTS**"
+		println "***"
+	}
+}
+// script end
+
+//*************************************************************
+// Method Definitions
+//*************************************************************
+
+def renameAndCommit(String renameFile, String newFilename) {
+	println "** Rename $renameFile to $newFilename"
+	def commands = """
+	mv ${props.appLocation}/${renameFile} ${props.appLocation}/${newFilename}
+	git -C ${props.appLocation} add .
+	git -C ${props.appLocation} commit . -m "renamed program file"
+"""
+	def task = ['bash', '-c', commands].execute()
+	def outputStream = new StringBuffer();
+	task.waitForProcessOutput(outputStream, System.err)
+}
+
+def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
+
+	println "** Validating impact build results"
+	def expectedFilesBuiltList = filesBuiltMappings.getValue(renameFile).split(',')
+
+	try{
+		// Validate clean build
+		assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $renameFile\nOUTPUT STREAM:\n$outputStream\n"
+
+		// Validate expected number of files built
+		def numImpactFiles = expectedFilesBuiltList.size()
+		assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FOR $renameFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
+
+		// Validate expected built files in output stream
+		assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FOR $renameFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+
+		println "**"
+		println "** IMPACT BUILD TEST RENAME : PASSED FOR $renameFile **"
+		println "**"
+	}
+	catch(AssertionError e) {
+		def result = e.getMessage()
+		assertionList << result;
+	}
+}
+def cleanUpDatasets() {
+	def segments = props.impactBuild_datasetsToCleanUp.split(',')
+
+	println "Deleting impact build PDSEs ${segments}"
+	segments.each { segment ->
+		def pds = "'${props.hlq}.${segment}'"
+		if (ZFile.dsExists(pds)) {
+			if (props.verbose) println "** Deleting ${pds}"
+			ZFile.remove("//$pds")
+		}
+	}
+}

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -205,11 +205,18 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
 				changedFiles.add(file)
 			} else if (action == "D") {// handle deleted files
 				deletedFiles.add(file)
-			} else if (action == "R100") { // handle renamed file
-				renamedFile = gitDiffOutput[1]
-				newFileName = gitDiffOutput[2]
-				changedFiles.add(newFileName) // will rebuild file
-				renamedFiles.add(renamedFile)
+			} else if (action.startsWith("R")) { // handle renamed file
+				similarityScore = action.substring(1) as int
+				if (similarityScore > 75){
+					renamedFile = gitDiffOutput[1]
+					newFileName = gitDiffOutput[2]
+					changedFiles.add(newFileName) // will rebuild file
+					renamedFiles.add(renamedFile)
+				}
+				else {
+					println ("*! (GitUtils.getChangedFiles - Renaming Scenario) Low similarity score for renamed file $file : $similarityScore. ")
+				}
+
 			}
 			else {
 				println ("*! (GitUtils.getChangedFiles) Error in determining action in git diff. ")
@@ -302,6 +309,6 @@ def getChangedProperties(String gitDir, String baseline, String currentHash, Str
 			}
 		}
 	}
-	
+
 	return changedProperties.propertyNames()
 }

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -206,15 +206,14 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
 			} else if (action == "D") {// handle deleted files
 				deletedFiles.add(file)
 			} else if (action.startsWith("R")) { // handle renamed file
+				renamedFile = gitDiffOutput[1]
+				newFileName = gitDiffOutput[2]
+				changedFiles.add(newFileName) // will rebuild file
+				renamedFiles.add(renamedFile)
+				//evaluate similarity score
 				similarityScore = action.substring(1) as int
-				if (similarityScore > 75){
-					renamedFile = gitDiffOutput[1]
-					newFileName = gitDiffOutput[2]
-					changedFiles.add(newFileName) // will rebuild file
-					renamedFiles.add(renamedFile)
-				}
-				else {
-					println ("*! (GitUtils.getChangedFiles - Renaming Scenario) Low similarity score for renamed file $file : $similarityScore. ")
+				if (similarityScore > 50){
+					println ("*! (GitUtils.getChangedFiles - Renaming Scenario) Low similarity score for renamed file $renamedFile : $similarityScore with new file $newFileName. ")
 				}
 
 			}

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -212,7 +212,7 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
 				renamedFiles.add(renamedFile)
 				//evaluate similarity score
 				similarityScore = action.substring(1) as int
-				if (similarityScore > 50){
+				if (similarityScore < 50){
 					println ("*! (GitUtils.getChangedFiles - Renaming Scenario) Low similarity score for renamed file $renamedFile : $similarityScore with new file $newFileName. ")
 				}
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -232,7 +232,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 		if (props.verbose) println "*** Deleted files for directory $dir:"
 		deleted.each { file ->
 			if ( !matches(file, excludeMatchers)) {
-				file = fixGitDiffPath(file, dir, false, mode)
+				(file, mode) = fixGitDiffPath(file, dir, false, mode)
 				deletedFiles << file
 				if (props.verbose) println "**** $file"
 			}
@@ -241,7 +241,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 		if (props.verbose) println "*** Renamed files for directory $dir:"
 		renamed.each { file ->
 			if ( !matches(file, excludeMatchers)) {
-				file = fixGitDiffPath(file, dir, false, mode)
+				(file, mode) = fixGitDiffPath(file, dir, false, mode)
 				renamedFiles << file
 				if (props.verbose) println "**** $file"
 			}
@@ -618,7 +618,7 @@ def fixGitDiffPath(String file, String dir, boolean mustExist, mode) {
 	}
 
 	if (props.verbose) println "!! (fixGitDiffPath) Mode could not be determined. Returning default."
-	return [defaultValue]
+	return [defaultValue, null]
 }
 
 def matches(String file, List<PathMatcher> pathMatchers) {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -592,7 +592,7 @@ def fixGitDiffPath(String file, String dir, boolean mustExist, mode) {
 
 	if ( new File("${props.workspace}/${fixedFileName}").exists())
 		return [fixedFileName, 1];
-	if (mode==1 && !mustExist) return fixedFileName
+	if (mode==1 && !mustExist) return [fixedFileName, 1]
 
 	// Scenario 2: Repository name is used as Application Root directory
 	String dirName = new File(dir).getName()
@@ -601,7 +601,7 @@ def fixGitDiffPath(String file, String dir, boolean mustExist, mode) {
 			"$dirName/$file" as String,
 			2
 		]
-	if (mode==2 && !mustExist) return "$dirName/$file" as String
+	if (mode==2 && !mustExist) return ["$dirName/$file" as String, 2]
 
 	// Scenario 3: Directory ${dir} is not the root directory of the file
 	// Example :
@@ -609,12 +609,12 @@ def fixGitDiffPath(String file, String dir, boolean mustExist, mode) {
 	fixedFileName = buildUtils.relativizePath(dir) + ( file.indexOf ("/") >= 0 ? file.substring(file.lastIndexOf("/")) : file )
 	if ( new File("${props.workspace}/${fixedFileName}").exists())
 		return [fixedFileName, 3];
-	if (mode==3 && !mustExist) return fixedFileName
+	if (mode==3 && !mustExist) return [fixedFileName, 3]
 
 	// returns null or assumed fullPath to file
 	if (mustExist){
 		if (props.verbose) println "!! (fixGitDiffPath) File not found."
-		return [null]
+		return [null,null]
 	}
 
 	if (props.verbose) println "!! (fixGitDiffPath) Mode could not be determined. Returning default."


### PR DESCRIPTION
This PR implements #135 and #118 

If a file is renamed and changed, git will report a similarity score. For renamed files, the build framework needs to:
- update collections (delete old file, and add the new file)
- rebuild the new file to gather output dependency data.

This PR also adds the renaming scenario as a new test case to the zAppBuild Test framework.