### PR TITLE
Build Type mergeBuild

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -970,6 +970,7 @@ groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --
 ```
 <details>
   <summary>Build log</summary>
+
 ```
 + /usr/lpp/dbb/v1r0/bin/groovyz /var/dbb/dbb-zappbuild/build.groovy --sourceDir /var/dbb/dbb-zappbuild/samples --workDir /var/dbb/out/MortgageApplication --hlq DBB.ZAPP.MERGE.BUILD --application MortgageApplication --verbose --mergeBuild --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties
 
@@ -1071,6 +1072,8 @@ Cobol compiler parms for MortgageApplication/cobol/epsmlist.cbl = LIB,CICS
 ** Total files processed : 1
 ** Total build time  : 5.468 seconds
 ```
+
+
 </details>
 
 ### Perform a Scan Source build
@@ -1084,6 +1087,7 @@ groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --
 ```
 <details>
   <summary>Build log</summary>
+
 ```
 ** Build start at 20210622.104821.048
 ** Input args = /var/dbb/dbb-zappbuild/samples --hlq DBB.ZAPP.CLEAN.MASTER --workDir /var/dbb/out/MortgageApplication --application MortgageApplication --logEncoding UTF-8 --fullBuild --scanSource --verbose
@@ -1219,6 +1223,7 @@ groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --
 ```
 <details>
   <summary>Build log</summary>
+
 ```
 ** Build start at 20210622.105915.059
 ** Input args = /var/dbb/dbb-zappbuild/samples --hlq DBB.ZAPP.CLEAN.MASTER --workDir /var/dbb/out/MortgageApplication --application MortgageApplication --logEncoding UTF-8 --fullBuild --scanAll --verbose
@@ -1374,4 +1379,5 @@ HTTP/1.1 200 OK
 ** Total files processed : 15
 ** Total build time  : 23.718 seconds
 ```
+
 </details>

--- a/BUILD.md
+++ b/BUILD.md
@@ -129,7 +129,7 @@ utility options
 - [Perform Impact Build](#perform-impact-build)
 - [Perform Impact Build for topic branches](#perform-impact-build-for-topic-branches)
 - [Perform Impact Build by providing baseline reference for the analysis of changed files](#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files)
-- [Perform Merge Build](some link)
+- [Perform a Merge build](#perform-a-merge-build)
 - [Perform a Scan Source build](#perform-a-scan-source-build)
 - [Perform a Scan Source + Outputs build](#perform-a-scan-source--outputs-build)
 
@@ -1070,7 +1070,7 @@ Cobol compiler parms for MortgageApplication/cobol/epsmlist.cbl = LIB,CICS
 ** Build State : CLEAN
 ** Total files processed : 1
 ** Total build time  : 5.468 seconds
-``
+```
 </details>
 
 ### Perform a Scan Source build

--- a/BUILD.md
+++ b/BUILD.md
@@ -48,6 +48,10 @@ $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1
 ```
 $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --userBuild --dependencyFile userBuildDependencyFile.json app1/cobol/epsmpmt.cbl
 ```
+ **Build only the changes which will be merged back to the main build branch. No calculation of impacted files.**
+```
+$DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --mergeBuild
+```
 
 ## Command Line Options Summary
 ```
@@ -74,6 +78,8 @@ build options:
                               by changed files since last successful build.
  -b,--baselineRef             Comma seperated list of git references to overwrite
                               the baselineHash hash in an impactBuild scenario.
+ -m,--mergeBuild              Flag indicating to build only source code changes which will be 
+                              merged back to the mainBuildBranch. 
 
  -s,--scanOnly                Flag indicating to only scan source files for application without building anything (deprecated use --scanSource)
  -ss,--scanSource             Flag indicating to only scan source files for application without building anything
@@ -123,6 +129,7 @@ utility options
 - [Perform Impact Build](#perform-impact-build)
 - [Perform Impact Build for topic branches](#perform-impact-build-for-topic-branches)
 - [Perform Impact Build by providing baseline reference for the analysis of changed files](#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files)
+- [Perform Merge Build](some link)
 - [Perform a Scan Source build](#perform-a-scan-source-build)
 - [Perform a Scan Source + Outputs build](#perform-a-scan-source--outputs-build)
 
@@ -815,57 +822,57 @@ groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --
   
 ```
 ** Build start at 20210830.095350.053
-** Input args = /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples --workDir /u/dbehm/test/out --hlq DBB.ZAPP.REL --application MortgageApplication --verbose --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/jenkins/zappbuild_config/zappbuild.jenkins.properties --impactBuild --baselineRef 6db56f7eecb420b56b69ca0ab7fcc2f1d9a7e5a8
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/datasets.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/dependencyReport.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/Assembler.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/BMS.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/MFS.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/PSBgen.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/DBDgen.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/ACBgen.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/Cobol.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/LinkEdit.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/PLI.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/REXX.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/ZunitConfig.properties
-** appConf = /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf/file.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf/BMS.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf/Cobol.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf/LinkEdit.properties
+** Input args = /var/dbb/dbb-zappbuild/samples --workDir /var/dbb/out/MortgageApplication --hlq DBB.ZAPP.REL --application MortgageApplication --verbose --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/jenkins/zappbuild_config/zappbuild.jenkins.properties --impactBuild --baselineRef 6db56f7eecb420b56b69ca0ab7fcc2f1d9a7e5a8
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/datasets.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/dependencyReport.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Assembler.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/MFS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PSBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/DBDgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ACBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/LinkEdit.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PLI.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/REXX.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ZunitConfig.properties
+** appConf = /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/file.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/LinkEdit.properties
 ** Loading property file /var/dbb/dbb-zappbuild-config/build.properties
 ** Loading property file /var/dbb/dbb-zappbuild-config/datasets.properties
 ** Loading property file /var/jenkins/zappbuild_config/zappbuild.jenkins.properties
 java.version=8.0.6.20 - pmz6480sr6fp20-20201120_02(SR6 FP20)
 java.home=/V2R4/usr/lpp/java/J8.0_64
-user.dir=/u/dbehm/test/baselineOverwrite/dbb-zappbuild
+user.dir=/var/dbb/dbb-zappbuild
 ** Build properties at start up:
 ..... // lists of all build properties
 ** Repository client created for https://dbb-webapp:8080/dbb
-** Build output located at /u/dbehm/test/out/build.20210830.095350.053
+** Build output located at /var/dbb/out/MortgageApplication/build.20210830.095350.053
 ** Build result created for BuildGroup:MortgageApplication-baselineBranch BuildLabel:build.20210830.095350.053 at https://dbb-webapp:8080/dbb/rest/buildResult/54806
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication
-** Getting current hash for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication
+** Getting current hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
 ** Storing MortgageApplication : 192adb8568b8179c7e537a339f1d8df7f2932f4a
-** Getting baseline hash for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication
+** Getting baseline hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
 *** Baseline hash for directory MortgageApplication retrieved from overwrite.
 ** Storing MortgageApplication : 6db56f7eecb420b56b69ca0ab7fcc2f1d9a7e5a8
-** Calculating changed files for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication
+** Calculating changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
 ** Diffing baseline 6db56f7eecb420b56b69ca0ab7fcc2f1d9a7e5a8 -> current 192adb8568b8179c7e537a339f1d8df7f2932f4a
-*** Changed files for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication:
+*** Changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
 **** MortgageApplication/cobol/epscmort.cbl
 **** MortgageApplication/cobol/epsmpmt.cbl
 !! (fixGitDiffPath) File not found.
-*** Deleted files for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication:
-*** Renamed files for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication:
+*** Deleted files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
+*** Renamed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
 ** Updating collections MortgageApplication-baselineBranch and MortgageApplication-baselineBranch-outputs
 *** Sorted list of changed files: [MortgageApplication/cobol/epsmpmt.cbl, MortgageApplication/cobol/epscmort.cbl]
-*** Scanning file MortgageApplication/cobol/epsmpmt.cbl (/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/cobol/epsmpmt.cbl)
+*** Scanning file MortgageApplication/cobol/epsmpmt.cbl (/var/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epsmpmt.cbl)
 *** Scanning file with the default scanner
 *** Logical file for MortgageApplication/cobol/epsmpmt.cbl =
 {"dli":false,"lname":"EPSMPMT","file":"MortgageApplication\/cobol\/epsmpmt.cbl","mq":false,"cics":false,"logicalDependencies":[{"lname":"EPSPDATA","library":"SYSLIB","category":"COPY"}],"language":"COB","sql":false}
-*** Scanning file MortgageApplication/cobol/epscmort.cbl (/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/cobol/epscmort.cbl)
+*** Scanning file MortgageApplication/cobol/epscmort.cbl (/var/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epscmort.cbl)
 *** Scanning file with the default scanner
 *** Logical file for MortgageApplication/cobol/epscmort.cbl =
 {"dli":false,"lname":"EPSCMORT","file":"MortgageApplication\/cobol\/epscmort.cbl","mq":false,"cics":true,"logicalDependencies":[{"lname":"DFHAID","library":"SYSLIB","category":"COPY"},{"lname":"EPSMORT","library":"SYSLIB","category":"COPY"},{"lname":"EPSMTCOM","library":"SYSLIB","category":"COPY"},{"lname":"EPSNBRPM","library":"SYSLIB","category":"COPY"},{"lname":"SQLCA","library":"SYSLIB","category":"SQL INCLUDE"}],"language":"COB","sql":true}
@@ -874,14 +881,14 @@ HTTP/1.1 200 OK
 *** Perform impacted analysis for changed files.
 ** Found build script mapping for MortgageApplication/cobol/epsmpmt.cbl. Adding to build list
 ** Performing impact analysis on changed file MortgageApplication/cobol/epsmpmt.cbl
-*** Creating impact resolver for MortgageApplication/cobol/epsmpmt.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                },{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/bms"} ]             },{"category": "LINK", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/cobol"}, {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/link"} ]             },{"category": "PROPERTY"}] rules
+*** Creating impact resolver for MortgageApplication/cobol/epsmpmt.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                },{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/bms"} ]             },{"category": "LINK", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/cobol"}, {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/link"} ]             },{"category": "PROPERTY"}] rules
 ** Found impacted file MortgageApplication/link/epsmlist.lnk
 ** MortgageApplication/link/epsmlist.lnk is impacted by changed file MortgageApplication/cobol/epsmpmt.cbl. Adding to build list.
 ** Found build script mapping for MortgageApplication/cobol/epscmort.cbl. Adding to build list
 ** Performing impact analysis on changed file MortgageApplication/cobol/epscmort.cbl
-*** Creating impact resolver for MortgageApplication/cobol/epscmort.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                },{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/bms"} ]             },{"category": "LINK", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/cobol"}, {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/link"} ]             },{"category": "PROPERTY"}] rules
+*** Creating impact resolver for MortgageApplication/cobol/epscmort.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                },{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/bms"} ]             },{"category": "LINK", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/cobol"}, {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/link"} ]             },{"category": "PROPERTY"}] rules
 *** Perform impacted analysis for property changes.
-** Writing build list file to /u/dbehm/test/out/build.20210830.095350.053/buildList.txt
+** Writing build list file to /var/dbb/out/MortgageApplication/build.20210830.095350.053/buildList.txt
 MortgageApplication/cobol/epsmpmt.cbl
 MortgageApplication/cobol/epscmort.cbl
 MortgageApplication/link/epsmlist.lnk
@@ -894,28 +901,28 @@ required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_comp
 ** Creating / verifying build dataset DBB.ZAPP.REL.DBRM
 ** Creating / verifying build dataset DBB.ZAPP.REL.LOAD
 *** Building file MortgageApplication/cobol/epsmpmt.cbl
-*** Creating dependency resolver for MortgageApplication/cobol/epsmpmt.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
+*** Creating dependency resolver for MortgageApplication/cobol/epsmpmt.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
 *** Scanning file with the default scanner
 *** Resolution rules for MortgageApplication/cobol/epsmpmt.cbl:
-{"library":"SYSLIB","searchPath":[{"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
+{"library":"SYSLIB","searchPath":[{"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
 *** Physical dependencies for MortgageApplication/cobol/epsmpmt.cbl:
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSPDATA","library":"SYSLIB","file":"MortgageApplication\/copybook\/epspdata.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSPDATA","library":"SYSLIB","file":"MortgageApplication\/copybook\/epspdata.cpy","category":"COPY","resolved":true}
 Cobol compiler parms for MortgageApplication/cobol/epsmpmt.cbl = LIB
 *** Scanning load module for MortgageApplication/cobol/epsmpmt.cbl
 *** Logical file =
 {"dli":false,"lname":"EPSMPMT","file":"MortgageApplication\/cobol\/epsmpmt.cbl","mq":false,"cics":false,"language":"ZBND","sql":false}
 *** Building file MortgageApplication/cobol/epscmort.cbl
-*** Creating dependency resolver for MortgageApplication/cobol/epscmort.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
+*** Creating dependency resolver for MortgageApplication/cobol/epscmort.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
 *** Scanning file with the default scanner
 *** Resolution rules for MortgageApplication/cobol/epscmort.cbl:
-{"library":"SYSLIB","searchPath":[{"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
+{"library":"SYSLIB","searchPath":[{"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
 *** Physical dependencies for MortgageApplication/cobol/epscmort.cbl:
 {"excluded":false,"lname":"DFHAID","library":"SYSLIB","category":"COPY","resolved":false}
 {"excluded":false,"lname":"EPSMORT","library":"SYSLIB","category":"COPY","resolved":false}
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSNBRPM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSNBRPM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","category":"COPY","resolved":true}
 {"excluded":false,"lname":"SQLCA","library":"SYSLIB","category":"SQL INCLUDE","resolved":false}
 Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
 *** Scanning load module for MortgageApplication/cobol/epscmort.cbl
@@ -932,12 +939,12 @@ required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkE
 *** Scanning load module for MortgageApplication/link/epsmlist.lnk
 *** Logical file =
 {"dli":false,"lname":"EPSMLIST","file":"MortgageApplication\/link\/epsmlist.lnk","mq":false,"cics":false,"logicalDependencies":[{"lname":"EPSMPMT","library":"DBB.ZAPP.REL.LOAD","category":"LINK"},{"lname":"EPSMLIST","library":"DBB.ZAPP.REL.OBJ","category":"LINK"}],"language":"ZBND","sql":false}
-*** Obtaining hash for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication
+*** Obtaining hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
 ** Setting property :githash:MortgageApplication : 192adb8568b8179c7e537a339f1d8df7f2932f4a
 ** Setting property :giturl:MortgageApplication : git@github.com:dennis-behm/dbb-zappbuild.git
 ** Setting property :gitchangedfiles:MortgageApplication : https://github.com/ibm/dbb-zappbuild/compare/192adb8568b8179c7e537a339f1d8df7f2932f4a..192adb8568b8179c7e537a339f1d8df7f2932f4a
-** Writing build report data to /u/dbehm/test/out/build.20210830.095350.053/BuildReport.json
-** Writing build report to /u/dbehm/test/out/build.20210830.095350.053/BuildReport.html
+** Writing build report data to /var/dbb/out/MortgageApplication/build.20210830.095350.053/BuildReport.json
+** Writing build report to /var/dbb/out/MortgageApplication/build.20210830.095350.053/BuildReport.html
 ** Updating build result BuildGroup:MortgageApplication-baselineBranch BuildLabel:build.20210830.095350.053 at https://dbb-webapp:8080/dbb/rest/buildResult/54806
 ** Build ended at Mon Aug 30 09:53:59 GMT+01:00 2021
 ** Build State : CLEAN
@@ -947,6 +954,124 @@ required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkE
 
 </details>
 
+
+### Perform a Merge build
+
+`--mergeBuild` calculate the changes of a topic branch flowing back into the `mainBuildBranch` reference. This build type does not perform calculation of impacted files.
+
+The scenario is targeting for builds on topic branches. The scope of the build is focussing on the outgoing changes. It is not incremental. Any time you invoke this build, it will the changes which will be merged to the target reference. 
+
+It leverages the git triple-dot diff syntax to identify the changes, similar to what can be seen in a pull/merge request.      
+
+In the below case both `MortgageApplication/cobol/epsmlist.cbl` and `MortgageApplication/copybook/epsnbrpm.cpy` are changed, but only the `epsmlist.cbl` is built because it is mapped to a build script.  
+
+```
+groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --hlq DBB.ZAPP.CLEAN.MASTER --workDir /var/dbb/out/MortgageApplication --application MortgageApplication --logEncoding UTF-8 --mergeBuild --verbose
+```
+<details>
+  <summary>Build log</summary>
+```
++ /usr/lpp/dbb/v1r0/bin/groovyz /var/dbb/dbb-zappbuild/build.groovy --sourceDir /var/dbb/dbb-zappbuild/samples --workDir /var/dbb/out/MortgageApplication --hlq DBB.ZAPP.MERGE.BUILD --application MortgageApplication --verbose --mergeBuild --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties
+
+** Build start at 20211116.104234.042
+** Input args = /var/dbb/dbb-zappbuild/samples --workDir /var/dbb/out/MortgageApplication --hlq DBB.ZAPP.MERGE.BUILD --application MortgageApplication --verbose --mergeBuild --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/datasets.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/dependencyReport.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Assembler.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/MFS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PSBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/DBDgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ACBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/LinkEdit.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PLI.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/REXX.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ZunitConfig.properties
+** appConf = /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/file.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/LinkEdit.properties
+** Loading property file /var/dbb/dbb-zappbuild-config/build.properties
+** Loading property file /var/dbb/dbb-zappbuild-config/datasets.properties
+java.version=8.0.6.36 - pmz6480sr6fp36-20210913_01(SR6 FP36)
+java.home=/V2R4/usr/lpp/java/J8.0_64
+user.dir=/u/dbehm
+** Build properties at start up:
+..... // lists of all build properties
+** Repository client created for https://10.3.20.96:10443/dbb
+** Build output located at /var/dbb/out/MortgageApplication/build.20211116.104234.042
+** Build result created for BuildGroup:MortgageApplication-outgoingChangesBuild BuildLabel:build.20211116.104234.042 at https://10.3.20.96:10443/dbb/rest/buildResult/58773
+** --mergeBuild option selected. Building changed programs for application MortgageApplication flowing back to main
+** Calculating changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+** Triple-dot Diffing configuration baseline main -> current HEAD
+*** Changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
+!! (fixGitDiffPath) File not found.
+**** MortgageApplication/application-conf/application.properties
+**** MortgageApplication/cobol/epsmlist.cbl
+**** MortgageApplication/copybook/epsnbrpm.cpy
+!! (fixGitDiffPath) File not found.
+!! (fixGitDiffPath) File not found.
+!! (fixGitDiffPath) File not found.
+*** Deleted files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
+*** Renamed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
+** Updating collections MortgageApplication-outgoingChangesBuild and MortgageApplication-outgoingChangesBuild-outputs
+*** Sorted list of changed files: [MortgageApplication/cobol/epsmlist.cbl, MortgageApplication/copybook/epsnbrpm.cpy]
+*** Scanning file MortgageApplication/cobol/epsmlist.cbl (/var/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epsmlist.cbl)
+*** Scanning file with the default scanner
+*** Logical file for MortgageApplication/cobol/epsmlist.cbl =
+{"dli":false,"lname":"EPSMLIST","file":"MortgageApplication\/cobol\/epsmlist.cbl","mq":false,"cics":true,"logicalDependencies":[{"lname":"DFHAID","library":"SYSLIB","category":"COPY"},{"lname":"EPSMLIS","library":"SYSLIB","category":"COPY"},{"lname":"EPSMORTF","library":"SYSLIB","category":"COPY"},{"lname":"EPSMTCOM","library":"SYSLIB","category":"COPY"},{"lname":"EPSNBRPM","library":"SYSLIB","category":"COPY"}],"language":"COB","sql":false}
+*** Scanning file MortgageApplication/copybook/epsnbrpm.cpy (/var/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsnbrpm.cpy)
+*** Scanning file with the default scanner
+*** Logical file for MortgageApplication/copybook/epsnbrpm.cpy =
+{"dli":false,"lname":"EPSNBRPM","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","mq":false,"cics":false,"language":"COB","sql":false}
+** Storing 2 logical files in repository collection 'MortgageApplication-outgoingChangesBuild'
+HTTP/1.1 200 OK
+** Found build script mapping for MortgageApplication/cobol/epsmlist.cbl. Adding to build list
+** Writing build list file to /var/dbb/out/MortgageApplication/build.20211116.104234.042/buildList.txt
+MortgageApplication/cobol/epsmlist.cbl
+** Updating collections MortgageApplication-outgoingChangesBuild and MortgageApplication-outgoingChangesBuild-outputs
+*** Scanning file MortgageApplication/cobol/epsmlist.cbl (/var/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epsmlist.cbl)
+*** Scanning file with the default scanner
+*** Logical file for MortgageApplication/cobol/epsmlist.cbl =
+{"dli":false,"lname":"EPSMLIST","file":"MortgageApplication\/cobol\/epsmlist.cbl","mq":false,"cics":true,"logicalDependencies":[{"lname":"DFHAID","library":"SYSLIB","category":"COPY"},{"lname":"EPSMLIS","library":"SYSLIB","category":"COPY"},{"lname":"EPSMORTF","library":"SYSLIB","category":"COPY"},{"lname":"EPSMTCOM","library":"SYSLIB","category":"COPY"},{"lname":"EPSNBRPM","library":"SYSLIB","category":"COPY"}],"language":"COB","sql":false}
+** Storing 1 logical files in repository collection 'MortgageApplication-outgoingChangesBuild'
+HTTP/1.1 200 OK
+** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
+** Building files mapped to Cobol.groovy script
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.COBOL
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.COPY
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.OBJ
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.DBRM
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.LOAD
+*** Building file MortgageApplication/cobol/epsmlist.cbl
+*** Creating dependency resolver for MortgageApplication/cobol/epsmlist.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
+*** Scanning file with the default scanner
+*** Resolution rules for MortgageApplication/cobol/epsmlist.cbl:
+{"library":"SYSLIB","searchPath":[{"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
+*** Physical dependencies for MortgageApplication/cobol/epsmlist.cbl:
+{"excluded":false,"lname":"DFHAID","library":"SYSLIB","category":"COPY","resolved":false}
+{"excluded":false,"lname":"EPSMLIS","library":"SYSLIB","category":"COPY","resolved":false}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMORTF","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmortf.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSNBRPM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","category":"COPY","resolved":true}
+Cobol compiler parms for MortgageApplication/cobol/epsmlist.cbl = LIB,CICS
+*** Obtaining hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+** Setting property :githash:MortgageApplication : d03087c5e4583be84cbe5c03a5fc7113074f46d2
+** Setting property :giturl:MortgageApplication : https://github.com/dennis-behm/dbb-zappbuild.git
+** Writing build report data to /var/dbb/out/MortgageApplication/build.20211116.104234.042/BuildReport.json
+** Writing build report to /var/dbb/out/MortgageApplication/build.20211116.104234.042/BuildReport.html
+** Updating build result BuildGroup:MortgageApplication-outgoingChangesBuild BuildLabel:build.20211116.104234.042 at https://10.3.20.96:10443/dbb/rest/buildResult/58773
+** Build ended at Tue Nov 16 22:42:40 GMT+01:00 2021
+** Build State : CLEAN
+** Total files processed : 1
+** Total build time  : 5.468 seconds
+``
+</details>
 
 ### Perform a Scan Source build
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ zAppBuild supports a number of build scenarios:
 * **Impact Build** - Build only programs impacted by source files that have changed since the last successful build.
 * **Impact Build with baseline reference** - Build only programs impacted by source files that have changed by diff'ing to a previous configuration reference.
 * **Topic Branch Build** - Detects when building a topic branch for the first time and will automatically clone the dependency data collections from the main build branch in order to avoid having to rescan the entire application.
+* **Merge Build** - Build only changed programs which will be merged back into the mainBuildBranch by using a triple-dot git diff. 
 * **Scan Source** - Skip the actual building and only scan source files to store dependency data in collection (migration scenario).
 * **Scan Source + Outputs** - Skip the actual building and only scan source files and existing load modules to dependency data in source and output collection (migration scenario with static linkage scenarios).
 

--- a/build.groovy
+++ b/build.groovy
@@ -440,7 +440,7 @@ def createBuildList() {
 		println "** --outgoingChangesBuild option selected. $action changed programs for application ${props.application} flowing back to ${props.mainBuildBranch}"
 		if (repositoryClient) {
 			assert (props.topicBranchBuild) : "*! Build type --outgoingChangesBuild can only be run on for topic branch builds."
-				(buildSet, deletedFiles) = impactUtils.createOutgoingChangeBuildList(repositoryClient)		
+				(buildSet, deletedFiles) = impactUtils.createOutgoingChangeBuildList(repositoryClient)		}
 		else {
 			println "*! Impact build requires a repository client connection to a DBB web application"
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -429,11 +429,7 @@ def createBuildList() {
 	// check if full build
 	if (props.fullBuild) {
 		println "** --fullBuild option selected. $action all programs for application ${props.application}"
-		if (repositoryClient) {
-			buildSet = buildUtils.createFullBuildList() }
-		else {
-			println "*! Full build requires a repository client connection to a DBB web application"
-		}	
+		buildSet = buildUtils.createFullBuildList()
 	}
 	// check if impact build
 	else if (props.impactBuild) {

--- a/build.groovy
+++ b/build.groovy
@@ -442,7 +442,7 @@ def createBuildList() {
 			assert (props.topicBranchBuild) : "*! Build type --mergeBuild can only be run on for topic branch builds."
 				(buildSet, deletedFiles) = impactUtils.createMergeBuildList(repositoryClient)		}
 		else {
-			println "*! Impact build requires a repository client connection to a DBB web application"
+			println "*! Merge build requires a repository client connection to a DBB web application"
 		}
 	}
 
@@ -505,7 +505,7 @@ def createBuildList() {
 	// scan and update source collection with build list files for non-impact builds
 	// since impact build list creation already scanned the incoming changed files
 	// we do not need to scan them again
-	if (!props.impactBuild && !props.userBuild) {
+	if (!props.impactBuild && !props.userBuild && !props.mergeBuild) {
 		println "** Scanning source code."
 		impactUtils.updateCollection(buildList, null, null, repositoryClient)
 	}

--- a/build.groovy
+++ b/build.groovy
@@ -167,7 +167,7 @@ options:
 	cli.f(longOpt:'fullBuild', 'Flag indicating to build all programs for application')
 	cli.i(longOpt:'impactBuild', 'Flag indicating to build only programs impacted by changed files since last successful build.')
 	cli.b(longOpt:'baselineRef',args:1,'Comma seperated list of git references to overwrite the baselineHash hash in an impactBuild scenario.')
-	cli.oc(longOpt:'outgoingChangesBuild', 'Flag indicating to build only changes which will flow back to the mainBuildBranch.')	
+	cli.m(longOpt:'mergeBuild', 'Flag indicating to build only changes which will be merged back to the mainBuildBranch.')	
 	cli.r(longOpt:'reset', 'Deletes the dependency collections and build result group from the DBB repository')
 	cli.v(longOpt:'verbose', 'Flag to turn on script trace')
 
@@ -314,7 +314,7 @@ def populateBuildProperties(String[] args) {
 	if (opts.r) props.reset = 'true'
 	if (opts.v) props.verbose = 'true'
 	if (opts.b) props.baselineRef = opts.b
-	if (opts.oc) props.outgoingChangesBuild = 'true'
+	if (opts.m) props.mergeBuild = 'true'
 	
 	// scan options
 	if (opts.s) props.scanOnly = 'true'
@@ -436,11 +436,11 @@ def createBuildList() {
 			println "*! Impact build requires a repository client connection to a DBB web application"
 		}
 	}
-	else if (props.outgoingChangesBuild){
-		println "** --outgoingChangesBuild option selected. $action changed programs for application ${props.application} flowing back to ${props.mainBuildBranch}"
+	else if (props.mergeBuild){
+		println "** --mergeBuild option selected. $action changed programs for application ${props.application} flowing back to ${props.mainBuildBranch}"
 		if (repositoryClient) {
-			assert (props.topicBranchBuild) : "*! Build type --outgoingChangesBuild can only be run on for topic branch builds."
-				(buildSet, deletedFiles) = impactUtils.createOutgoingChangeBuildList(repositoryClient)		}
+			assert (props.topicBranchBuild) : "*! Build type --mergeBuild can only be run on for topic branch builds."
+				(buildSet, deletedFiles) = impactUtils.createMergeBuildList(repositoryClient)		}
 		else {
 			println "*! Impact build requires a repository client connection to a DBB web application"
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -167,7 +167,7 @@ options:
 	cli.f(longOpt:'fullBuild', 'Flag indicating to build all programs for application')
 	cli.i(longOpt:'impactBuild', 'Flag indicating to build only programs impacted by changed files since last successful build.')
 	cli.b(longOpt:'baselineRef',args:1,'Comma seperated list of git references to overwrite the baselineHash hash in an impactBuild scenario.')
-	cli.oc(longOpt:'outgoingChangesBuild',args:1,'Flag indicating to build only changes which will flow back to the mainBuildBranch.')	
+	cli.oc(longOpt:'outgoingChangesBuild', 'Flag indicating to build only changes which will flow back to the mainBuildBranch.')	
 	cli.r(longOpt:'reset', 'Deletes the dependency collections and build result group from the DBB repository')
 	cli.v(longOpt:'verbose', 'Flag to turn on script trace')
 

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -18,7 +18,7 @@ buildOrder=BMS.groovy,Cobol.groovy,LinkEdit.groovy
 #
 # The main build branch.  Used for cloning collections for topic branch builds instead
 # of rescanning the entire application.
-mainBuildBranch=master
+mainBuildBranch=main
 
 #
 # The git repository URL of the application repository to establish links to the changed files 

--- a/test/applications/MortgageApplication/bms/epsmlis.bms
+++ b/test/applications/MortgageApplication/bms/epsmlis.bms
@@ -1,0 +1,112 @@
+*********************************************************************** 00010000
+EPSMLIS  DFHMSD TYPE=&SYSPARM,MODE=INOUT,LANG=COBOL,                   X
+               STORAGE=AUTO,TIOAPFX=YES,DSATTS=(COLOR,HILIGHT),        X 0009000
+               MAPATTS=(COLOR,HILIGHT)                                   0009100
+EPSMLIS  DFHMDI SIZE=(24,80),CTRL=(PRINT,FREEKB)                         0011000
+         DFHMDF POS=(1,24),LENGTH=26,INITIAL='Better Mortgage Rates',  *
+               ATTRB=(ASKIP,BRT)
+         DFHMDF POS=(24,58),LENGTH=0,                                  *
+               ATTRB=ASKIP
+*        MENU MORTGAGE LIST MERGE BUILD TEST.
+
+LITCOMP  DFHMDF POS=(3,1),LENGTH=24,INITIAL='Company',                 *
+               ATTRB=(ASKIP,NORM)
+LITPHN   DFHMDF POS=(3,26),LENGTH=13,INITIAL='Phone Number',           *
+               ATTRB=(PROT,NORM)
+EPDIFF1  DFHMDF POS=(3,40),LENGTH=13,INITIAL='Interest Rate',          *
+               ATTRB=(PROT,NORM)
+EPDIFF2  DFHMDF POS=(3,54),LENGTH=16,INITIAL='Monthly Payment',        *
+               ATTRB=(PROT,NORM)
+LITPHN1  DFHMDF POS=(3,71),LENGTH=7,INITIAL='# Years',                 *
+               ATTRB=(PROT,NORM)
+EPCMP1   DFHMDF POS=(4,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN1   DFHMDF POS=(4,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE1  DFHMDF POS=(4,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN1  DFHMDF POS=(4,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS1 DFHMDF POS=(4,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP2   DFHMDF POS=(5,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN2   DFHMDF POS=(5,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE2  DFHMDF POS=(5,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN2  DFHMDF POS=(5,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS2 DFHMDF POS=(5,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP3   DFHMDF POS=(6,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN3   DFHMDF POS=(6,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE3  DFHMDF POS=(6,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN3  DFHMDF POS=(6,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS3 DFHMDF POS=(6,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP4   DFHMDF POS=(7,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN4   DFHMDF POS=(7,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE4  DFHMDF POS=(7,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN4  DFHMDF POS=(7,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS4 DFHMDF POS=(7,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP5   DFHMDF POS=(8,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN5   DFHMDF POS=(8,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE5  DFHMDF POS=(8,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN5  DFHMDF POS=(8,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS5 DFHMDF POS=(8,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP6   DFHMDF POS=(9,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN6   DFHMDF POS=(9,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE6  DFHMDF POS=(9,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN6  DFHMDF POS=(9,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS6 DFHMDF POS=(9,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP7   DFHMDF POS=(10,1),LENGTH=24,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN7   DFHMDF POS=(10,26),LENGTH=13,                                 *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE7  DFHMDF POS=(10,45),LENGTH=5,                                  *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN7  DFHMDF POS=(10,56),LENGTH=12,                                 *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS7 DFHMDF POS=(10,74),LENGTH=2,                                  *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP8   DFHMDF POS=(11,1),LENGTH=24,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN8   DFHMDF POS=(11,26),LENGTH=13,                                 *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE8  DFHMDF POS=(11,45),LENGTH=5,                                  *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN8  DFHMDF POS=(11,56),LENGTH=12,                                 *
+               ATTRB=(NUM,IC,NORM)
+         DFHMDF POS=(11,69),                                           *
+               ATTRB=ASKIP
+EPYEARS8 DFHMDF POS=(11,74),LENGTH=2,                                  *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+         DFHMDF POS=(11,77),LENGTH=0,                                  *
+               ATTRB=ASKIP
+         DFHMDF POS=(23,17),LENGTH=43,                                 *
+               INITIAL='Press F3 to quit or Enter to calculate loan',  *
+               ATTRB=(ASKIP,NORM),HILIGHT=OFF,COLOR=BLUE
+MSGERR   DFHMDF POS=(24,17),LENGTH=40,INITIAL='INVALID KEY PRESSED',   X
+               ATTRB=(PROT,DRK)
+EPSMLIS DFHMSD TYPE=FINAL
+        END

--- a/test/applications/MortgageApplication/build-conf/mergeBuildOpts.properties
+++ b/test/applications/MortgageApplication/build-conf/mergeBuildOpts.properties
@@ -1,2 +1,2 @@
-# Overwriting the mainBuildBranch for the mergeBuild scenario
-mainBuildBranch=${props.branch}
+# mainBuildBranch requires to be overriden for the mergeBuild test scenario
+# mainBuildBranch=${props.branch}

--- a/test/applications/MortgageApplication/build-conf/mergeBuildOpts.properties
+++ b/test/applications/MortgageApplication/build-conf/mergeBuildOpts.properties
@@ -1,0 +1,2 @@
+# Overwriting the mainBuildBranch for the mergeBuild scenario
+mainBuildBranch=${props.branch}

--- a/test/applications/MortgageApplication/cobol/epscsmrt.cbl
+++ b/test/applications/MortgageApplication/cobol/epscsmrt.cbl
@@ -1,0 +1,61 @@
+   CBL NUMPROC(MIG),FLAG(I,W),RENT
+       ID DIVISION.
+       PROGRAM-ID. EPSCSMRT.
+      *    THIS IS A CALLED PROGRAM EXAMPLE FOR DEMONSTRATION
+      *
+      *    THIS PROGRAM IS INVOKED VIA A CICS LINK STATMENT
+      *    AND DYNAMICALLY CALLS THE ACTUAL PROGRAM
+      *
+      *    TEST CHANGE
+      *
+      *    (C) 2017 IBM JIM HILDNER.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. FLEX-ES.
+       OBJECT-COMPUTER. FLEX-ES.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      *
+       01  WS-CALLED-PROGRAM    PIC X(8).
+
+       01  STATIC-CALLED-PROGRAMS.
+           03 STATIC-CALLED-PROGRAM-TABLE.
+              05 FILLER            PIC X(8) VALUE 'EPSMPMT'.
+              05 FILLER            PIC X(8) VALUE 'NOT VLD'.
+              05 FILLER            PIC X(8) VALUE ' '.
+           03 CALLED-PROGRAM-TABLE
+                        REDEFINES STATIC-CALLED-PROGRAM-TABLE
+                        OCCURS 3 TIMES.
+              05 CALLED-PROGRAM-NAME PIC X(8).
+
+       COPY EPSPDATA.
+
+       LINKAGE SECTION.
+      *
+       01 DFHCOMMAREA.
+       COPY EPSMTCOM.
+
+       PROCEDURE DIVISION USING DFHCOMMAREA.
+      *
+       A000-MAINLINE.
+           MOVE EPSPCOM-PRINCIPLE-DATA  TO EPSPDATA-PRINCIPLE-DATA.
+           MOVE EPSPCOM-NUMBER-OF-YEARS TO EPSPDATA-NUMBER-OF-YEARS.
+           MOVE 'Y'                     TO EPSPDATA-YEAR-MONTH-IND.
+           MOVE EPSPCOM-QUOTED-INTEREST-RATE
+                                        TO
+                                   EPSPDATA-QUOTED-INTEREST-RATE.
+           MOVE CALLED-PROGRAM-NAME(1)  TO WS-CALLED-PROGRAM.
+           MOVE SPACES                  TO EPSPDATA-RETURN-ERROR.
+      *     CALL 'EPSMPMT' USING EPSPDATA.
+           CALL WS-CALLED-PROGRAM USING EPSPDATA.
+           MOVE EPSPDATA-RETURN-MONTH-PAYMENT
+                                        TO
+                                        EPSPCOM-RETURN-MONTH-PAYMENT.
+           MOVE EPSPDATA-RETURN-ERROR   TO EPSPCOM-ERRMSG.
+           IF EPSPDATA-RETURN-ERROR = SPACES
+              MOVE ZERO TO EPSPCOM-PROGRAM-RETCODE
+           ELSE
+              MOVE 8 TO EPSPCOM-PROGRAM-RETCODE
+           END-IF.
+           GOBACK
+           .

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -54,11 +54,11 @@ impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MF
 # build properties to overwrite a set of options to enable test scenario in test framework
 mergeBuild_buildPropSetting = build-conf/mergeBuildOpts.properties
 # list of changed source files to test impact builds
-mergeBuild_changedFiles = bms/epsmort.bms,cobol/epscsmrt.cbl
+mergeBuild_changedFiles = bms/epsmlis.bms.bms,cobol/epscsmrt.cbl
 #
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 mergeBuild_datasetsToCleanUp = BMS,COBOL,LINK
 #
 # Use file properties to associate expected files built to changed files
-mergeBuild_expectedFilesBuilt = epsmort.bms :: bms/epsmort.bms
-mergeBuild_expectedFilesBuilt = epsmort.bms,epscsmrt.cbl :: cobol/epscsmrt.cbl
+mergeBuild_expectedFilesBuilt = epsmlis.bms.bms :: bms/epsmlis.bms.bms
+mergeBuild_expectedFilesBuilt = epsmlis.bms.bms,epscsmrt.cbl :: cobol/epscsmrt.cbl

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -54,7 +54,7 @@ impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MF
 # build properties to overwrite a set of options to enable test scenario in test framework
 mergeBuild_buildPropSetting = build-conf/mergeBuildOpts.properties
 # list of changed source files to test impact builds
-mergeBuild_changedFiles = bms/epsmort.bms,cobol/epsmlist.cbl
+mergeBuild_changedFiles = bms/epsmort.bms,cobol/epscsmrt.cbl
 #
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 mergeBuild_datasetsToCleanUp = BMS,COBOL,LINK

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -54,7 +54,7 @@ impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MF
 # build properties to overwrite a set of options to enable test scenario in test framework
 mergeBuild_buildPropSetting = build-conf/mergeBuildOpts.properties
 # list of changed source files to test impact builds
-mergeBuild_changedFiles = bms/epsmlis.bms.bms,cobol/epscsmrt.cbl
+mergeBuild_changedFiles = bms/epsmlis.bms,cobol/epscsmrt.cbl
 #
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 mergeBuild_datasetsToCleanUp = BMS,COBOL,LINK

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,mergeBuild.groovy,resetBuild.groovy
+test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,mergeBuild.groovy,impactBuild_renaming.groovy,resetBuild.groovy
 
 
 #############################
@@ -50,6 +50,8 @@ impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MF
 # mergeBuild.groovy properties
 ###############################
 #
+# build properties to overwrite a set of options to enable test scenario in test framework
+mergeBuild_buildPropSetting = build-conf/mergeBuildOpts.properties
 # list of changed source files to test impact builds
 mergeBuild_changedFiles = bms/epsmort.bms,cobol/epsmlist.cbl
 #

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,resetBuild.groovy
+test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,mergeBuild.groovy,resetBuild.groovy
 
 
 #############################
@@ -45,3 +45,17 @@ impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: cobol/epscsmrt.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 
+
+###############################
+# mergeBuild.groovy properties
+###############################
+#
+# list of changed source files to test impact builds
+mergeBuild_changedFiles = bms/epsmort.bms,cobol/epsmlist.cbl
+#
+# list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
+mergeBuild_datasetsToCleanUp = BMS,COBOL,LINK
+#
+# Use file properties to associate expected files built to changed files
+mergeBuild_expectedFilesBuilt = epsmort.bms :: bms/epsmort.bms
+mergeBuild_expectedFilesBuilt = epsmlist.cbl :: cobol/epsmlist.cbl

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,8 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,mergeBuild.groovy,impactBuild_renaming.groovy,resetBuild.groovy
+#  the order of the list matters
+test_testOrder=resetBuild.groovy,mergeBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,resetBuild.groovy
 
 
 #############################
@@ -60,4 +61,4 @@ mergeBuild_datasetsToCleanUp = BMS,COBOL,LINK
 #
 # Use file properties to associate expected files built to changed files
 mergeBuild_expectedFilesBuilt = epsmort.bms :: bms/epsmort.bms
-mergeBuild_expectedFilesBuilt = epsmlist.cbl :: cobol/epsmlist.cbl
+mergeBuild_expectedFilesBuilt = epsmort.bms,epscsmrt.cbl :: cobol/epscsmrt.cbl

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -60,5 +60,5 @@ mergeBuild_changedFiles = bms/epsmlis.bms.bms,cobol/epscsmrt.cbl
 mergeBuild_datasetsToCleanUp = BMS,COBOL,LINK
 #
 # Use file properties to associate expected files built to changed files
-mergeBuild_expectedFilesBuilt = epsmlis.bms.bms :: bms/epsmlis.bms.bms
-mergeBuild_expectedFilesBuilt = epsmlis.bms.bms,epscsmrt.cbl :: cobol/epscsmrt.cbl
+mergeBuild_expectedFilesBuilt = epsmlis.bms :: bms/epsmlis.bms
+mergeBuild_expectedFilesBuilt = epsmlis.bms,epscsmrt.cbl :: cobol/epscsmrt.cbl

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -92,8 +92,6 @@ def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, 
 	println "** Validating impact build results"
 	def expectedFilesBuiltList = filesBuiltMappings.getValue(renameFile).split(',')
 
-	println("*** Outputstream: $outputStream")
-	
 	try{
 		// Validate clean build
 		assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $renameFile\nOUTPUT STREAM:\n$outputStream\n"

--- a/test/testScripts/mergeBuild.groovy
+++ b/test/testScripts/mergeBuild.groovy
@@ -85,6 +85,7 @@ def copyAndCommit(String changedFile) {
 	println "** Copying and committing ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} to ${props.appLocation}/${changedFile}"
 	def commands = """
     cp ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} ${props.appLocation}/${changedFile}
+    echo ' ' >> ${props.appLocation}/${changedFile}
     cd ${props.appLocation}/
     git add .
     git commit . -m "edited program file"

--- a/test/testScripts/mergeBuild.groovy
+++ b/test/testScripts/mergeBuild.groovy
@@ -12,51 +12,51 @@ println "\n** Executing test script mergeBuild.groovy"
 def dbbHome = EnvVars.getHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
-// create impact build command
-def impactBuildCommand = []
-impactBuildCommand << "${dbbHome}/bin/groovyz"
-impactBuildCommand << "${props.zAppBuildDir}/build.groovy"
-impactBuildCommand << "--workspace ${props.workspace}"
-impactBuildCommand << "--application ${props.app}"
-impactBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
-impactBuildCommand << "--hlq ${props.hlq}"
-impactBuildCommand << "--logEncoding UTF-8"
-impactBuildCommand << "--url ${props.url}"
-impactBuildCommand << "--id ${props.id}"
-impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
-impactBuildCommand << (props.verbose ? "--verbose" : "")
-impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles}" : "")
-impactBuildCommand << "--mergeBuild"
+// create merge build command
+def mergeBuildCommand = []
+mergeBuildCommand << "${dbbHome}/bin/groovyz"
+mergeBuildCommand << "${props.zAppBuildDir}/build.groovy"
+mergeBuildCommand << "--workspace ${props.workspace}"
+mergeBuildCommand << "--application ${props.app}"
+mergeBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+mergeBuildCommand << "--hlq ${props.hlq}"
+mergeBuildCommand << "--logEncoding UTF-8"
+mergeBuildCommand << "--url ${props.url}"
+mergeBuildCommand << "--id ${props.id}"
+mergeBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+mergeBuildCommand << (props.verbose ? "--verbose" : "")
+mergeBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.mergeBuild_buildPropSetting},${props.propFiles}" : "")
+mergeBuildCommand << "--mergeBuild"
 
-// iterate through change files to test impact build
+// iterate through change files to test merge build
 @Field def assertionList = []
 PropertyMappings filesBuiltMappings = new PropertyMappings('mergeBuild_expectedFilesBuilt')
 def changedFiles = props.mergeBuild_changedFiles.split(',')
 println("** Processing changed files from mergeBuild_changedFiles property : ${props.mergeBuild_changedFiles}")
 try {
 	changedFiles.each { changedFile ->
-		println "\n** Running impact build test for changed file $changedFile"
+		println "\n** Running merge build test for changed file $changedFile"
 		
 		// update changed file in Git repo test branch
 		copyAndCommit(changedFile)
 		
-		// run impact build
-		println "** Executing ${impactBuildCommand.join(" ")}"
+		// run merge build
+		println "** Executing ${mergeBuildCommand.join(" ")}"
 		def outputStream = new StringBuffer()
-		def process = ['bash', '-c', impactBuildCommand.join(" ")].execute()
+		def process = ['bash', '-c', mergeBuildCommand.join(" ")].execute()
 		process.waitForProcessOutput(outputStream, System.err)
 		
 		// validate build results
-		validateImpactBuild(changedFile, filesBuiltMappings, outputStream)
+		validateMergeBuild(changedFile, filesBuiltMappings, outputStream)
 	}
 }
 finally {
 	cleanUpDatasets()
 	if (assertionList.size()>0) {
         println "\n***"
-	println "**START OF FAILED IMPACT BUILD TEST RESULTS**\n"
-	println "*FAILED IMPACT BUILD TEST RESULTS*\n" + assertionList
-	println "\n**END OF FAILED IMPACT BUILD TEST RESULTS**"
+	println "**START OF FAILED MERGED BUILD TEST RESULTS**\n"
+	println "*FAILED MERGED BUILD TEST RESULTS*\n" + assertionList
+	println "\n**END OF FAILED MERGED BUILD TEST RESULTS**"
 	println "***"
   }
 }
@@ -79,24 +79,24 @@ def copyAndCommit(String changedFile) {
 	task.waitForProcessOutput(outputStream, System.err)
 }
 
-def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
+def validateMergeBuild(String changedFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
 
-	println "** Validating impact build results"
+	println "** Validating merge build results"
 	def expectedFilesBuiltList = filesBuiltMappings.getValue(changedFile).split(',')
 	
     try{
 	// Validate clean build
-	assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $changedFile\nOUTPUT STREAM:\n$outputStream\n"
+	assert outputStream.contains("Build State : CLEAN") : "*! MERGED BUILD FAILED FOR $changedFile\nOUTPUT STREAM:\n$outputStream\n"
 
 	// Validate expected number of files built
-	def numImpactFiles = expectedFilesBuiltList.size()
-	assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FOR $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
+	def numMergeFiles = expectedFilesBuiltList.size()
+	assert outputStream.contains("Total files processed : ${numMergeFiles}") : "*! MERGED BUILD FOR $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numMergeFiles}\nOUTPUT STREAM:\n$outputStream\n"
 
 	// Validate expected built files in output stream
-	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FOR $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! MERGED BUILD FOR $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
 	
 	println "**"
-	println "** IMPACT BUILD TEST : PASSED FOR $changedFile **"
+	println "** MERGED BUILD TEST : PASSED FOR $changedFile **"
 	println "**"
     }
     catch(AssertionError e) {
@@ -107,7 +107,7 @@ def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings,
 def cleanUpDatasets() {
 	def segments = props.mergeBuild_datasetsToCleanUp.split(',')
 	
-	println "Deleting impact build PDSEs ${segments}"
+	println "Deleting merge build PDSEs ${segments}"
 	segments.each { segment ->
 	    def pds = "'${props.hlq}.${segment}'"
 	    if (ZFile.dsExists(pds)) {

--- a/test/testScripts/mergeBuild.groovy
+++ b/test/testScripts/mergeBuild.groovy
@@ -12,6 +12,9 @@ println "\n** Executing test script mergeBuild.groovy"
 def dbbHome = EnvVars.getHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
+// prepare properties file
+writePropsFile()
+
 // create merge build command
 def mergeBuildCommand = []
 mergeBuildCommand << "${dbbHome}/bin/groovyz"
@@ -65,6 +68,18 @@ finally {
 //*************************************************************
 // Method Definitions
 //*************************************************************
+
+def writePropsFile() {
+	println "** Writing propFile ${props.mergeBuild_buildPropSetting} for overwriting the mainBuildBranch"
+	def commands = """
+    echo "# Overwriting the mainBuildBranch for the mergeBuild scenario \nmainBuildBranch=${props.branch}" > ${props.zAppBuildDir}/test/applications/${props.app}/${props.mergeBuild_buildPropSetting}
+    cat ${props.zAppBuildDir}/test/applications/${props.app}/${props.mergeBuild_buildPropSetting}
+"""
+		def task = ['bash', '-c', commands].execute()
+		def outputStream = new StringBuffer();
+		task.waitForProcessOutput(outputStream, System.err)
+	
+}
 
 def copyAndCommit(String changedFile) {
 	println "** Copying and committing ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} to ${props.appLocation}/${changedFile}"

--- a/test/testScripts/mergeBuild.groovy
+++ b/test/testScripts/mergeBuild.groovy
@@ -1,0 +1,118 @@
+
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+import com.ibm.dbb.*
+import com.ibm.dbb.build.*
+import com.ibm.jzos.ZFile
+
+@Field BuildProperties props = BuildProperties.getInstance()
+println "\n** Executing test script mergeBuild.groovy"
+
+// Get the DBB_HOME location
+def dbbHome = EnvVars.getHome()
+if (props.verbose) println "** DBB_HOME = ${dbbHome}"
+
+// create impact build command
+def impactBuildCommand = []
+impactBuildCommand << "${dbbHome}/bin/groovyz"
+impactBuildCommand << "${props.zAppBuildDir}/build.groovy"
+impactBuildCommand << "--workspace ${props.workspace}"
+impactBuildCommand << "--application ${props.app}"
+impactBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+impactBuildCommand << "--hlq ${props.hlq}"
+impactBuildCommand << "--logEncoding UTF-8"
+impactBuildCommand << "--url ${props.url}"
+impactBuildCommand << "--id ${props.id}"
+impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+impactBuildCommand << (props.verbose ? "--verbose" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles}" : "")
+impactBuildCommand << "--mergeBuild"
+
+// iterate through change files to test impact build
+@Field def assertionList = []
+PropertyMappings filesBuiltMappings = new PropertyMappings('mergeBuild_expectedFilesBuilt')
+def changedFiles = props.mergeBuild_changedFiles.split(',')
+println("** Processing changed files from mergeBuild_changedFiles property : ${props.mergeBuild_changedFiles}")
+try {
+	changedFiles.each { changedFile ->
+		println "\n** Running impact build test for changed file $changedFile"
+		
+		// update changed file in Git repo test branch
+		copyAndCommit(changedFile)
+		
+		// run impact build
+		println "** Executing ${impactBuildCommand.join(" ")}"
+		def outputStream = new StringBuffer()
+		def process = ['bash', '-c', impactBuildCommand.join(" ")].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+		
+		// validate build results
+		validateImpactBuild(changedFile, filesBuiltMappings, outputStream)
+	}
+}
+finally {
+	cleanUpDatasets()
+	if (assertionList.size()>0) {
+        println "\n***"
+	println "**START OF FAILED IMPACT BUILD TEST RESULTS**\n"
+	println "*FAILED IMPACT BUILD TEST RESULTS*\n" + assertionList
+	println "\n**END OF FAILED IMPACT BUILD TEST RESULTS**"
+	println "***"
+  }
+}
+// script end  
+
+//*************************************************************
+// Method Definitions
+//*************************************************************
+
+def copyAndCommit(String changedFile) {
+	println "** Copying and committing ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} to ${props.appLocation}/${changedFile}"
+	def commands = """
+    cp ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} ${props.appLocation}/${changedFile}
+    cd ${props.appLocation}/
+    git add .
+    git commit . -m "edited program file"
+"""
+	def task = ['bash', '-c', commands].execute()
+	def outputStream = new StringBuffer();
+	task.waitForProcessOutput(outputStream, System.err)
+}
+
+def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
+
+	println "** Validating impact build results"
+	def expectedFilesBuiltList = filesBuiltMappings.getValue(changedFile).split(',')
+	
+    try{
+	// Validate clean build
+	assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $changedFile\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected number of files built
+	def numImpactFiles = expectedFilesBuiltList.size()
+	assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FOR $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected built files in output stream
+	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FOR $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+	
+	println "**"
+	println "** IMPACT BUILD TEST : PASSED FOR $changedFile **"
+	println "**"
+    }
+    catch(AssertionError e) {
+        def result = e.getMessage()
+        assertionList << result;
+ }
+}
+def cleanUpDatasets() {
+	def segments = props.mergeBuild_datasetsToCleanUp.split(',')
+	
+	println "Deleting impact build PDSEs ${segments}"
+	segments.each { segment ->
+	    def pds = "'${props.hlq}.${segment}'"
+	    if (ZFile.dsExists(pds)) {
+	       if (props.verbose) println "** Deleting ${pds}"
+	       ZFile.remove("//$pds")
+	    }
+	}
+}

--- a/test/testScripts/mergeBuild.groovy
+++ b/test/testScripts/mergeBuild.groovy
@@ -85,7 +85,6 @@ def copyAndCommit(String changedFile) {
 	println "** Copying and committing ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} to ${props.appLocation}/${changedFile}"
 	def commands = """
     cp ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} ${props.appLocation}/${changedFile}
-    echo ' ' >> ${props.appLocation}/${changedFile}
     cd ${props.appLocation}/
     git add .
     git commit . -m "edited program file"

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -28,6 +28,10 @@ def assertBuildProperties(String requiredProps) {
 	}
 }
 
+/*
+ * createFullBuildList() - returns all existing files of the build workspace for the --fullBuild build type
+ * 
+ */
 def createFullBuildList() {
 	Set<String> buildSet = new HashSet<String>()
 	// create the list of build directories
@@ -59,7 +63,6 @@ def getFileSet(String dir, boolean relativePaths, String includeFileList, String
 
 	return fileSet
 }
-
 
 /*
  * copySourceFiles - copies both the program being built and the program

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -188,11 +188,11 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
 }
 
 /*
- * getOutgoingChanges - assembles a git triple-dot diff command to support outgoingChangesBuild scenarios 
+ * getMergeChanges - assembles a git triple-dot diff command to support mergeBuild scenarios 
  *  returns the changed, deleted and renamed files between current HEAD and the provided baseline.
  *  
  */
-def getOutgoingChanges(String gitDir, String baselineReference) {
+def getMergeChanges(String gitDir, String baselineReference) {
 	String gitCmd = "git -C $gitDir --no-pager diff --name-status remotes/origin/$baselineReference...HEAD"
 	return getChangedFiles(gitCmd)
 }

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -177,8 +177,30 @@ def getPreviousGitHash(String gitDir) {
 	}
 }
 
+/*
+ * getChangedFiles - assembles a git diff command to support the impactBuild for a given directory
+ *  returns the changed, deleted and renamed files.
+ * 
+ */
 def getChangedFiles(String gitDir, String baseHash, String currentHash) {
-	String cmd = "git -C $gitDir --no-pager diff --name-status $baseHash $currentHash"
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status $baseHash $currentHash"
+	return getChangedFiles(gitCmd)
+}
+
+/*
+ * getOutgoingChanges - assembles a git triple-dot diff command to support outgoingChangesBuild scenarios 
+ *  returns the changed, deleted and renamed files between current HEAD and the provided baseline.
+ *  
+ */
+def getOutgoingChanges(String gitDir, String baselineReference) {
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status remotes/origin/$baselineReference...HEAD"
+	return getChangedFiles(gitCmd)
+}
+
+/*
+ * getChangedFiles - internal method to submit the a gitDiff command and calucate and classify the idenfified changes 
+ */
+def getChangedFiles(String cmd) {
 	def git_diff = new StringBuffer()
 	def git_error = new StringBuffer()
 	def changedFiles = []

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -291,7 +291,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 				baseline = props.mainBuildBranch
 				current = "HEAD"
 				
-				if (props.verbose) println "** Triple-dot Diffing configuration baseline $baseline -> current HEAD"
+				if (props.verbose) println "** Triple-dot diffing configuration baseline remotes/origin/$baseline -> current HEAD"
 				(changed, deleted, renamed) = gitUtils.getMergeChanges(dir, baseline)
 			}
 		}	

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -174,6 +174,7 @@ def createOutgoingChangeBuildList(RepositoryClient repositoryClient){
 			buildSet.add(changedFile)
 			if (props.verbose) println "** Found build script mapping for $changedFile. Adding to build list"
 		}
+	}
 	
 	return [ buildSet, deletedFiles	]
 }

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -292,7 +292,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 				current = "HEAD"
 				
 				if (props.verbose) println "** Triple-dot Diffing configuration baseline $baseline -> current HEAD"
-				(changed, deleted, renamed) = gitUtils.getOutgoingChanges(dir, baseline)
+				(changed, deleted, renamed) = gitUtils.getMergeChanges(dir, baseline)
 			}
 		}	
 		else {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -146,6 +146,33 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 }
 
 
+/*
+ * createOutgoingChangeBuildList - calculates the changed and deleted files flowing back to the mainBuildBranch
+ *  implements the build type --outgoingChangesBuild
+ *
+ */
+
+def createOutgoingChangeBuildList(){
+	Set<String> changedFiles = new HashSet<String>()
+	Set<String> deletedFiles = new HashSet<String>()
+	Set<String> renamedFiles = new HashSet<String>()
+	Set<String> changedBuildProperties = new HashSet<String>()
+	
+	(changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = calculateChangedFiles(null)
+	
+	// scan files and update source collection
+	updateCollection(changedFiles, deletedFiles, renamedFiles, repositoryClient)
+}
+
+
+/*
+ * calculateChangedFiles - method to caluclate the the changed files
+ * 
+ *  If a BuildResult is provided, this method will diff between the different states in the repository
+ *   if no BuildResult is provided, the method will diff the changes from the topic branch to the main build branch
+ * 
+ */
+
 def calculateChangedFiles(BuildResult lastBuildResult) {
 	// local variables
 	Map<String,String> currentHashes = new HashMap<String,String>()
@@ -160,58 +187,61 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 	if (props.applicationSrcDirs)
 		directories.addAll(props.applicationSrcDirs.split(','))
 
-	// get the current Git hash for all build directories
-	directories.each { dir ->
-		dir = buildUtils.getAbsolutePath(dir)
-		if (props.verbose) println "** Getting current hash for directory $dir"
-		String hash = null
-		if (gitUtils.isGitDir(dir)) {
-			hash = gitUtils.getCurrentGitHash(dir)
+	// when a build result is provided, calculate the baseline hash for each directory
+	if (lastBuildResult != null){
+		// get the current Git hash for all build directories
+		directories.each { dir ->
+			dir = buildUtils.getAbsolutePath(dir)
+			if (props.verbose) println "** Getting current hash for directory $dir"
+			String hash = null
+			if (gitUtils.isGitDir(dir)) {
+				hash = gitUtils.getCurrentGitHash(dir)
+			}
+			String relDir = buildUtils.relativizePath(dir)
+			if (props.verbose) println "** Storing $relDir : $hash"
+			currentHashes.put(relDir,hash)
 		}
-		String relDir = buildUtils.relativizePath(dir)
-		if (props.verbose) println "** Storing $relDir : $hash"
-		currentHashes.put(relDir,hash)
-	}
 
-	// get the baseline hash for all build directories
-	directories.each { dir ->
-		dir = buildUtils.getAbsolutePath(dir)
-		if (props.verbose) println "** Getting baseline hash for directory $dir"
-		String key = "$hashPrefix${buildUtils.relativizePath(dir)}"
-		String relDir = buildUtils.relativizePath(dir)
-		String hash
-		// retrieve baseline reference overwrite if set
-		if (props.baselineRef){
-			String[] baselineMap = (props.baselineRef).split(",")
-			baselineMap.each{
-				// case: baselineRef (gitref)
-				if(it.split(":").size()==1 && relDir.equals(props.application)){
-					if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
-					hash = it
-				}
-				// case: baselineRef (folder:gitref)
-				else if(it.split(":").size()>1){
-					(appSrcDir, gitReference) = it.split(":")
-					if (appSrcDir.equals(relDir)){
+		// get the baseline hash for all build directories
+		directories.each { dir ->
+			dir = buildUtils.getAbsolutePath(dir)
+			if (props.verbose) println "** Getting baseline hash for directory $dir"
+			String key = "$hashPrefix${buildUtils.relativizePath(dir)}"
+			String relDir = buildUtils.relativizePath(dir)
+			String hash
+			// retrieve baseline reference overwrite if set
+			if (props.baselineRef){
+				String[] baselineMap = (props.baselineRef).split(",")
+				baselineMap.each{
+					// case: baselineRef (gitref)
+					if(it.split(":").size()==1 && relDir.equals(props.application)){
 						if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
-						hash = gitReference
+						hash = it
+					}
+					// case: baselineRef (folder:gitref)
+					else if(it.split(":").size()>1){
+						(appSrcDir, gitReference) = it.split(":")
+						if (appSrcDir.equals(relDir)){
+							if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
+							hash = gitReference
+						}
 					}
 				}
-			}
-			// for build directories which are not specified in baselineRef mapping, return the info from lastBuildResult
-			if (hash == null && lastBuildResult) {
+				// for build directories which are not specified in baselineRef mapping, return the info from lastBuildResult
+				if (hash == null && lastBuildResult) {
+					hash = lastBuildResult.getProperty(key)
+				}
+			} else if (lastBuildResult){
+				// return from lastBuildResult
 				hash = lastBuildResult.getProperty(key)
 			}
-		} else if (lastBuildResult){
-			// return from lastBuildResult
-			hash = lastBuildResult.getProperty(key)
+			if (hash == null){
+				println "!** Could not obtain the baseline hash for directory $relDir."
+			}
+
+			if (props.verbose) println "** Storing $relDir : $hash"
+			baselineHashes.put(relDir,hash)
 		}
-		if (hash == null){
-			println "!** Could not obtain the baseline hash for directory $relDir."
-		}
-		
-		if (props.verbose) println "** Storing $relDir : $hash"
-		baselineHashes.put(relDir,hash)
 	}
 
 	// calculate the changed and deleted files by diff'ing the current and baseline hashes
@@ -221,16 +251,35 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 		def changed = []
 		def deleted = []
 		def renamed = []
-		String baseline = baselineHashes.get(buildUtils.relativizePath(dir))
-		String current = currentHashes.get(buildUtils.relativizePath(dir))
-		if (!baseline || !current) {
-			if (props.verbose) println "*! Skipping directory $dir because baseline or current hash does not exist.  baseline : $baseline current : $current"
-		}
-		else if (gitUtils.isGitDir(dir)) {
-			if (props.verbose) println "** Diffing baseline $baseline -> current $current"
-			(changed, deleted, renamed) = gitUtils.getChangedFiles(dir, baseline, current )
-
-		}
+		String baseline
+		String current
+		
+		if (gitUtils.isGitDir(dir)){
+			// when a build result is provided and build type impactBuild,
+			//   calculate changed between baseline and current state of the repository
+			if (lastBuildResult != null && props.impactBuild){
+				baseline = baselineHashes.get(buildUtils.relativizePath(dir))
+				current = currentHashes.get(buildUtils.relativizePath(dir))
+				if (!baseline || !current) {
+					if (props.verbose) println "*! Skipping directory $dir because baseline or current hash does not exist.  baseline : $baseline current : $current"
+				}
+				else {
+					if (props.verbose) println "** Diffing baseline $baseline -> current $current"
+					(changed, deleted, renamed) = gitUtils.getChangedFiles(dir, baseline, current)
+				}
+			}
+			// when no build result is provided but the outgoingChangesBuild,
+			//   calculate the outgoing changes
+			else if(props.outgoingChangesBuild) {
+				
+				// set git references
+				baseline = props.mainBuildBranch
+				current = "HEAD"
+				
+				if (props.verbose) println "** Triple-dot Diffing configuration baseline $baseline -> current HEAD"
+				(changed, deleted, renamed) = gitUtils.getOutgoingChanges(dir, baseline)
+			}
+		}	
 		else {
 			if (props.verbose) println "*! Directory $dir not a local Git repository. Skipping."
 		}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -147,12 +147,12 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 
 
 /*
- * createOutgoingChangeBuildList - calculates the changed and deleted files flowing back to the mainBuildBranch
- *  implements the build type --outgoingChangesBuild
+ * createMergeBuildList - calculates the changed and deleted files flowing back to the mainBuildBranch
+ *  implements the build type --mergeBuild
  *
  */
 
-def createOutgoingChangeBuildList(RepositoryClient repositoryClient){
+def createMergeBuildList(RepositoryClient repositoryClient){
 	Set<String> changedFiles = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()
@@ -285,7 +285,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 			}
 			// when no build result is provided but the outgoingChangesBuild,
 			//   calculate the outgoing changes
-			else if(props.outgoingChangesBuild) {
+			else if(props.mergeBuild) {
 				
 				// set git references
 				baseline = props.mainBuildBranch

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -162,6 +162,20 @@ def createOutgoingChangeBuildList(RepositoryClient repositoryClient){
 	
 	// scan files and update source collection
 	updateCollection(changedFiles, deletedFiles, renamedFiles, repositoryClient)
+	
+	// iterate over changed file and add them to the buildSet
+	
+	Set<String> buildSet = new HashSet<String>()
+	
+	
+	changedFiles.each { changedFile ->
+		// if the changed file has a build script then add to build list
+		if (ScriptMappings.getScriptName(changedFile)) {
+			buildSet.add(changedFile)
+			if (props.verbose) println "** Found build script mapping for $changedFile. Adding to build list"
+		}
+	
+	return [ buildSet, deletedFiles	]
 }
 
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -152,7 +152,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
  *
  */
 
-def createOutgoingChangeBuildList(){
+def createOutgoingChangeBuildList(RepositoryClient repositoryClient){
 	Set<String> changedFiles = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()


### PR DESCRIPTION
This enhancement implements a new build strategy in zAppBuild for topic branches and addresses #151 

The purpose of `--mergeBuild` is to calculate changes which will be merged from the current configuration into the target configuration. 

It uses a `triple-dot git diff` to compare the HEAD to the target remote configuration using the `mainBuildBranch`.

The changes include
* Implementation and Documentation of the new build strategy 
* Test case for the zAppBuild Test Framework

As mentioned in the documentation `--mergeBuild` only builds the changes. **It does not perform impact analysis and is not incremental**; it always processes the list returned by the git diff. Ex.: When you change one file in your topic branch, mergeBuild will process this file. When you change and commit a second file, then both files will be built.