### PR TITLE
Printout and validation of the DBB Toolkit version in use

### DIFF
--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -38,6 +38,7 @@ buildPropFiles | Comma separated list of additional build property files to load
 buildListFileExt | File extension that indicates the build file is really a build list.
 languagePropertyQualifiers | List of language script property qualifiers. Each language script property has a unique qualifier to avoid collision with other language script properties.
 applicationConfRootDir | Alternate root directory for application-conf location.  Allows for the deployment of the application-conf directories to a static location.  Defaults to ${workspace}/${application}
+requiredDBBToolkitVersion | Minimum required DBB ToolkitVersion to run this version of zAppBuild.
 requiredBuildProperties | Comma separated list of required build properties for zAppBuild/build.groovy. Build and language scripts will validate that *required* build properties have been set before the script runs.  If any are missing or empty, then a validation error will be thrown.
 impactBuildOnBuildPropertyChanges | Boolean property to activate impact builds on changes of build properties within the application repository
 impactBuildOnBuildPropertyList | List of build property lists referencing which language properties should cause an impact build when the given property is changed 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -43,6 +43,11 @@ gitRepositoryCompareService=/compare/
 applicationConfRootDir=
 
 #
+# Minimum required DBB ToolkitVersion to run this version of zAppBuild
+#  Build initialization process validates the DBB Toolkit Version in use and matches that against this setting 
+requiredDBBToolkitVersion=1.0.0
+
+#
 # Comma separated list of required build properties for zAppBuild/build.groovy
 requiredBuildProperties=buildOrder,buildListFileExt
 

--- a/build.groovy
+++ b/build.groovy
@@ -89,7 +89,7 @@ def initializeBuildProcess(String[] args) {
 	populateBuildProperties(args)
 	
 	// print dbb toolkit version in use
-	def dbbToolkitVersion = VersionInfo().getInstance().getVersion()
+	def dbbToolkitVersion = new VersionInfo().getVersion()
 	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion}"
 	
 

--- a/build.groovy
+++ b/build.groovy
@@ -90,7 +90,8 @@ def initializeBuildProcess(String[] args) {
 	
 	// print dbb toolkit version in use
 	def dbbToolkitVersion = VersionInfo.getInstance().getVersion()
-	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion}"
+	def dbbToolkitBuildDate = VersionInfo.getInstance().getDate()
+	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion} ${dbbToolkitBuildDate} "
 	
 	// verify required dbb toolkit
 	buildUtils.assertDbbBuildToolkitVersion(dbbToolkitVersion)

--- a/build.groovy
+++ b/build.groovy
@@ -89,7 +89,7 @@ def initializeBuildProcess(String[] args) {
 	populateBuildProperties(args)
 	
 	// print dbb toolkit version in use
-	def dbbToolkitVersion = new VersionInfo().getVersion()
+	def dbbToolkitVersion = VersionInfo.getInstance().getVersion()
 	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion}"
 	
 

--- a/build.groovy
+++ b/build.groovy
@@ -89,7 +89,7 @@ def initializeBuildProcess(String[] args) {
 	populateBuildProperties(args)
 	
 	// print dbb toolkit version in use
-	def dbbToolkitVersion = VersionInfo().getVersion()
+	def dbbToolkitVersion = VersionInfo().getInstance().getVersion()
 	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion}"
 	
 

--- a/build.groovy
+++ b/build.groovy
@@ -92,6 +92,8 @@ def initializeBuildProcess(String[] args) {
 	def dbbToolkitVersion = VersionInfo.getInstance().getVersion()
 	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion}"
 	
+	// verify required dbb toolkit
+	buildUtils.assertDbbBuildToolkitVersion(dbbToolkitVersion)
 
 	// verify required build properties
 	buildUtils.assertBuildProperties(props.requiredBuildProperties)

--- a/build.groovy
+++ b/build.groovy
@@ -87,6 +87,11 @@ def initializeBuildProcess(String[] args) {
 
 	// build properties initial set
 	populateBuildProperties(args)
+	
+	// print dbb toolkit version in use
+	def dbbToolkitVersion = VersionInfo().getVersion()
+	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion}"
+	
 
 	// verify required build properties
 	buildUtils.assertBuildProperties(props.requiredBuildProperties)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -510,6 +510,7 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 	}
 	return deployType
 }
+
 /*
  * parse and validates the user build dependency file 
  * returns a parsed json object 
@@ -532,4 +533,31 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 	// validate that depFileData.fileName == buildFile
 	assert getAbsolutePath(depFileData.fileName) == getAbsolutePath(buildFile) : "*! Dependency file mismatch: fileName does not match build file"
 	return depFileData // return the parsed JSON object
+}
+
+/*
+ * Validates the current Dbb Toolkit version
+ * exits the process, if it does not meet the minimum required version of zAppBuild.
+ * 
+ */
+def assertDbbBuildToolkitVersion(String currentVersion){
+
+	try {
+		// Tokenize current version
+		List currentVersionList = currentVersion.tokenize(".")
+		List requiredVersionList = props.requiredDBBToolkitVersion.tokenize(".")
+
+		// validate the version formats, current version is allowed have more labels.
+		assert currentVersionList.size() >= requiredVersionList.size() : "Version syntax does not match."
+
+		// validate each label
+		currentVersionList.eachWithIndex{ it, i ->
+			if(requiredVersionList.size() >= i +1 )  assert (it as int) >= ((requiredVersionList[i]) as int)
+		}
+
+	} catch(AssertionError e) {
+		println "Current DBB Toolkit Version $currentVersion does not meet the minimum required version $requiredVersion. EXIT."
+		println e.getMessage()
+		System.exit(1)
+	}
 }


### PR DESCRIPTION
* Provides the printout in `--verbose` tracing of the DBB toolkit which is use . 
```
** zAppBuild running on DBB Toolkit Version 1.1.1 03-Jun-2021 19:39:09
```
* Validates the toolkit against the defined requiredDbbToolkit level in build.properties