### PR TITLE
Document Db2 Bind configuration in DBB build report

### DIFF
--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -43,6 +43,7 @@ impactBuildOnBuildPropertyChanges | Boolean property to activate impact builds o
 impactBuildOnBuildPropertyList | List of build property lists referencing which language properties should cause an impact build when the given property is changed 
 continueOnScanFailure | Determine the behavior when facing a scanner failure. true (default) to continue scanning. false will terminate the process. 
 createBuildOutputSubfolder | Option to create a subfolder with the build label within the build output dir (outDir). Default: true. 
+generateDb2BindInfoRecord | Flag to control the generation of a generic DBB build record for a build file to document the configured db2 bind information (application-conf/bind.properties). Default: false ** Can be overridden by a file property. 
 dbb.file.tagging | Controls compile log and build report file tagging. Default: true.
 dbb.LinkEditScanner.excludeFilter | DBB configuration property used by the link edit scanner to exclude load module entries
 dbb.RepositoryClient.url | DBB configuration property for web application URL.  ***Can be overridden by build.groovy option -url, --url***

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -70,8 +70,12 @@ createTestcaseDependency=false
 # to document the configured db2 bind information (application-conf/bind.properties) .
 # This allows to pass the information into the packaging step and on to your deployment manager, like UCD.
 # Implemented in Assembler.groovy, Cobol.groovy and PLI.groovy
+# See also generateDb2BindInfoRecordProperties for the list of properties which are documented
 # Default: false
 generateDb2BindInfoRecord=false
+
+# generateDb2BindInfoRecordProperties is a comma-separated list of existing bind parameters configured to zAppBuild.
+generateDb2BindInfoRecordProperties=bind_collectionID,bind_packageOwner,bind_qualifier
 
 # dbb.file.tagging controls compile log and build report file tagging. If true, files
 # written as UTF-8 or ASCII are tagged.

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -67,7 +67,7 @@ impactBuildOnBuildPropertyList=[${assembler_impactPropertyList},${assembler_impa
 createTestcaseDependency=false
 
 # generateDb2BindInfoRecord controls if zAppBuild generates a generic DBB build record for a build file
-# to document the configured db2 bind information (application-conf/bind.properties) .
+# to document the configured db2 bind options (application-conf/bind.properties) .
 # This allows to pass the information into the packaging step and on to your deployment manager, like UCD.
 # Implemented in Assembler.groovy, Cobol.groovy and PLI.groovy
 # See also generateDb2BindInfoRecordProperties for the list of properties which are documented
@@ -75,6 +75,7 @@ createTestcaseDependency=false
 generateDb2BindInfoRecord=false
 
 # generateDb2BindInfoRecordProperties is a comma-separated list of existing bind parameters configured to zAppBuild.
+# See application-conf/bind.properties for available properties.
 generateDb2BindInfoRecordProperties=bind_collectionID,bind_packageOwner,bind_qualifier
 
 # dbb.file.tagging controls compile log and build report file tagging. If true, files

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -66,6 +66,13 @@ impactBuildOnBuildPropertyList=[${assembler_impactPropertyList},${assembler_impa
 # Default: false
 createTestcaseDependency=false
 
+# generateDb2BindInfoRecord controls if zAppBuild generates a generic DBB build record for a build file
+# to document the configured db2 bind information (application-conf/bind.properties) .
+# This allows to pass the information into the packaging step and on to your deployment manager, like UCD.
+# Implemented in Assembler.groovy, Cobol.groovy and PLI.groovy
+# Default: false
+generateDb2BindInfoRecord=false
+
 # dbb.file.tagging controls compile log and build report file tagging. If true, files
 # written as UTF-8 or ASCII are tagged.
 # If the environment variable _BPXK_AUTOCVT is set ALL, file tagging may have an

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -3,6 +3,8 @@ import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
+import com.ibm.dbb.build.report.*
+import com.ibm.dbb.build.report.records.*
 
 
 // define script properties

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -60,6 +60,13 @@ sortedList.each { buildFile ->
 			println(errorMsg)
 			props.error = "true"
 			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+		} else {
+			// Store db2 bind information as a generic property record in the BuildReport
+			String generateDb2BindInfoRecord = props.getFileProperty('generateDb2BindInfoRecord', buildFile)
+			if (generateDb2BindInfoRecord.toBoolean()){
+				PropertiesRecord db2BindInfoRecord = buildUtils.generateDb2InfoRecord(buildFile)
+				BuildReportFactory.getBuildReport().addRecord(db2BindInfoRecord)
+			}
 		}
 	}
 

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -4,6 +4,8 @@ import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
 import com.ibm.jzos.ZFile
+import com.ibm.dbb.build.report.*
+import com.ibm.dbb.build.report.records.*
 
 
 // define script properties

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -71,8 +71,15 @@ sortedList.each { buildFile ->
 		props.error = "true"
 		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
 	}
-	else {
-		// if this program needs to be link edited . . .
+	else { // if this program needs to be link edited . . .
+		
+		// Store db2 bind information as a generic property record in the BuildReport
+		String generateDb2BindInfoRecord = props.getFileProperty('generateDb2BindInfoRecord', buildFile)
+		if (buildUtils.isSQL(logicalFile) && generateDb2BindInfoRecord.toBoolean() ){
+			PropertiesRecord db2BindInfoRecord = buildUtils.generateDb2InfoRecord(buildFile)
+			BuildReportFactory.getBuildReport().addRecord(db2BindInfoRecord)
+		}
+		
 		String needsLinking = props.getFileProperty('cobol_linkEdit', buildFile)
 		if (needsLinking.toBoolean()) {
 			rc = linkEdit.execute()

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -4,6 +4,8 @@ import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
 import com.ibm.jzos.ZFile
+import com.ibm.dbb.build.report.*
+import com.ibm.dbb.build.report.records.*
 
 
 // define script properties

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -58,6 +58,14 @@ sortedList.each { buildFile ->
 	}
 	else {
 		// if this program needs to be link edited . . .
+
+		// Store db2 bind information as a generic property record in the BuildReport
+		String generateDb2BindInfoRecord = props.getFileProperty('generateDb2BindInfoRecord', buildFile)
+		if (buildUtils.isSQL(logicalFile) && generateDb2BindInfoRecord.toBoolean() ){
+			PropertiesRecord db2BindInfoRecord = buildUtils.generateDb2InfoRecord(buildFile)
+			BuildReportFactory.getBuildReport().addRecord(db2BindInfoRecord)
+		}
+
 		String needsLinking = props.getFileProperty('pli_linkEdit', buildFile)
 		if (needsLinking.toBoolean()) {
 			rc = linkEdit.execute()

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -457,3 +457,22 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 	}
 	return deployType
 }
+
+/*
+ * Creates a Generic PropertyRecord with the provided db2 information in bind.properties
+ */
+def generateDb2InfoRecord(String buildFile){
+	
+	// New Generic Property Record
+	PropertiesRecord db2BindInfo = new PropertiesRecord("db2BindInfo:${buildFile}")
+	
+	// Link to buildFile
+	db2BindInfo.addProperty("file", buildFile)
+	
+	// Add all properties, which are defined for bind - see application-conf/bind.properties 
+	db2BindInfo.addProperty("bind_collectionID",props.getFileProperty("bind_collectionID",props.getFileProperty))
+	db2BindInfo.addProperty("bind_packageOwner",props.getFileProperty("bind_packageOwner",props.getFileProperty))
+	db2BindInfo.addProperty("bind_qualifier",props.getFileProperty("bind_qualifier",props.getFileProperty))
+	
+	return db2BindInfo		
+}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -5,6 +5,7 @@ import com.ibm.dbb.build.*
 import groovy.transform.*
 import groovy.json.JsonSlurper
 import com.ibm.dbb.build.DBBConstants.CopyMode
+import com.ibm.dbb.build.report.records.*
 
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -471,11 +471,13 @@ def generateDb2InfoRecord(String buildFile){
 	db2BindInfo.addProperty("file", buildFile)
 
 	// Iterate over list of Db2InfoRecord properties
-	String[] generateDb2InfoRecordPropertiesList = props.getFileProperty("generateDb2InfoRecordProperties", buildFile).split(',')
-	generateDb2InfoRecordPropertiesList.each { db2Prop ->
-		// Add all properties, which are defined for bind - see application-conf/bind.properties
-		String bindPropertyValue = props.getFileProperty("${db2Prop}", buildFile)
-		if (bindPropertyValue != null ) db2BindInfo.addProperty("${db2Prop}",bindPropertyValue)
+	if (props.generateDb2BindInfoRecordProperties) {
+		String[] generateDb2InfoRecordPropertiesList = props.getFileProperty("generateDb2BindInfoRecordProperties", buildFile).split(',')
+		generateDb2InfoRecordPropertiesList.each { db2Prop ->
+			// Add all properties, which are defined for bind - see application-conf/bind.properties
+			String bindPropertyValue = props.getFileProperty("${db2Prop}", buildFile)
+			if (bindPropertyValue != null ) db2BindInfo.addProperty("${db2Prop}",bindPropertyValue)
+		}
 	}
 		
 	return db2BindInfo		

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -469,11 +469,14 @@ def generateDb2InfoRecord(String buildFile){
 	
 	// Link to buildFile
 	db2BindInfo.addProperty("file", buildFile)
-	
-	// Add all properties, which are defined for bind - see application-conf/bind.properties 
-	db2BindInfo.addProperty("bind_collectionID",props.getFileProperty("bind_collectionID",props.getFileProperty))
-	db2BindInfo.addProperty("bind_packageOwner",props.getFileProperty("bind_packageOwner",props.getFileProperty))
-	db2BindInfo.addProperty("bind_qualifier",props.getFileProperty("bind_qualifier",props.getFileProperty))
-	
+
+	// Iterate over list of Db2InfoRecord properties
+	String[] generateDb2InfoRecordPropertiesList = props.getFileProperty("generateDb2InfoRecordProperties", buildFile).split(',')
+	generateDb2InfoRecordPropertiesList.each { db2Prop ->
+		// Add all properties, which are defined for bind - see application-conf/bind.properties
+		String bindPropertyValue = props.getFileProperty("${db2Prop}", buildFile)
+		if (bindPropertyValue != null ) db2BindInfo.addProperty("${db2Prop}",bindPropertyValue)
+	}
+		
 	return db2BindInfo		
 }


### PR DESCRIPTION
zAppBuild allows to define Db2 bind property information in the `bind.properties` file (managed within application-conf of the application). 

For subsequent steps in the pipeline, it is beneficial to pass on this information and avoid to manage it in multiple areas. You can, for example, leverage these in your deployment process and deployment manager like UrbanCode Deploy.

If activated, this enhancement creates a generic DBB build report record to store the configured db2 bind options. Sample: 

![image](https://user-images.githubusercontent.com/28918869/139212658-436515fa-0a7e-4585-8fc2-809c172923c9.png)
 
This enhancement allows to store configuration as code in your version control system and pass on the information to the next steps in the pipeline.

You can activate the feature using the flag `generateDb2BindInfoRecord`. `generateDb2BindInfoRecordProperties` contains a comma-separated list of bind parameters, which should stored in the dbb build report record.

The `dbb-ucd-packaging.groovy` sample script already processes these information today and stores these as properties for the DBRM member which are then available in the bind step : (see https://github.com/IBM/dbb/blob/master/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy#L166-L179) 