### PR TITLE
Update zAppBuild to support IDE passed dependency information

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -44,6 +44,10 @@ $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1
 ```
 $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --fullBuild --cc --cch localhost --ccp 8009 --cco "e=CCPDF"
 ```
+ **Build one program using a [user build dependency file](samples/userBuildDependencyFile) predefining dependency information to skip DBB scans and dependency resolution.**
+```
+$DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --userBuild --dependencyFile userBuildDependencyFile.json app1/cobol/epsmpmt.cbl
+```
 
 ## Command Line Options Summary
 ```
@@ -101,6 +105,7 @@ web application credentials
 IDz/ZOD User Build options
  -u,--userBuild               Flag indicating running a user build
  -e,--errPrefix <arg>         Unique id used for IDz error message datasets
+ -df,--dependencyFile <arg>   Absolute or relative path (from workspace) to user build JSON file containing dependency information.
 
 utility options
  -help,--help                 Prints this message

--- a/build.groovy
+++ b/build.groovy
@@ -381,6 +381,9 @@ def populateBuildProperties(String[] args) {
 		props.buildOutDir = ((props.createBuildOutputSubfolder && props.createBuildOutputSubfolder.toBoolean()) ? "${props.outDir}/${props.applicationBuildLabel}" : "${props.outDir}") as String
 	}
 	
+	// Validate User Build Dependency file used with user build
+	if (props.userBuildDependencyFile) assert (props.userBuild)
+
 	// Validate Build Properties  
 	if(props.reportExternalImpactsAnalysisDepths) assert (props.reportExternalImpactsAnalysisDepths == 'simple' || props.reportExternalImpactsAnalysisDepths == 'deep' ) : "*! Build Property props.reportExternalImpactsAnalysisDepths has an invalid value"
 		

--- a/build.groovy
+++ b/build.groovy
@@ -201,7 +201,7 @@ options:
 	// build framework options
 	cli.re(longOpt:'reportExternalImpacts', 'Flag to activate analysis and report of external impacted files within DBB collections')
 	
-	// IDE user build dependency options
+	// IDE user build dependency file options
 	cli.df(longOpt:'dependencyFile', args:1, 'Absolute or relative (from workspace) path to user build JSON file containing dependency information.')
 
 	// utility options

--- a/build.groovy
+++ b/build.groovy
@@ -202,7 +202,7 @@ options:
 	cli.re(longOpt:'reportExternalImpacts', 'Flag to activate analysis and report of external impacted files within DBB collections')
 	
 	// IDz Dependency Options
-	cli.df(longOpt:'dependencyFile', args:1, argName:'Absolute or relative (from workspace) path to user build JSON file containing dependency information.')
+	cli.df(longOpt:'dependencyFile', args:1, argName:'depFilePath', 'Absolute or relative (from workspace) path to user build JSON file containing dependency information.')
 
 	// utility options
 	cli.help(longOpt:'help', 'Prints this message')
@@ -354,8 +354,8 @@ def populateBuildProperties(String[] args) {
 	if (opts.e) props.errPrefix = opts.e
 	if (opts.u) props.userBuild = 'true'
 	if (opts.t) props.team = opts.t
-	// support IDz dependency file parameter
-	if (opts.df) props.userBuildDependencyFile = opts.df
+	// support IDE passing dependency file parameter
+	if (opts.df) props.userBuildDependencyFile = opts.depFilePath
 
 	// set build file from first non-option argument
 	if (opts.arguments()) props.buildFile = opts.arguments()[0].trim()

--- a/build.groovy
+++ b/build.groovy
@@ -201,7 +201,7 @@ options:
 	// build framework options
 	cli.re(longOpt:'reportExternalImpacts', 'Flag to activate analysis and report of external impacted files within DBB collections')
 	
-	// IDz Dependency Options
+	// IDE user build dependency options
 	cli.df(longOpt:'dependencyFile', args:1, 'Absolute or relative (from workspace) path to user build JSON file containing dependency information.')
 
 	// utility options

--- a/build.groovy
+++ b/build.groovy
@@ -202,7 +202,7 @@ options:
 	cli.re(longOpt:'reportExternalImpacts', 'Flag to activate analysis and report of external impacted files within DBB collections')
 	
 	// IDz Dependency Options
-	cli.df(longOpt:'dependencyFile', args:1, argName:'Absolute or relative (from workspace) path to file containing list of build dependencies for user ')
+	cli.df(longOpt:'dependencyFile', args:1, argName:'Absolute or relative (from workspace) path to user build JSON file containing dependency information.')
 
 	// utility options
 	cli.help(longOpt:'help', 'Prints this message')

--- a/build.groovy
+++ b/build.groovy
@@ -201,6 +201,9 @@ options:
 	// build framework options
 	cli.re(longOpt:'reportExternalImpacts', 'Flag to activate analysis and report of external impacted files within DBB collections')
 	
+	// IDz Dependency Options
+	cli.df(longOpt:'dependencyFile', args:1, argName:'Absolute or relative (from workspace) path to file containing list of build dependencies for user ')
+
 	// utility options
 	cli.help(longOpt:'help', 'Prints this message')
 
@@ -247,6 +250,9 @@ def populateBuildProperties(String[] args) {
 	if (opts.srcDir) props.workspace = opts.srcDir
 	if (opts.wrkDir) props.outDir = opts.wrkDir
 	buildUtils.assertBuildProperties('workspace,outDir')
+
+	// support IDz dependency file parameter
+	if (opts.df) props.userBuildDependencyFile = opts.df
 
 	// load build.properties
 	def buildConf = "${zAppBuildDir}/build-conf"

--- a/build.groovy
+++ b/build.groovy
@@ -251,9 +251,6 @@ def populateBuildProperties(String[] args) {
 	if (opts.wrkDir) props.outDir = opts.wrkDir
 	buildUtils.assertBuildProperties('workspace,outDir')
 
-	// support IDz dependency file parameter
-	if (opts.df) props.userBuildDependencyFile = opts.df
-
 	// load build.properties
 	def buildConf = "${zAppBuildDir}/build-conf"
 	props.load(new File("${buildConf}/build.properties"))
@@ -357,6 +354,8 @@ def populateBuildProperties(String[] args) {
 	if (opts.e) props.errPrefix = opts.e
 	if (opts.u) props.userBuild = 'true'
 	if (opts.t) props.team = opts.t
+	// support IDz dependency file parameter
+	if (opts.df) props.userBuildDependencyFile = opts.df
 
 	// set build file from first non-option argument
 	if (opts.arguments()) props.buildFile = opts.arguments()[0].trim()

--- a/build.groovy
+++ b/build.groovy
@@ -381,8 +381,8 @@ def populateBuildProperties(String[] args) {
 		props.buildOutDir = ((props.createBuildOutputSubfolder && props.createBuildOutputSubfolder.toBoolean()) ? "${props.outDir}/${props.applicationBuildLabel}" : "${props.outDir}") as String
 	}
 	
-	// Validate User Build Dependency file used with user build
-	if (props.userBuildDependencyFile) assert (props.userBuild)
+	// Validate User Build Dependency file is used only with user build
+	if (props.userBuildDependencyFile) assert (props.userBuild) : "*! User Build Dependency File requires User Build option."
 
 	// Validate Build Properties  
 	if(props.reportExternalImpactsAnalysisDepths) assert (props.reportExternalImpactsAnalysisDepths == 'simple' || props.reportExternalImpactsAnalysisDepths == 'deep' ) : "*! Build Property props.reportExternalImpactsAnalysisDepths has an invalid value"

--- a/build.groovy
+++ b/build.groovy
@@ -202,7 +202,7 @@ options:
 	cli.re(longOpt:'reportExternalImpacts', 'Flag to activate analysis and report of external impacted files within DBB collections')
 	
 	// IDz Dependency Options
-	cli.df(longOpt:'dependencyFile', args:1, argName:'depFilePath', 'Absolute or relative (from workspace) path to user build JSON file containing dependency information.')
+	cli.df(longOpt:'dependencyFile', args:1, 'Absolute or relative (from workspace) path to user build JSON file containing dependency information.')
 
 	// utility options
 	cli.help(longOpt:'help', 'Prints this message')
@@ -355,7 +355,7 @@ def populateBuildProperties(String[] args) {
 	if (opts.u) props.userBuild = 'true'
 	if (opts.t) props.team = opts.t
 	// support IDE passing dependency file parameter
-	if (opts.df) props.userBuildDependencyFile = opts.depFilePath
+	if (opts.df) props.userBuildDependencyFile = opts.df
 
 	// set build file from first non-option argument
 	if (opts.arguments()) props.buildFile = opts.arguments()[0].trim()

--- a/samples/userBuildDependencyFile/README.md
+++ b/samples/userBuildDependencyFile/README.md
@@ -1,0 +1,20 @@
+## User Build Dependency File
+
+In order to increase performance of User Build running on ZD&T, the IDEs can **optionally** pass dependency information about the program being built to zAppBuild allowing it to skip running dependency resolution which depending on the size and number of build dependencies the program references can be time consuming on ZD&T platforms.
+
+### Dependency File Option
+Providing the following option when calling *build.groovy* will skip scanning and dependency resolution within zAppBuild.
+
+    --dependencyFile <pathToFile>
+    -df <pathToFile>
+If not provided, zAppBuild will run the traditional scan and dependency resolution on the build file.
+If it is provided, zAppBuild will skip scanning and resolution and refer to the dependencies and information from the file. 
+  
+### Dependency File Location
+
+The location of the user build dependency file on USS is unimportant, as long as that path is correctly specified when passing the **-\-dependencyFile \<path>** option to zAppBuild. 
+
+### Additional Resources
+View the user build dependency file schema and a sample file using the links below. 
+##### [Dependency File Schema](schema.json)
+##### [Sample Dependency File](sample.json)

--- a/samples/userBuildDependencyFile/sample.json
+++ b/samples/userBuildDependencyFile/sample.json
@@ -7,8 +7,8 @@
     "dependencies": [
         "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsmtcom.cpy",
         "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsnbrpm.cpy",
-        "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsmtinp.cpy",
-        "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsmtout.cpy"
+        "MortgageApplication/copybook/epsmtinp.cpy",
+        "MortgageApplication/copybook/epsmtout.cpy"
     ],
     "schemaVersion": "1.0"
 }

--- a/samples/userBuildDependencyFile/sample.json
+++ b/samples/userBuildDependencyFile/sample.json
@@ -1,0 +1,14 @@
+{
+    "fileName": "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epscmort.cbl",
+    "isCICS": true,
+    "isSQL": true,
+    "isDLI": false,
+    "isMQ": false,
+    "dependencies": [
+        "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsmtcom.cpy",
+        "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsnbrpm.cpy",
+        "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsmtinp.cpy",
+        "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsmtout.cpy"
+    ],
+    "schemaVersion": "1.0"
+}

--- a/samples/userBuildDependencyFile/schema.json
+++ b/samples/userBuildDependencyFile/schema.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "UserBuildDependencyFile": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fileName": { 
+                    "description": "Represents the absolute or relative path (from the sandbox) of the source file to build. This field should include the file extension (if applicable) and is case sensitive. ",
+                    "type": "string"
+                },
+                "isCICS": {
+                    "type": "boolean",
+                    "description": "Represents the existence of EXEC CICS statements in the program or its listed dependencies.",
+                    "default": "false"
+                },
+                "isSQL": {
+                    "type": "boolean",
+                    "description": "Represents the existence of EXEC CICS statements in the program or its listed dependencies.",
+                    "default": "false"
+                },
+                "isDLI": {
+                    "type": "boolean",
+                    "description": "Represents the existence of EXEC CICS statements in the program or its listed dependencies.",
+                    "default": "false"
+                },
+                "isMQ": {
+                    "type": "boolean",
+                    "description": "Represents the existence of EXEC CICS statements in the program or its listed dependencies.",
+                    "default": "false"
+                },
+                "dependencies": {
+                    "description": "An array of strings representing the list of program dependencies as paths. ",
+                    "type": "array",
+                    "minItems": 0,
+                    "uniqueItems": true,
+                    "items": {
+                        "description": "The absolute or relative path (from the sandbox) to a program dependency. Each entry should include the file extension (if applicable) and is case sensitive. ",
+                        "type": "string"
+                    }
+                },
+                "schemaVersion": {
+                    "description": "Represents the schema version of this JSON structure. ",
+                    "type": "string",
+                    "default": "1.0"
+                }
+            },
+            "required": [
+                "fileName",
+                "isCICS",
+                "isSQL",
+                "isDLI",
+                "isMQ",
+                "dependencies",
+                "schemaVersion"
+                
+            ],
+            "title": ".userbuilddependencyfile"
+        }
+    }
+}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -77,7 +77,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 	}
 
 	if (dependencyPDS && props.userBuildDependencyFile && props.userBuild) {
-		println("User Build Dep File Present. Skipping DBB Scan...")
+		if (props.verbose) println "*** User Build Dep File Present. Skipping DBB Scan"
 		// userBuildDependencyFile present (passed from the IDE)
 		// skip dependency resolution, extract dependencies from userBuildDependencyFile, and copy directly to dependencyPDS
 
@@ -88,6 +88,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		// parse JSON dependency file
 		JsonSlurper slurper = new groovy.json.JsonSlurper()
 		def depFileData = slurper.parse(depFile)
+		if (props.verbose) println "UserBuild Dependency File: \n" + depFileData
 
 		// Manually create logical file for the user build program
 		String lname = CopyToPDS.createMemberName(buildFile)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -110,8 +110,6 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 				// retrieve zUnitFileExtension plbck
 				zunitFileExtension = (props.zunit_playbackFileExtension) ? props.zunit_playbackFileExtension : null
 
-				// original
-				// ((physicalDependency.getFile().substring(physicalDependency.getFile().indexOf("."))).contains(zunitFileExtension))
 				// get index of last '.' in file path to extract the file extension
 				def extIndex = dependency.lastIndexOf('.')
 				if( zunitFileExtension && !zunitFileExtension.isEmpty() && (dependency.substring(extIndex).contains(zunitFileExtension))){
@@ -130,21 +128,6 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 				}			
 			}
 		} 
-		/*
-
-		// scan the source file to obtain isCICS,SQL,DLI,MQ flags
-		if (dependencyResolver) {
-			DependencyScanner scanner = dependencyResolver.getScanner()
-			// get file and source Dir
-			String sourceDir = dependencyResolver.getSourceDir()
-			String sourceFile = dependencyResolver.getFile()
-
-			// run manual scan to identify flags
-			LogicalFile lfile = scanner.scan(sourceFile, sourceDir)
-			// save lfile to dependency resolver
-			dependencyResolver.setLogicalFile(lfile)
-		} */
-
 	}
 	else if (dependencyPDS && dependencyResolver) {
 		// resolve the logical dependencies to physical files to copy to data sets

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -530,7 +530,7 @@ def validateDependencyFile(String depFilePath) {
 	
 	// make assertions on required fields from dependency file
 	reqDepFileProps.each { depFileProp ->
-		assert depFileData."$depFileProp" != null : "*! Missing required user build dependency file field '$depFileProp'"
+		assert depFileData.${depFileProp} != null : "*! Missing required user build dependency file field '$depFileProp'"
 	}
 
 	return depFileData // return the parsed JSON object

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -84,11 +84,10 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		String depFilePath = props.userBuildDependencyFile
 		// if depFilePath is relatvie, convert to absolute path
 		String depFileLoc = getAbsolutePath(depFilePath)
-		String depFileJSON = new File(depFileLoc).text
-		
+		String depFileJSON = new File(depFileLoc).text // convert JSON dep file to String
 		JsonSlurper slurper = new groovy.json.JsonSlurper()
-		if (props.verbose) println "*** Dependency File ${depFileLoc}: \n" + groovy.json.JsonOutput.prettyPrint(depFileJSON)
-		// parse dependency File JSON Data
+		if (props.verbose) println "*** Dependency File (${depFileLoc}): \n" + groovy.json.JsonOutput.prettyPrint(depFileJSON)
+		// parse dependency File JSON String as Text
 		def depFileData = slurper.parseText(depFileJSON)
 
 		// Manually create logical file for the user build program
@@ -152,21 +151,24 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 				// only copy the dependency file once per script invocation
 				if (!copiedFileCache.contains(physicalDependencyLoc)) {
 					copiedFileCache.add(physicalDependencyLoc)
-
+					// create member name
+					String memberName = CopyToPDS.createMemberName(physicalDependency.getFile())
 					//retrieve zUnitFileExtension plbck
 					zunitFileExtension = (props.zunit_playbackFileExtension) ? props.zunit_playbackFileExtension : null
 
 					if( zunitFileExtension && !zunitFileExtension.isEmpty() && ((physicalDependency.getFile().substring(physicalDependency.getFile().indexOf("."))).contains(zunitFileExtension))){
+						if (props.verbose) println "** Copying dependency ${physicalDependencyLoc} to ${dependencyPDS}:${memberName} as BINARY"
 						new CopyToPDS().file(new File(physicalDependencyLoc))
 								.copyMode(CopyMode.BINARY)
 								.dataset(dependencyPDS)
-								.member(CopyToPDS.createMemberName(physicalDependency.getFile()))
+								.member(memberName)
 								.execute()
 					} else
 					{
+						if (props.verbose) println "** Copying dependency ${physicalDependencyLoc} to ${dependencyPDS}:${memberName}"
 						new CopyToPDS().file(new File(physicalDependencyLoc))
 								.dataset(dependencyPDS)
-								.member(CopyToPDS.createMemberName(physicalDependency.getFile()))
+								.member(memberName)
 								.execute()
 					}
 				}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -88,7 +88,8 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		// parse JSON dependency file
 		JsonSlurper slurper = new groovy.json.JsonSlurper()
 		def depFileData = slurper.parse(depFile)
-		if (props.verbose) println "UserBuild Dependency File: \n" + depFileData.toString()
+		def jsonString = groovy.json.JsonOutput.toJson(depFileData)
+		if (props.verbose) println "UserBuild Dependency File: \n" + groovy.json.JsonOutput.prettyPrint(jsonString)
 
 		// Manually create logical file for the user build program
 		String lname = CopyToPDS.createMemberName(buildFile)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -86,7 +86,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		String depFileLoc = getAbsolutePath(depFilePath)
 		String depFileJSON = new File(depFileLoc).text // convert JSON dep file to String
 		JsonSlurper slurper = new groovy.json.JsonSlurper()
-		if (props.verbose) println "*** Dependency File (${depFileLoc}): \n" + groovy.json.JsonOutput.prettyPrint(depFileJSON)
+		if (props.verbose) println "  Dependency File (${depFileLoc}): \n" + groovy.json.JsonOutput.prettyPrint(depFileJSON)
 		// parse dependency File JSON String as Text
 		def depFileData = slurper.parseText(depFileJSON)
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -530,6 +530,6 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 		assert depFileData."${depFileProp}" != null : "*! Missing required dependency file field '$depFileProp'"
 	}
 	// validate that depFileData.fileName == buildFile
-	assert getAbsolutePath(depFileData.fileName) == getAbsolutePath(buildFile) : "*! Dependency file mismatch: fileName does not match build file."
+	assert getAbsolutePath(depFileData.fileName) == getAbsolutePath(buildFile) : "*! Dependency file mismatch: fileName does not match build file"
 	return depFileData // return the parsed JSON object
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -77,6 +77,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 	}
 
 	if (dependencyPDS && props.userBuildDependencyFile && props.userBuild) {
+		println("User Build Dep File Present... Skipping scan and dep. resolution!")
 		// userBuildDependencyFile present (passed from the IDE)
 		// skip dependency resolution, extract dependencies from userBuildDependencyFile, and copy directly to dependencyPDS
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -66,8 +66,6 @@ def getFileSet(String dir, boolean relativePaths, String includeFileList, String
  * dependencies from USS directories to data sets
  */
 
- // , String userBuildDependencyFile)
-
 def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, DependencyResolver dependencyResolver) {
 	// only copy the build file once
 	if (!copiedFileCache.contains(buildFile)) {
@@ -78,8 +76,8 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 				.execute()
 	}
 
-	// should this be placed inside following if statement? 
-	if (dependencyPDS && props.userBuildDependencyFile) {
+	if (dependencyPDS && props.userBuildDependencyFile && props.userBuild) {
+		// userBuildDependencyFile present passed from the IDE
 		// skip dependency resolution and copy files from dependency file to dependency dataset
 		def depFilePath = props.userBuildDependencyFile
 		File depFile = new File(depFilePath)
@@ -90,21 +88,21 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 			if (!copiedFileCache.contains(dependency)) {
 				copiedFileCache.add(dependency)
 
-				//retrieve zUnitFileExtension plbck
+				// retrieve zUnitFileExtension plbck
 				zunitFileExtension = (props.zunit_playbackFileExtension) ? props.zunit_playbackFileExtension : null
 
 				// original
 				// ((physicalDependency.getFile().substring(physicalDependency.getFile().indexOf("."))).contains(zunitFileExtension))
 				// get index of last '.' in file path to extract the file extension
-				def extIndex = dependency.lastIndexOf('.');
-
+				def extIndex = dependency.lastIndexOf('.')
 				if( zunitFileExtension && !zunitFileExtension.isEmpty() && (dependency.substring(extIndex).contains(zunitFileExtension))){
 					new CopyToPDS().file(new File(dependency))
 							.copyMode(CopyMode.BINARY)
 							.dataset(dependencyPDS)
 							.member(CopyToPDS.createMemberName(dependency)) // do I need this? 
 							.execute()
-				} else
+				} 
+				else
 				{
 					new CopyToPDS().file(new File(dependency))
 							.dataset(dependencyPDS)
@@ -114,17 +112,17 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 			}
 		}
 
-		// scan the source file to obtain isMQ flags
+		// scan the source file to obtain isCICS,SQL,DLI,MQ flags
 		if (dependencyResolver) {
-			DependencyScanner scanner = dependencyResolver.getScanner();
+			DependencyScanner scanner = dependencyResolver.getScanner()
 			// get file and source Dir
-			String sourceDir = dependencyResolver.getSourceDir();
-			String sourceFile = dependencyResolver.getFile();
+			String sourceDir = dependencyResolver.getSourceDir()
+			String sourceFile = dependencyResolver.getFile()
 
 			// run manual scan to identify flags
-			LogicalFile lfile = scanner.scan(sourceFile, sourceDir);
+			LogicalFile lfile = scanner.scan(sourceFile, sourceDir)
 			// save lfile to dependency resolver
-			dependencyResolver.setLogicalFile(lfile);
+			dependencyResolver.setLogicalFile(lfile)
 		}
 
 	}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -86,7 +86,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		String depFileLoc = getAbsolutePath(depFilePath)
 		String depFileJSON = new File(depFileLoc).text // convert JSON dep file to String
 		JsonSlurper slurper = new groovy.json.JsonSlurper()
-		if (props.verbose) println "  Dependency File (${depFileLoc}): \n" + groovy.json.JsonOutput.prettyPrint(depFileJSON)
+		if (props.verbose) println "Dependency File (${depFileLoc}): \n" + groovy.json.JsonOutput.prettyPrint(depFileJSON)
 		// parse dependency File JSON String as Text
 		def depFileData = slurper.parseText(depFileJSON)
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -77,7 +77,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 	}
 
 	if (dependencyPDS && props.userBuildDependencyFile && props.userBuild) {
-		println("User Build Dep File Present... Skipping scan and dep. resolution!")
+		println("User Build Dep File Present. Skipping DBB Scan...")
 		// userBuildDependencyFile present (passed from the IDE)
 		// skip dependency resolution, extract dependencies from userBuildDependencyFile, and copy directly to dependencyPDS
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -116,7 +116,6 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 				// get index of last '.' in file path to extract the file extension
 				def extIndex = dependencyLoc.lastIndexOf('.')
 				if( zunitFileExtension && !zunitFileExtension.isEmpty() && (dependencyLoc.substring(extIndex).contains(zunitFileExtension))){
-					if (props.verbose) println "** Copying dependency ${dependencyLoc} to ${dependencyPDS}:${memberName} as BINARY"
 					new CopyToPDS().file(new File(dependencyLoc))
 							.copyMode(CopyMode.BINARY)
 							.dataset(dependencyPDS)
@@ -125,7 +124,6 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 				} 
 				else
 				{
-					if (props.verbose) println "** Copying dependency ${dependencyLoc} to ${dependencyPDS}:${memberName}"
 					new CopyToPDS().file(new File(dependencyLoc))
 							.dataset(dependencyPDS)
 							.member(memberName)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -535,7 +535,7 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 	}
 
 	// validate that depFileData.fileName == buildFile
-	assert getAbsolutePath(depFileData.fileName) == getAbsolutePath(buildFile) : "*! [ERROR] Dependency file mismatch: fileName does not match build "
+	assert getAbsolutePath(depFileData.fileName) == getAbsolutePath(buildFile) : "*! [ERROR] Dependency file mismatch: fileName does not match build file."
 
 	return depFileData // return the parsed JSON object
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -530,7 +530,7 @@ def validateDependencyFile(String depFilePath) {
 	
 	// make assertions on required fields from dependency file
 	reqDepFileProps.each { depFileProp ->
-		assert depFileData."$depFileProp" : "*! Missing required user build dependency file property '$depFilePath'.'$depFileProp'"
+		assert depFileData."$depFileProp" != null : "*! Missing required user build dependency file field '$depFileProp'"
 	}
 
 	return depFileData // return the parsed JSON object

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -88,7 +88,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		// parse JSON dependency file
 		JsonSlurper slurper = new groovy.json.JsonSlurper()
 		def depFileData = slurper.parse(depFile)
-		if (props.verbose) println "UserBuild Dependency File: \n" + depFileData
+		if (props.verbose) println "UserBuild Dependency File: \n" + depFileData.toString()
 
 		// Manually create logical file for the user build program
 		String lname = CopyToPDS.createMemberName(buildFile)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -206,7 +206,7 @@ def sortBuildList(List<String> buildList, String rankPropertyName) {
 }
 
 /*
- * updateBuildResult - used by language scripts to update the build depFileData after a build step
+ * updateBuildResult - used by language scripts to update the build result after a build step
  */
 def updateBuildResult(Map args) {
 	// args : errorMsg / warningMsg, logs[logName:logFile], client:repoClient
@@ -215,7 +215,7 @@ def updateBuildResult(Map args) {
 	if (args.client && !props.userBuild) {
 		def buildResult = args.client.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 		if (!buildResult) {
-			println "*! No build depFileData found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
+			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
 			return
 		}
 
@@ -226,7 +226,7 @@ def updateBuildResult(Map args) {
 
 		}
 
-		// add warning message, but keep depFileData status
+		// add warning message, but keep result status
 		if (args.warningMsg) {
 			// buildResult.setStatus(buildResult.WARNING)
 			buildResult.addProperty("warning", args.warningMsg)
@@ -241,7 +241,7 @@ def updateBuildResult(Map args) {
 			}
 		}
 
-		// save depFileData
+		// save result
 		buildResult.save()
 	}
 }
@@ -525,7 +525,7 @@ def validateDependencyFile(String depFilePath) {
 	// parse dependency File JSON String
 	def depFileData = slurper.parseText(depFileJSON)
 
-	// List of required fields in the user build dependnecy file:
+	// List of required fields in the user build dependency file:
 	String[] reqDepFileProps = ["fileName", "isCICS", "isSQL", "isDLI", "isMQ", "dependencies", "schemaVersion"]
 	
 	// make assertions on required fields from dependency file

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -92,7 +92,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		// Manually create logical file for the user build program
 		String lname = CopyToPDS.createMemberName(buildFile)
 		String language = props.getFileProperty('dbb.DependencyScanner.languageHint', buildFile) ?: 'UNKN'
-		LogicalFile lfile = new LogicalFile(lname, buildFile, language, depFileData.isCICS, depFileData.isSQL, depFileData.isDLI, depFileData.isMQ)
+		LogicalFile lfile = new LogicalFile(lname, buildFile, language, depFileData.isCICS, depFileData.isSQL, depFileData.isDLI)
 
 		// save logical file to dependency resolver
 		if (dependencyResolver)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -509,29 +509,29 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 		// a file level overwrite was used
 	}
 	return deployType
+}
+/*
+ * parse and validates the user build dependency file 
+ * returns a parsed json object 
+ */
+def validateDependencyFile(String depFilePath) {
+	// if depFilePath is relatvie, convert to absolute path
+	depFilePath = getAbsolutePath(depFilePath)
+	String depFileJSON = new File(depFilePath).text // convert JSON dep file to String
+	JsonSlurper slurper = new groovy.json.JsonSlurper()
+	
+	if (props.verbose) println "Dependency File (${depFilePath}): \n" + groovy.json.JsonOutput.prettyPrint(depFileJSON)
+	
+	// parse dependency File JSON String
+	def depFileData = sluper.parseText(depFileJSON)
 
-	/*
-	 * parse and validates the user build dependency file, returns a parsed json object 
-	 */
-	def validateDependencyFile(String depFilePath) {
-		// if depFilePath is relatvie, convert to absolute path
-		depFilePath = getAbsolutePath(depFilePath)
-		String depFileJSON = new File(depFilePath).text // convert JSON dep file to String
-		JsonSlurper slurper = new groovy.json.JsonSlurper()
-		
-		if (props.verbose) println "Dependency File (${depFilePath}): \n" + groovy.json.JsonOutput.prettyPrint(depFileJSON)
-		
-		// parse dependency File JSON String
-		def depFileData = sluper.parseText(depFileJSON)
-
-		// List of required fields in the user build dependnecy file:
-		String[] reqDepFileProps = ["fileName", "isCICS", "isSQL", "isDLI", "isMQ", "dependencies", "schemaVersion"]
-		
-		// make assertions on required fields from dependency file
-		reqDepFileProps.each { depFileProp ->
-			assert depFileData."$depFileProp" : "*! Missing required user build dependency file property '$depFilePath'.'$depFileProp'"
-		}
-
-		return depFileData // return the parsed JSON object
+	// List of required fields in the user build dependnecy file:
+	String[] reqDepFileProps = ["fileName", "isCICS", "isSQL", "isDLI", "isMQ", "dependencies", "schemaVersion"]
+	
+	// make assertions on required fields from dependency file
+	reqDepFileProps.each { depFileProp ->
+		assert depFileData."$depFileProp" : "*! Missing required user build dependency file property '$depFilePath'.'$depFileProp'"
 	}
+
+	return depFileData // return the parsed JSON object
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -157,7 +157,6 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 					zunitFileExtension = (props.zunit_playbackFileExtension) ? props.zunit_playbackFileExtension : null
 
 					if( zunitFileExtension && !zunitFileExtension.isEmpty() && ((physicalDependency.getFile().substring(physicalDependency.getFile().indexOf("."))).contains(zunitFileExtension))){
-						if (props.verbose) println "** Copying dependency ${physicalDependencyLoc} to ${dependencyPDS}:${memberName} as BINARY"
 						new CopyToPDS().file(new File(physicalDependencyLoc))
 								.copyMode(CopyMode.BINARY)
 								.dataset(dependencyPDS)
@@ -165,7 +164,6 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 								.execute()
 					} else
 					{
-						if (props.verbose) println "** Copying dependency ${physicalDependencyLoc} to ${dependencyPDS}:${memberName}"
 						new CopyToPDS().file(new File(physicalDependencyLoc))
 								.dataset(dependencyPDS)
 								.member(memberName)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -259,12 +259,14 @@ def updateBuildResult(Map args) {
 def createDependencyResolver(String buildFile, String rules) {
 	if (props.verbose) println "*** Creating dependency resolver for $buildFile with $rules rules"
 
-	def scanner = getScanner(buildFile)
-
 	// create a dependency resolver for the build file
 	DependencyResolver resolver = new DependencyResolver().file(buildFile)
 			.sourceDir(props.workspace)
-			.scanner(scanner)
+	
+	// add scanner if userBuild Dep File not provided, or not a user build
+	if (!props.userBuildDependencyFile || !props.userBuild)
+		resolver.setScanner(getScanner(buildFile))
+
 	// add resolution rules
 	if (rules)
 		resolver.setResolutionRules(parseResolutionRules(rules))

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -518,24 +518,18 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 	// if depFilePath is relatvie, convert to absolute path
 	depFilePath = getAbsolutePath(depFilePath)
 	File depFile = new File(depFilePath)
-	assert depFile.exists() : "*! [ERROR] Dependency file not found: ${depFilePath}"
+	assert depFile.exists() : "*! Dependency file not found: ${depFilePath}"
 	JsonSlurper slurper = new groovy.json.JsonSlurper()
-	
 	if (props.verbose) println "Dependency File (${depFilePath}): \n" + groovy.json.JsonOutput.prettyPrint(depFile.getText())
-	
-	// parse dependency File JSON String
+	// parse dependency File
 	def depFileData = slurper.parse(depFile)
 
-	// List of required fields in the user build dependency file:
+	/* Begin Validation */ 
 	String[] reqDepFileProps = ["fileName", "isCICS", "isSQL", "isDLI", "isMQ", "dependencies", "schemaVersion"]
-	
-	// make assertions on required fields from dependency file
 	reqDepFileProps.each { depFileProp ->
-		assert depFileData."${depFileProp}" != null : "*! [ERROR] Missing required dependency file field '$depFileProp'"
+		assert depFileData."${depFileProp}" != null : "*! Missing required dependency file field '$depFileProp'"
 	}
-
 	// validate that depFileData.fileName == buildFile
-	assert getAbsolutePath(depFileData.fileName) == getAbsolutePath(buildFile) : "*! [ERROR] Dependency file mismatch: fileName does not match build file."
-
+	assert getAbsolutePath(depFileData.fileName) == getAbsolutePath(buildFile) : "*! Dependency file mismatch: fileName does not match build file."
 	return depFileData // return the parsed JSON object
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -523,7 +523,7 @@ def validateDependencyFile(String depFilePath) {
 	if (props.verbose) println "Dependency File (${depFilePath}): \n" + groovy.json.JsonOutput.prettyPrint(depFileJSON)
 	
 	// parse dependency File JSON String
-	def depFileData = sluper.parseText(depFileJSON)
+	def depFileData = slurper.parseText(depFileJSON)
 
 	// List of required fields in the user build dependnecy file:
 	String[] reqDepFileProps = ["fileName", "isCICS", "isSQL", "isDLI", "isMQ", "dependencies", "schemaVersion"]

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -530,7 +530,7 @@ def validateDependencyFile(String depFilePath) {
 	
 	// make assertions on required fields from dependency file
 	reqDepFileProps.each { depFileProp ->
-		assert depFileData.${depFileProp} != null : "*! Missing required user build dependency file field '$depFileProp'"
+		assert depFileData."${depFileProp}" != null : "*! Missing required user build dependency file field '$depFileProp'"
 	}
 
 	return depFileData // return the parsed JSON object

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -83,7 +83,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		File depFile = new File(depFilePath)
 
 		JsonSlurper slurper = new groovy.json.JsonSlurper()
-		def uBuildJson = slurper.parse(depFile)
+		def depFileData = slurper.parse(depFile)
 
 		// Create logical file name
 		String lname = CopyToPDS.createMemberName(buildFile)
@@ -92,14 +92,14 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		String language = props.getFileProperty('dbb.DependencyScanner.languageHint', buildFile) ?: 'UNKN'
 
 		// create logical file
-		LogicalFile lfile = new LogicalFile(lname, buildFile, language, uBuildJson.isCICS, uBuildJson.isSQL, uBuildJson.isDLI, uBuildJson.isMQ)
+		LogicalFile lfile = new LogicalFile(lname, buildFile, language, depFileData.isCICS, depFileData.isSQL, depFileData.isDLI, depFileData.isMQ)
 
 		// save logical file to dependency resolver
 		if (dependencyResolver)
 			dependencyResolver.setLogicalFile(lfile)
 
  		// get list of dependencies from userBuildDependencyFile
-		List<String> dependencies = uBuildJson.dependencies
+		List<String> dependencies = depFileData.dependencies
 		
 		// copy each dependency from USS to member of depedencyPDS
 		dependencies.each { dependency ->
@@ -225,7 +225,7 @@ def sortBuildList(List<String> buildList, String rankPropertyName) {
 }
 
 /*
- * updateBuildResult - used by language scripts to update the build uBuildJson after a build step
+ * updateBuildResult - used by language scripts to update the build depFileData after a build step
  */
 def updateBuildResult(Map args) {
 	// args : errorMsg / warningMsg, logs[logName:logFile], client:repoClient
@@ -234,7 +234,7 @@ def updateBuildResult(Map args) {
 	if (args.client && !props.userBuild) {
 		def buildResult = args.client.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 		if (!buildResult) {
-			println "*! No build uBuildJson found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
+			println "*! No build depFileData found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
 			return
 		}
 
@@ -245,7 +245,7 @@ def updateBuildResult(Map args) {
 
 		}
 
-		// add warning message, but keep uBuildJson status
+		// add warning message, but keep depFileData status
 		if (args.warningMsg) {
 			// buildResult.setStatus(buildResult.WARNING)
 			buildResult.addProperty("warning", args.warningMsg)
@@ -260,7 +260,7 @@ def updateBuildResult(Map args) {
 			}
 		}
 
-		// save uBuildJson
+		// save depFileData
 		buildResult.save()
 	}
 }


### PR DESCRIPTION
Update zAppBuild to support IDE passed dependency information

In order to increase performance of User Build running on ZD&T, the IDEs can optionally pass dependency information about the program being built to zAppBuild allowing it to skip running dependency resolution which depending on the size and number of build dependencies the program references can be time consuming on ZD&T platforms.
**Requires IDz version 15.0.3**
**Requires IBM Z Open Editor version 1.4.0**

Note: Backwards (user build) compatibility of IDz and Z Open Editor is maintained. zAppBuild will function the same as previously if no --dependencyFile option is passed. 


Changes Made:
- Added -df (--dependencyFile) option to build.groovy which accepts 1 argument, the Absolute or relative (from workspace) path to user build JSON file containing dependency information
- Updated BuildUtilities.copySourceFiles() to, if a user build dependency file is provided, skip dependency resolution and scan by reading dependency and program information from the dependency file uploaded by the IDE. 
- If User Build Dep file is provided, the JSON file is validated for required fields: BuildUtilities.validateDependencyFile()
- If no dependency file is provided (and thus no -df option is passed to build.groovy), then zApp will revert to traditional scan and dependency resolution just as it did previously.  
