### PR TITLE
Fix impact build on build property changes

### DIFF
--- a/test/applications/MortgageApplication/application-conf/Cobol.properties
+++ b/test/applications/MortgageApplication/application-conf/Cobol.properties
@@ -1,0 +1,85 @@
+# Application properties used by zAppBuild/language/Cobol.groovy
+
+#
+# default COBOL program build rank - used to sort language build file list
+# leave empty - overridden by file properties if sorting needed
+cobol_fileBuildRank=
+
+#
+# COBOL dependency resolution rules
+# Rules defined in application.properties
+cobol_resolutionRules=[${copybookRule}]
+
+#
+# default COBOL compiler version
+# can be overridden by file properties
+cobol_compilerVersion=V6
+
+#
+# default COBOL maximum RCs allowed
+# can be overridden by file properties
+cobol_compileMaxRC=4
+cobol_linkEditMaxRC=4
+
+#
+# lists of properties which should cause a rebuild after being changed
+cobol_impactPropertyList=cobol_compilerVersion,cobol_compileParms
+cobol_impactPropertyListCICS=cobol_compileCICSParms
+cobol_impactPropertyListSQL=cobol_compileSQLParms
+
+#
+# default COBOL compiler parameters
+# can be overridden by file properties
+cobol_compileParms=LIB,LIST
+cobol_compileCICSParms=CICS
+cobol_compileSQLParms=SQL
+cobol_compileErrorPrefixParms=ADATA,EX(ADX(ELAXMGUX))
+
+# Compile Options for IBM Debugger. Assuming to keep Dwarf Files inside the load.
+# If you would like to separate debug info, additional allocations needed (See COBOL + Debugger libraries)
+cobol_compileDebugParms=TEST
+
+#
+# default LinkEdit parameters
+# can be overridden by file properties
+cobol_linkEditParms=MAP,RENT,COMPAT(PM5)
+
+# If you would like to have a physical link card, we generated it for you given the below pattern
+# This property has priority over cobol_linkDebugExit
+# cobol_linkEditStream=    INCLUDE OBJECT(@{member})
+cobol_linkEditStream=
+
+# If using a debug exit, provide the SYSLIN instream DD
+# Samp: cobol_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
+cobol_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
+
+
+#
+# execute link edit step
+# can be overridden by file properties
+cobol_linkEdit=true
+
+#
+# default deployType
+cobol_deployType=LOAD
+
+#
+# default deployType
+cobol_deployTypeCICS=CICSLOAD
+
+#
+# default deployType
+cobol_deployTypeDLI=IMSLOAD
+
+#
+# scan link edit load module for link dependencies
+# can be overridden by file properties
+cobol_scanLoadModule=true
+
+#
+# additional libraries for compile SYSLIB concatenation, comma-separated
+cobol_compileSyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+cobol_linkEditSyslibConcatenation=

--- a/test/applications/MortgageApplication/build-conf/impactPropertyChanges.properties
+++ b/test/applications/MortgageApplication/build-conf/impactPropertyChanges.properties
@@ -1,0 +1,1 @@
+impactBuildOnBuildPropertyChanges=true

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,impactBuild_properties.groovy,resetBuild.groovy
+test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_properties.groovy,impactBuild_renaming.groovy,resetBuild.groovy
 
 
 #############################

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -48,8 +48,10 @@ impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MF
 ###############################
 # impactBuild_properties.groovy properties
 ###############################
-# list of changed source files to test impact builds
-impactBuild_properties_changedFiles = application-conf/Cobol.properties
+# changed source files to test impact builds
+impactBuild_properties_changedFile = application-conf/Cobol.properties
+# build properties file source files to test impact builds
+impactBuild_properties_buildPropSetting = build-conf/impactPropertyChanges.properties
 # Use file properties to associate expected files built for a changed build property
 impactBuild_properties_expectedFilesBuilt = epscmort.cbl,epscsmrd.cbl,epscsmrt.cbl,epsmlist.cbl,epsmpmt.cbl,epsnbrvl.cbl :: application-conf/Cobol.properties
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,resetBuild.groovy
+test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,impactBuild_properties.groovy,resetBuild.groovy
 
 
 #############################
@@ -45,3 +45,12 @@ impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: cobol/epscsmrt.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 
+###############################
+# impactBuild_properties.groovy properties
+###############################
+# list of changed source files to test impact builds
+impactBuild_properties_changedFiles = application-conf/Cobol.properties
+# Use file properties to associate expected files built for a changed build property
+impactBuild_properties_expectedFilesBuilt = epscmort.cbl,epscsmrd.cbl,epscsmrt.cbl,epsmlist.cbl,epsmpmt.cbl,epsnbrvl.cbl :: application-conf/Cobol.properties
+# list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
+impactBuild_properties_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -78,9 +78,9 @@ finally {
 	cleanUpDatasets()
 	if (assertionList.size()>0) {
 		println "\n***"
-	println "**START OF FAILED IMPACT BUILD TEST RESULTS**\n"
-	println "*FAILED IMPACT BUILD TEST RESULTS*\n" + assertionList
-	println "\n**END OF FAILED IMPACT BUILD TEST RESULTS**"
+	println "**START OF FAILED IMPACT BUILD ON PROPERTY CHANGE TEST RESULTS**\n"
+	println "*FAILED IMPACT BUILD ON PROPERT CHANGE TEST  RESULTS*\n" + assertionList
+	println "\n**END OF FAILED IMPACT BUILD ON PROPERTY CHANGE TEST RESULTS**"
 	println "***"
   }
 }

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -68,8 +68,8 @@ try {
 		
 		// run impact build
 		println "** Executing ${impactBuildCommand.join(" ")}"
-		def outputStream = new StringBuffer()
-		def process = ['bash', '-c', impactBuildCommand.join(" ")].execute()
+		outputStream = new StringBuffer()
+		process = ['bash', '-c', impactBuildCommand.join(" ")].execute()
 		process.waitForProcessOutput(outputStream, System.err)
 		
 		// validate build results

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -110,14 +110,14 @@ def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings,
 	
 	try{
 	// Validate clean build
-	assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $changedFile\nOUTPUT STREAM:\n$outputStream\n"
+	assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY $changedFile\nOUTPUT STREAM:\n$outputStream\n"
 
 	// Validate expected number of files built
 	def numImpactFiles = expectedFilesBuiltList.size()
-	assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FOR $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
+	assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY  $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
 
 	// Validate expected built files in output stream
-	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD PROPERTY CHANGE $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
 	
 	println "**"
 	println "** IMPACT BUILD ON PROPERTY CHANGE : PASSED FOR $changedFile **"

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -1,0 +1,144 @@
+
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+import com.ibm.dbb.*
+import com.ibm.dbb.build.*
+import com.ibm.jzos.ZFile
+
+@Field BuildProperties props = BuildProperties.getInstance()
+println "\n** Executing test script impactBuild.groovy"
+
+// Get the DBB_HOME location
+def dbbHome = EnvVars.getHome()
+if (props.verbose) println "** DBB_HOME = ${dbbHome}"
+
+// Create full build command to initilize property dependencies
+def fullBuildCommand = []
+fullBuildCommand << "${dbbHome}/bin/groovyz"
+fullBuildCommand << "${props.zAppBuildDir}/build.groovy"
+fullBuildCommand << "--workspace ${props.workspace}"
+fullBuildCommand << "--application ${props.app}"
+fullBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+fullBuildCommand << "--hlq ${props.hlq}"
+fullBuildCommand << "--logEncoding UTF-8"
+fullBuildCommand << "--url ${props.url}"
+fullBuildCommand << "--id ${props.id}"
+fullBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+fullBuildCommand << (props.verbose ? "--verbose" : "")
+fullBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile},${props.propFiles}" : "")
+fullBuildCommand << "--fullBuild"
+
+// create impact build command
+def impactBuildCommand = []
+impactBuildCommand << "${dbbHome}/bin/groovyz"
+impactBuildCommand << "${props.zAppBuildDir}/build.groovy"
+impactBuildCommand << "--workspace ${props.workspace}"
+impactBuildCommand << "--application ${props.app}"
+impactBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+impactBuildCommand << "--hlq ${props.hlq}"
+impactBuildCommand << "--logEncoding UTF-8"
+impactBuildCommand << "--url ${props.url}"
+impactBuildCommand << "--id ${props.id}"
+impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+impactBuildCommand << (props.verbose ? "--verbose" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile},${props.propFiles}" : "")
+impactBuildCommand << "--impactBuild"
+
+// iterate through change files to test impact build
+@Field def assertionList = []
+PropertyMappings filesBuiltMappings = new PropertyMappings('impactBuild_expectedFilesBuilt')
+def changedPropFile = props.impactBuild_properties_changedFiles
+println("** Processing changed files from impactBuild_changedFiles property : ${props.impactBuild_changedFiles}")
+try {
+	changedFiles.each { changedFile ->
+		
+		println "\n** Running build to set baseline"
+				
+		// run impact build
+		println "** Executing ${fullBuildCommand.join(" ")}"
+		def outputStream = new StringBuffer()
+		def process = ['bash', '-c', fullBuildCommand.join(" ")].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+		
+		
+		println "\n** Running impact build test for changed file $changedPropFile"
+		
+		// update changed file in Git repo test branch
+		copyAndCommit(changedPropFile)
+		
+		// run impact build
+		println "** Executing ${impactBuildCommand.join(" ")}"
+		def outputStream = new StringBuffer()
+		def process = ['bash', '-c', impactBuildCommand.join(" ")].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+		
+		// validate build results
+		validateImpactBuild(changedPropFile, filesBuiltMappings, outputStream)
+	}
+}
+finally {
+	cleanUpDatasets()
+	if (assertionList.size()>0) {
+		println "\n***"
+	println "**START OF FAILED IMPACT BUILD TEST RESULTS**\n"
+	println "*FAILED IMPACT BUILD TEST RESULTS*\n" + assertionList
+	println "\n**END OF FAILED IMPACT BUILD TEST RESULTS**"
+	println "***"
+  }
+}
+// script end
+
+//*************************************************************
+// Method Definitions
+//*************************************************************
+
+def copyAndCommit(String changedFile) {
+	println "** Copying and committing ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} to ${props.appLocation}/${changedFile}"
+	def commands = """
+	cp ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} ${props.appLocation}/${changedFile}
+	cd ${props.appLocation}/
+	git add .
+	git commit . -m "edited program file"
+"""
+	def task = ['bash', '-c', commands].execute()
+	def outputStream = new StringBuffer();
+	task.waitForProcessOutput(outputStream, System.err)
+}
+
+def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
+
+	println "** Validating impact build results"
+	def expectedFilesBuiltList = filesBuiltMappings.getValue(changedFile).split(',')
+	
+	try{
+	// Validate clean build
+	assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $changedFile\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected number of files built
+	def numImpactFiles = expectedFilesBuiltList.size()
+	assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FOR $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected built files in output stream
+	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD PROPERTY CHANGE $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+	
+	println "**"
+	println "** IMPACT BUILD PROPERTY CHANGE : PASSED FOR $changedFile **"
+	println "**"
+	}
+	catch(AssertionError e) {
+		def result = e.getMessage()
+		assertionList << result;
+ }
+}
+def cleanUpDatasets() {
+	def segments = props.impactBuild_properties_datasetsToCleanUp.split(',')
+	
+	println "Deleting impact build PDSEs ${segments}"
+	segments.each { segment ->
+		def pds = "'${props.hlq}.${segment}'"
+		if (ZFile.dsExists(pds)) {
+		   if (props.verbose) println "** Deleting ${pds}"
+		   ZFile.remove("//$pds")
+		}
+	}
+}

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -25,7 +25,7 @@ fullBuildCommand << "--url ${props.url}"
 fullBuildCommand << "--id ${props.id}"
 fullBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 fullBuildCommand << (props.verbose ? "--verbose" : "")
-fullBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
+fullBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
 fullBuildCommand << "--fullBuild"
 
 // create impact build command
@@ -41,7 +41,7 @@ impactBuildCommand << "--url ${props.url}"
 impactBuildCommand << "--id ${props.id}"
 impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 impactBuildCommand << (props.verbose ? "--verbose" : "")
-impactBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
 impactBuildCommand << "--impactBuild"
 
 // iterate through change files to test impact build

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -46,7 +46,7 @@ impactBuildCommand << "--impactBuild"
 
 // iterate through change files to test impact build
 @Field def assertionList = []
-PropertyMappings filesBuiltMappings = new PropertyMappings('impactBuild_expectedFilesBuilt')
+PropertyMappings filesBuiltMappings = new PropertyMappings('impactBuild_properties_expectedFilesBuilt')
 def changedPropFile = props.impactBuild_properties_changedFile
 println("** Processing changed files from impactBuild_properties_changedFiles property : ${changedPropFile}")
 try {
@@ -106,6 +106,8 @@ def copyAndCommit(String changedFile) {
 def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
 
 	println "** Validating impact build results"
+	println changedFile
+	println filesBuiltMappings
 	def expectedFilesBuiltList = filesBuiltMappings.getValue(changedFile).split(',')
 	
 	try{
@@ -120,7 +122,7 @@ def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings,
 	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD PROPERTY CHANGE $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
 	
 	println "**"
-	println "** IMPACT BUILD PROPERTY CHANGE : PASSED FOR $changedFile **"
+	println "** IMPACT BUILD ON PROPERTY CHANGE : PASSED FOR $changedFile **"
 	println "**"
 	}
 	catch(AssertionError e) {

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -6,7 +6,7 @@ import com.ibm.dbb.build.*
 import com.ibm.jzos.ZFile
 
 @Field BuildProperties props = BuildProperties.getInstance()
-println "\n** Executing test script impactBuild.groovy"
+println "\n** Executing test script impactBuild_properties.groovy"
 
 // Get the DBB_HOME location
 def dbbHome = EnvVars.getHome()
@@ -25,7 +25,7 @@ fullBuildCommand << "--url ${props.url}"
 fullBuildCommand << "--id ${props.id}"
 fullBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 fullBuildCommand << (props.verbose ? "--verbose" : "")
-fullBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile},${props.propFiles}" : "")
+fullBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
 fullBuildCommand << "--fullBuild"
 
 // create impact build command
@@ -41,7 +41,7 @@ impactBuildCommand << "--url ${props.url}"
 impactBuildCommand << "--id ${props.id}"
 impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 impactBuildCommand << (props.verbose ? "--verbose" : "")
-impactBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile},${props.propFiles}" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
 impactBuildCommand << "--impactBuild"
 
 // iterate through change files to test impact build

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -50,7 +50,6 @@ PropertyMappings filesBuiltMappings = new PropertyMappings('impactBuild_expected
 def changedPropFile = props.impactBuild_properties_changedFiles
 println("** Processing changed files from impactBuild_changedFiles property : ${props.impactBuild_changedFiles}")
 try {
-	changedFiles.each { changedFile ->
 		
 		println "\n** Running build to set baseline"
 				
@@ -74,7 +73,6 @@ try {
 		
 		// validate build results
 		validateImpactBuild(changedPropFile, filesBuiltMappings, outputStream)
-	}
 }
 finally {
 	cleanUpDatasets()

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -106,8 +106,6 @@ def copyAndCommit(String changedFile) {
 def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
 
 	println "** Validating impact build results"
-	println changedFile
-	println filesBuiltMappings
 	def expectedFilesBuiltList = filesBuiltMappings.getValue(changedFile).split(',')
 	
 	try{

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -6,7 +6,7 @@ import com.ibm.dbb.build.*
 import com.ibm.jzos.ZFile
 
 @Field BuildProperties props = BuildProperties.getInstance()
-println "\n** Executing test script impactBuild_properties.groovy"
+println "\n### Executing test script impactBuild_properties.groovy"
 
 // Get the DBB_HOME location
 def dbbHome = EnvVars.getHome()
@@ -47,8 +47,8 @@ impactBuildCommand << "--impactBuild"
 // iterate through change files to test impact build
 @Field def assertionList = []
 PropertyMappings filesBuiltMappings = new PropertyMappings('impactBuild_expectedFilesBuilt')
-def changedPropFile = props.impactBuild_properties_changedFiles
-println("** Processing changed files from impactBuild_changedFiles property : ${props.impactBuild_changedFiles}")
+def changedPropFile = props.impactBuild_properties_changedFile
+println("** Processing changed files from impactBuild_properties_changedFiles property : ${changedPropFile}")
 try {
 		
 		println "\n** Running build to set baseline"

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -91,7 +91,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 	}
 
 	// Perform impact analysis for property changes
-	if (props.impactBuildOnBuildPropertyChanges){
+	if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean()){
 		if (props.verbose) println "*** Perform impacted analysis for property changes."
 
 		changedBuildProperties.each { changedProp ->
@@ -250,7 +250,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 					if (props.verbose) println "**** $file"
 				}
 				//retrieving changed build properties
-				if (props.impactBuildOnBuildPropertyChanges && file.endsWith(".properties")){
+				if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean() && file.endsWith(".properties")){
 					if (props.verbose) println "**** $file"
 					String gitDir = new File(buildUtils.getAbsolutePath(file)).getParent()
 					String pFile =  new File(buildUtils.getAbsolutePath(file)).getName()


### PR DESCRIPTION
Minor cosmetic fix to properly validate if the the impact analysis calculation for changed build properties should be invoked. It was correctly handled when updating the collections, so this defect had no impact on the functionality of zAppBuild and this specific feature.

Contributions:
* Proper validation of the build property `impactBuildOnBuildPropertyChanges`
* Added a new test case for changed build properties to the zAppBuild test framework

See also #147 