### PR TITLE
New build type - set the baseline hash in impact builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -785,16 +785,15 @@ Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
 
 ### Perform ImpactBuilds by overwriting the baseline reference for the analysis of changed files
 
-Implementing a release based development approach, will lead to combine several features into the release candidate, which is formed in a release branch. For more information please have a look to the documentation about git flow.
+Implementing a release-based approach will lead to combining several features into the release candidate, which is formed in a release branch. For more information please have a look to the documentation about git flow.
 
-In this case, the build framework should create a consolidated build for all changed files including their impacts (potentially with the optimized compile time options) for the incremental release candidate. The scenario for the first build on the release branch is expected to be slightly different from the impact build of topic branches. 
+To create an incremental release candidate, the build framework needs to perform a consolidated build that includes all changed files and their impacts (potentially this build can use optimized compile options). In this situation, the first build on the release branch must be slightly different from the typical impact build of topic branches.
 
-The invocation is similar to other impact builds, but provides an additional option `--baselineRef`. The commandline option `--baselineRef` allows you to overwrite the baseline hash for each directory for the analysis phase for changed files. The referenced directory needs to be in the list of the `applicationSrcDirs` build preference.
+The invocation for this consolidated build is performed through the `--impactBuild` parameter with the use of an additional option, called `--baselineRef`. The command-line option `--baselineRef` allows you to specify the baseline hash/tag for each directory when running an impact analysis: each file that was changed, renamed or deleted between the baseline hash/tag and the current hash will be managed by the build framework, and will impact the scope of the impact build. The referenced directory needs to be in the list of the `applicationSrcDirs` build property.
 
 The syntax for --baselineRef is a comma-seperated list of mappings for each application source dir. Each mapping is seperated by a colon:
 `--baselineRef <application source dir>:<gitReference>,<application source dir>:<gitReference>,...`
-Alternatively, for the main application directory reference, it is sufficient to specify `--baselineRef <gitReference>`
-`gitReference` can be anything in the history - a git commit, a git tag .
+Alternatively, for the main application directory reference, it is sufficient to specify `--baselineRef <gitReference>`. `gitReference` can either be a git commit hash or a git tag in the history.
 
 Another scenario of this build setup is to run the build with the DBB reportOnly option to build a cumulative deployment package without rebuilding the binaries.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -116,8 +116,8 @@ utility options
 - [Build a List of Programs](#build-a-list-of-programs)
 - [Perform Full Build to build all files](#perform-full-build-to-build-all-files)
 - [Perform Impact Build](#perform-impact-build)
-- [Perform ImpactBuilds for topic branches](#perform-impactbuilds-for-topic-branches)
-- [Perform ImpactBuilds by overwriting the baseline reference for the analysis of changed files](#perform-impactbuilds-by-overwriting-the-baseline-reference-for-the-analysis-of-changed-files)
+- [Perform Impact Build for topic branches](#perform-impact-build-for-topic-branches)
+- [Perform Impact Build by providing baseline reference for the analysis of changed files](#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files)
 - [Perform a Scan Source build](#perform-a-scan-source-build)
 - [Perform a Scan Source + Outputs build](#perform-a-scan-source--outputs-build)
 
@@ -672,7 +672,7 @@ required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkE
 
 </details>
 
-### Perform ImpactBuilds for topic branches 
+### Perform Impact Build for topic branches 
 
 zAppBuild is able to detect when building a topic branch for the first time. It will automatically clone the dependency data collections from the main build branch (see `mainBuildBranch` build property in application.properties) in order to avoid having to rescan the entire application.
 
@@ -783,7 +783,7 @@ Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
 
 </details>
 
-### Perform ImpactBuilds by overwriting the baseline reference for the analysis of changed files
+### Perform Impact Build by providing baseline reference for the analysis of changed files
 
 Implementing a release-based approach will lead to combining several features into the release candidate, which is formed in a release branch. For more information please have a look to the documentation about git flow.
 
@@ -791,9 +791,14 @@ To create an incremental release candidate, the build framework needs to perform
 
 The invocation for this consolidated build is performed through the `--impactBuild` parameter with the use of an additional option, called `--baselineRef`. The command-line option `--baselineRef` allows you to specify the baseline hash/tag for each directory when running an impact analysis: each file that was changed, renamed or deleted between the baseline hash/tag and the current hash will be managed by the build framework, and will impact the scope of the impact build. The referenced directory needs to be in the list of the `applicationSrcDirs` build property.
 
-The syntax for --baselineRef is a comma-seperated list of mappings for each application source dir. Each mapping is seperated by a colon:
-`--baselineRef <application source dir>:<gitReference>,<application source dir>:<gitReference>,...`
-Alternatively, for the main application directory reference, it is sufficient to specify `--baselineRef <gitReference>`. `gitReference` can either be a git commit hash or a git tag in the history.
+The syntax for `--baselineRef` is a comma-seperated list of mappings for each application source dir. Each mapping is seperated by a colon:
+```
+--baselineRef <application source dir>:<gitReference>,<application source dir>:<gitReference>,...
+```
+
+Alternatively, for the main application directory reference, it is sufficient to specify `--baselineRef <gitReference>`. 
+
+`gitReference` can either be a git commit hash or a git tag in the history.
 
 Another scenario of this build setup is to run the build with the DBB reportOnly option to build a cumulative deployment package without rebuilding the binaries.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ zAppBuild supports a number of build scenarios:
 * **List of Programs** - Build a list of programs provided by a text file.
 * **Full Build** - Build all programs (or buildable files) of an application.
 * **Impact Build** - Build only programs impacted by source files that have changed since the last successful build.
+* **Impact Build with baseline reference** - Build only programs impacted by source files that have changed by diff'ing to a previous configuration reference.
 * **Topic Branch Build** - Detects when building a topic branch for the first time and will automatically clone the dependency data collections from the main build branch in order to avoid having to rescan the entire application.
 * **Scan Source** - Skip the actual building and only scan source files to store dependency data in collection (migration scenario).
 * **Scan Source + Outputs** - Skip the actual building and only scan source files and existing load modules to dependency data in source and output collection (migration scenario with static linkage scenarios).

--- a/build.groovy
+++ b/build.groovy
@@ -166,7 +166,7 @@ options:
 	cli.l(longOpt:'logEncoding', args:1, 'Encoding of output logs. Default is EBCDIC')
 	cli.f(longOpt:'fullBuild', 'Flag indicating to build all programs for application')
 	cli.i(longOpt:'impactBuild', 'Flag indicating to build only programs impacted by changed files since last successful build.')
-	cli.b(longOpt:'baselineRef',args:1,'Build option to set the baselineHash in an impactBuild scenario.')
+	cli.b(longOpt:'baselineRef',args:1,'Comma seperated list of git references to overwrite the baselineHash hash in an impactBuild scenario.')
 	cli.r(longOpt:'reset', 'Deletes the dependency collections and build result group from the DBB repository')
 	cli.v(longOpt:'verbose', 'Flag to turn on script trace')
 

--- a/build.groovy
+++ b/build.groovy
@@ -380,7 +380,7 @@ def populateBuildProperties(String[] args) {
 	
 	// Validate Build Properties  
 	if(props.reportExternalImpactsAnalysisDepths) assert (props.reportExternalImpactsAnalysisDepths == 'simple' || props.reportExternalImpactsAnalysisDepths == 'deep' ) : "*! Build Property props.reportExternalImpactsAnalysisDepths has an invalid value"
-	if(props.baselineRef) assert (props.impactBuild) : "*! Build Property props.baselineRef is exclusive to an impactBuild scenario."
+	if(props.baselineRef) assert (props.impactBuild) : "*! Build Property props.baselineRef is exclusive to an impactBuild scenario"
 	
 	// Print all build properties + some envionment variables 
 	if (props.verbose) {

--- a/build.groovy
+++ b/build.groovy
@@ -166,7 +166,7 @@ options:
 	cli.l(longOpt:'logEncoding', args:1, 'Encoding of output logs. Default is EBCDIC')
 	cli.f(longOpt:'fullBuild', 'Flag indicating to build all programs for application')
 	cli.i(longOpt:'impactBuild', 'Flag indicating to build only programs impacted by changed files since last successful build.')
-	cli.b(longOpt:'baselineHash',args:1,'Build option to set the baselineHash in an impactBuild scenario.')
+	cli.b(longOpt:'baselineRef',args:1,'Build option to set the baselineHash in an impactBuild scenario.')
 	cli.r(longOpt:'reset', 'Deletes the dependency collections and build result group from the DBB repository')
 	cli.v(longOpt:'verbose', 'Flag to turn on script trace')
 
@@ -309,7 +309,7 @@ def populateBuildProperties(String[] args) {
 	if (opts.i) props.impactBuild = 'true'
 	if (opts.r) props.reset = 'true'
 	if (opts.v) props.verbose = 'true'
-	if (opts.b) props.baselineHash = opts.b
+	if (opts.b) props.baselineRef = opts.b
 	
 	// scan options
 	if (opts.s) props.scanOnly = 'true'
@@ -380,7 +380,7 @@ def populateBuildProperties(String[] args) {
 	
 	// Validate Build Properties  
 	if(props.reportExternalImpactsAnalysisDepths) assert (props.reportExternalImpactsAnalysisDepths == 'simple' || props.reportExternalImpactsAnalysisDepths == 'deep' ) : "*! Build Property props.reportExternalImpactsAnalysisDepths has an invalid value"
-	if(props.baselineHash) assert (props.impactBuild) : "*! Build Property props.baselineHash is exclusive to an impactBuild scenario."
+	if(props.baselineRef) assert (props.impactBuild) : "*! Build Property props.baselineRef is exclusive to an impactBuild scenario."
 	
 	// Print all build properties + some envionment variables 
 	if (props.verbose) {

--- a/build.groovy
+++ b/build.groovy
@@ -166,6 +166,7 @@ options:
 	cli.l(longOpt:'logEncoding', args:1, 'Encoding of output logs. Default is EBCDIC')
 	cli.f(longOpt:'fullBuild', 'Flag indicating to build all programs for application')
 	cli.i(longOpt:'impactBuild', 'Flag indicating to build only programs impacted by changed files since last successful build.')
+	cli.b(longOpt:'baselineHash',args:1,'Build option to set the baselineHash in an impactBuild scenario.')
 	cli.r(longOpt:'reset', 'Deletes the dependency collections and build result group from the DBB repository')
 	cli.v(longOpt:'verbose', 'Flag to turn on script trace')
 
@@ -308,7 +309,8 @@ def populateBuildProperties(String[] args) {
 	if (opts.i) props.impactBuild = 'true'
 	if (opts.r) props.reset = 'true'
 	if (opts.v) props.verbose = 'true'
-
+	if (opts.b) props.baselineHash = opts.b
+	
 	// scan options
 	if (opts.s) props.scanOnly = 'true'
 	if (opts.ss) props.scanOnly = 'true'
@@ -378,7 +380,8 @@ def populateBuildProperties(String[] args) {
 	
 	// Validate Build Properties  
 	if(props.reportExternalImpactsAnalysisDepths) assert (props.reportExternalImpactsAnalysisDepths == 'simple' || props.reportExternalImpactsAnalysisDepths == 'deep' ) : "*! Build Property props.reportExternalImpactsAnalysisDepths has an invalid value"
-		
+	if(props.baselineHash) assert (props.impactBuild) : "*! Build Property props.baselineHash is exclusive to an impactBuild scenario."
+	
 	// Print all build properties + some envionment variables 
 	if (props.verbose) {
 		println("java.version="+System.getProperty("java.runtime.version"))

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -185,15 +185,15 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 			String[] baselineMap = (props.baselineRef).split(",")
 			baselineMap.each{
 				// case: baselineRef gitref
-				if(it.split(":").size()==1 && dir.equals(props.application)){
-					if (props.verbose) println "*** Baseline hash for directory $dir retrieved from overwrite."
+				if(it.split(":").size()==1 && relDir.equals(props.application)){
+					if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
 					hash = gitReference
 				}
 				// case: baselineRef folder:gitref
 				else if(it.split(":").size()>1){
 					(appSrcDir, gitReference) = it.split(":")
 					if (appSrcDir.equals(relDir)){
-						if (props.verbose) println "*** Baseline hash for directory $dir retrieved from overwrite."
+						if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
 						hash = gitReference
 					}
 				}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -185,12 +185,12 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 			String[] baselineMap = (props.baselineRef).split(",")
 			baselineMap.each{
 				// case: baselineRef gitref
-				if(it.split(":").size==1 && dir.equals(props.application)){
+				if(it.split(":").size()==1 && dir.equals(props.application)){
 					if (props.verbose) println "*** Baseline hash for directory $dir retrieved from overwrite."
 					hash = gitReference
 				}
 				// case: baselineRef folder:gitref
-				else if(it.split(":").size>1){
+				else if(it.split(":").size()>1){
 					(appSrcDir, gitReference) = it.split(":")
 					if (appSrcDir.equals(relDir)){
 						if (props.verbose) println "*** Baseline hash for directory $dir retrieved from overwrite."

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -184,37 +184,32 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 		if (props.baselineRef){
 			String[] baselineMap = (props.baselineRef).split(",")
 			baselineMap.each{
-				// case: baselineRef gitref
+				// case: baselineRef (gitref)
 				if(it.split(":").size()==1 && relDir.equals(props.application)){
 					if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
 					hash = it
 				}
-				// case: baselineRef folder:gitref
+				// case: baselineRef (folder:gitref)
 				else if(it.split(":").size()>1){
 					(appSrcDir, gitReference) = it.split(":")
 					if (appSrcDir.equals(relDir)){
 						if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
 						hash = gitReference
 					}
-					//case: no reference defined
-					else if (lastBuildResult){
-						hash = lastBuildResult.getProperty(key)
-					}
-					else {
-						if (props.verbose) println "!** Could not obtain the baseline hash for directory $relDir."
-					}
 				}
-				else if (lastBuildResult){
-					hash = lastBuildResult.getProperty(key)
-				}
+			}
+			// for build directories which are not specified in baselineRef mapping, return the info from lastBuildResult
+			if (hash == null && lastBuildResult) {
+				hash = lastBuildResult.getProperty(key)
 			}
 		} else if (lastBuildResult){
 			// return from lastBuildResult
 			hash = lastBuildResult.getProperty(key)
-		} else {
-			if (props.verbose) println "!** Could not obtain the baseline hash for directory $relDir."
 		}
-
+		if (hash == null){
+			println "!** Could not obtain the baseline hash for directory $relDir."
+		}
+		
 		if (props.verbose) println "** Storing $relDir : $hash"
 		baselineHashes.put(relDir,hash)
 	}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -196,8 +196,14 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 						if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
 						hash = gitReference
 					}
+					//case: no reference defined
+					else if (lastBuildResult){
+						hash = lastBuildResult.getProperty(key)
+					}
+					else {
+						if (props.verbose) println "!** Could not obtain the baseline hash for directory $relDir."
+					}
 				}
-				//case: no reference defined
 				else if (lastBuildResult){
 					hash = lastBuildResult.getProperty(key)
 				}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -180,7 +180,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 		String key = "$hashPrefix${buildUtils.relativizePath(dir)}"
 		String relDir = buildUtils.relativizePath(dir)
 		String hash
-		// retrieve overwrite if set
+		// retrieve baseline reference overwrite if set
 		if (props.baselineRef){
 			String[] baselineMap = (props.baselineRef).split(",")
 			baselineMap.each{
@@ -198,14 +198,17 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 					}
 				}
 				//case: no reference defined
-				else {
+				else if (lastBuildResult){
 					hash = lastBuildResult.getProperty(key)
 				}
 			}
-		} else {
+		} else if (lastBuildResult){
 			// return from lastBuildResult
 			hash = lastBuildResult.getProperty(key)
+		} else {
+			if (props.verbose) println "!** Could not obtain the baseline hash for directory $relDir."
 		}
+
 		if (props.verbose) println "** Storing $relDir : $hash"
 		baselineHashes.put(relDir,hash)
 	}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -187,7 +187,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 				// case: baselineRef gitref
 				if(it.split(":").size()==1 && relDir.equals(props.application)){
 					if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
-					hash = gitReference
+					hash = it
 				}
 				// case: baselineRef folder:gitref
 				else if(it.split(":").size()>1){

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -182,7 +182,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 		String hash
 		// retrieve overwrite if set
 		if (props.baselineHash){
-			String[] baselineMap = "props.baselineHash".split(",")
+			String[] baselineMap = (props.baselineHash).split(",")
 			baselineMap.each{
 				(appSrcDir, gitReference) = it.split(":")
 				if (appSrcDir.equals(relDir)){


### PR DESCRIPTION
Depending on the selected branching model, build situations occur, that the implementation of `impactBuild` or the `impactBuild for topic branches` may not be sufficient to drive incremental builds.

One case is a release assembly process following the a standard git flow process, when several features are combined into an incremental release candidate package. In this scenario, the first build for this configuration should determine the changed files of all the contributed features and pass them to the impact analysis. 
In this case, the application team would rather define the baseline reference, which is passed into the changed files analysis processing.