### PR TITLE
Release zAppBuild 2.2.0

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -48,6 +48,10 @@ $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1
 ```
 $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --userBuild --dependencyFile userBuildDependencyFile.json app1/cobol/epsmpmt.cbl
 ```
+ **Build only the changes which will be merged back to the main build branch. No calculation of impacted files.**
+```
+$DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --mergeBuild
+```
 
 ## Command Line Options Summary
 ```
@@ -74,6 +78,8 @@ build options:
                               by changed files since last successful build.
  -b,--baselineRef             Comma seperated list of git references to overwrite
                               the baselineHash hash in an impactBuild scenario.
+ -m,--mergeBuild              Flag indicating to build only source code changes which will be 
+                              merged back to the mainBuildBranch. 
 
  -s,--scanOnly                Flag indicating to only scan source files for application without building anything (deprecated use --scanSource)
  -ss,--scanSource             Flag indicating to only scan source files for application without building anything
@@ -123,6 +129,7 @@ utility options
 - [Perform Impact Build](#perform-impact-build)
 - [Perform Impact Build for topic branches](#perform-impact-build-for-topic-branches)
 - [Perform Impact Build by providing baseline reference for the analysis of changed files](#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files)
+- [Perform a Merge build](#perform-a-merge-build)
 - [Perform a Scan Source build](#perform-a-scan-source-build)
 - [Perform a Scan Source + Outputs build](#perform-a-scan-source--outputs-build)
 
@@ -815,57 +822,57 @@ groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --
   
 ```
 ** Build start at 20210830.095350.053
-** Input args = /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples --workDir /u/dbehm/test/out --hlq DBB.ZAPP.REL --application MortgageApplication --verbose --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/jenkins/zappbuild_config/zappbuild.jenkins.properties --impactBuild --baselineRef 6db56f7eecb420b56b69ca0ab7fcc2f1d9a7e5a8
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/datasets.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/dependencyReport.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/Assembler.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/BMS.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/MFS.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/PSBgen.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/DBDgen.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/ACBgen.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/Cobol.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/LinkEdit.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/PLI.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/REXX.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/build-conf/ZunitConfig.properties
-** appConf = /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf/file.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf/BMS.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf/Cobol.properties
-** Loading property file /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/application-conf/LinkEdit.properties
+** Input args = /var/dbb/dbb-zappbuild/samples --workDir /var/dbb/out/MortgageApplication --hlq DBB.ZAPP.REL --application MortgageApplication --verbose --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/jenkins/zappbuild_config/zappbuild.jenkins.properties --impactBuild --baselineRef 6db56f7eecb420b56b69ca0ab7fcc2f1d9a7e5a8
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/datasets.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/dependencyReport.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Assembler.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/MFS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PSBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/DBDgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ACBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/LinkEdit.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PLI.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/REXX.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ZunitConfig.properties
+** appConf = /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/file.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/LinkEdit.properties
 ** Loading property file /var/dbb/dbb-zappbuild-config/build.properties
 ** Loading property file /var/dbb/dbb-zappbuild-config/datasets.properties
 ** Loading property file /var/jenkins/zappbuild_config/zappbuild.jenkins.properties
 java.version=8.0.6.20 - pmz6480sr6fp20-20201120_02(SR6 FP20)
 java.home=/V2R4/usr/lpp/java/J8.0_64
-user.dir=/u/dbehm/test/baselineOverwrite/dbb-zappbuild
+user.dir=/var/dbb/dbb-zappbuild
 ** Build properties at start up:
 ..... // lists of all build properties
 ** Repository client created for https://dbb-webapp:8080/dbb
-** Build output located at /u/dbehm/test/out/build.20210830.095350.053
+** Build output located at /var/dbb/out/MortgageApplication/build.20210830.095350.053
 ** Build result created for BuildGroup:MortgageApplication-baselineBranch BuildLabel:build.20210830.095350.053 at https://dbb-webapp:8080/dbb/rest/buildResult/54806
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication
-** Getting current hash for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication
+** Getting current hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
 ** Storing MortgageApplication : 192adb8568b8179c7e537a339f1d8df7f2932f4a
-** Getting baseline hash for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication
+** Getting baseline hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
 *** Baseline hash for directory MortgageApplication retrieved from overwrite.
 ** Storing MortgageApplication : 6db56f7eecb420b56b69ca0ab7fcc2f1d9a7e5a8
-** Calculating changed files for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication
+** Calculating changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
 ** Diffing baseline 6db56f7eecb420b56b69ca0ab7fcc2f1d9a7e5a8 -> current 192adb8568b8179c7e537a339f1d8df7f2932f4a
-*** Changed files for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication:
+*** Changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
 **** MortgageApplication/cobol/epscmort.cbl
 **** MortgageApplication/cobol/epsmpmt.cbl
 !! (fixGitDiffPath) File not found.
-*** Deleted files for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication:
-*** Renamed files for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication:
+*** Deleted files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
+*** Renamed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
 ** Updating collections MortgageApplication-baselineBranch and MortgageApplication-baselineBranch-outputs
 *** Sorted list of changed files: [MortgageApplication/cobol/epsmpmt.cbl, MortgageApplication/cobol/epscmort.cbl]
-*** Scanning file MortgageApplication/cobol/epsmpmt.cbl (/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/cobol/epsmpmt.cbl)
+*** Scanning file MortgageApplication/cobol/epsmpmt.cbl (/var/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epsmpmt.cbl)
 *** Scanning file with the default scanner
 *** Logical file for MortgageApplication/cobol/epsmpmt.cbl =
 {"dli":false,"lname":"EPSMPMT","file":"MortgageApplication\/cobol\/epsmpmt.cbl","mq":false,"cics":false,"logicalDependencies":[{"lname":"EPSPDATA","library":"SYSLIB","category":"COPY"}],"language":"COB","sql":false}
-*** Scanning file MortgageApplication/cobol/epscmort.cbl (/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication/cobol/epscmort.cbl)
+*** Scanning file MortgageApplication/cobol/epscmort.cbl (/var/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epscmort.cbl)
 *** Scanning file with the default scanner
 *** Logical file for MortgageApplication/cobol/epscmort.cbl =
 {"dli":false,"lname":"EPSCMORT","file":"MortgageApplication\/cobol\/epscmort.cbl","mq":false,"cics":true,"logicalDependencies":[{"lname":"DFHAID","library":"SYSLIB","category":"COPY"},{"lname":"EPSMORT","library":"SYSLIB","category":"COPY"},{"lname":"EPSMTCOM","library":"SYSLIB","category":"COPY"},{"lname":"EPSNBRPM","library":"SYSLIB","category":"COPY"},{"lname":"SQLCA","library":"SYSLIB","category":"SQL INCLUDE"}],"language":"COB","sql":true}
@@ -874,14 +881,14 @@ HTTP/1.1 200 OK
 *** Perform impacted analysis for changed files.
 ** Found build script mapping for MortgageApplication/cobol/epsmpmt.cbl. Adding to build list
 ** Performing impact analysis on changed file MortgageApplication/cobol/epsmpmt.cbl
-*** Creating impact resolver for MortgageApplication/cobol/epsmpmt.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                },{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/bms"} ]             },{"category": "LINK", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/cobol"}, {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/link"} ]             },{"category": "PROPERTY"}] rules
+*** Creating impact resolver for MortgageApplication/cobol/epsmpmt.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                },{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/bms"} ]             },{"category": "LINK", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/cobol"}, {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/link"} ]             },{"category": "PROPERTY"}] rules
 ** Found impacted file MortgageApplication/link/epsmlist.lnk
 ** MortgageApplication/link/epsmlist.lnk is impacted by changed file MortgageApplication/cobol/epsmpmt.cbl. Adding to build list.
 ** Found build script mapping for MortgageApplication/cobol/epscmort.cbl. Adding to build list
 ** Performing impact analysis on changed file MortgageApplication/cobol/epscmort.cbl
-*** Creating impact resolver for MortgageApplication/cobol/epscmort.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                },{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/bms"} ]             },{"category": "LINK", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/cobol"}, {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/link"} ]             },{"category": "PROPERTY"}] rules
+*** Creating impact resolver for MortgageApplication/cobol/epscmort.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                },{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/bms"} ]             },{"category": "LINK", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/cobol"}, {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/link"} ]             },{"category": "PROPERTY"}] rules
 *** Perform impacted analysis for property changes.
-** Writing build list file to /u/dbehm/test/out/build.20210830.095350.053/buildList.txt
+** Writing build list file to /var/dbb/out/MortgageApplication/build.20210830.095350.053/buildList.txt
 MortgageApplication/cobol/epsmpmt.cbl
 MortgageApplication/cobol/epscmort.cbl
 MortgageApplication/link/epsmlist.lnk
@@ -894,28 +901,28 @@ required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_comp
 ** Creating / verifying build dataset DBB.ZAPP.REL.DBRM
 ** Creating / verifying build dataset DBB.ZAPP.REL.LOAD
 *** Building file MortgageApplication/cobol/epsmpmt.cbl
-*** Creating dependency resolver for MortgageApplication/cobol/epsmpmt.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
+*** Creating dependency resolver for MortgageApplication/cobol/epsmpmt.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
 *** Scanning file with the default scanner
 *** Resolution rules for MortgageApplication/cobol/epsmpmt.cbl:
-{"library":"SYSLIB","searchPath":[{"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
+{"library":"SYSLIB","searchPath":[{"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
 *** Physical dependencies for MortgageApplication/cobol/epsmpmt.cbl:
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSPDATA","library":"SYSLIB","file":"MortgageApplication\/copybook\/epspdata.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSPDATA","library":"SYSLIB","file":"MortgageApplication\/copybook\/epspdata.cpy","category":"COPY","resolved":true}
 Cobol compiler parms for MortgageApplication/cobol/epsmpmt.cbl = LIB
 *** Scanning load module for MortgageApplication/cobol/epsmpmt.cbl
 *** Logical file =
 {"dli":false,"lname":"EPSMPMT","file":"MortgageApplication\/cobol\/epsmpmt.cbl","mq":false,"cics":false,"language":"ZBND","sql":false}
 *** Building file MortgageApplication/cobol/epscmort.cbl
-*** Creating dependency resolver for MortgageApplication/cobol/epscmort.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
+*** Creating dependency resolver for MortgageApplication/cobol/epscmort.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
 *** Scanning file with the default scanner
 *** Resolution rules for MortgageApplication/cobol/epscmort.cbl:
-{"library":"SYSLIB","searchPath":[{"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
+{"library":"SYSLIB","searchPath":[{"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
 *** Physical dependencies for MortgageApplication/cobol/epscmort.cbl:
 {"excluded":false,"lname":"DFHAID","library":"SYSLIB","category":"COPY","resolved":false}
 {"excluded":false,"lname":"EPSMORT","library":"SYSLIB","category":"COPY","resolved":false}
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
-{"excluded":false,"sourceDir":"\/u\/dbehm\/test\/baselineOverwrite\/dbb-zappbuild\/samples","lname":"EPSNBRPM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSNBRPM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","category":"COPY","resolved":true}
 {"excluded":false,"lname":"SQLCA","library":"SYSLIB","category":"SQL INCLUDE","resolved":false}
 Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
 *** Scanning load module for MortgageApplication/cobol/epscmort.cbl
@@ -932,12 +939,12 @@ required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkE
 *** Scanning load module for MortgageApplication/link/epsmlist.lnk
 *** Logical file =
 {"dli":false,"lname":"EPSMLIST","file":"MortgageApplication\/link\/epsmlist.lnk","mq":false,"cics":false,"logicalDependencies":[{"lname":"EPSMPMT","library":"DBB.ZAPP.REL.LOAD","category":"LINK"},{"lname":"EPSMLIST","library":"DBB.ZAPP.REL.OBJ","category":"LINK"}],"language":"ZBND","sql":false}
-*** Obtaining hash for directory /u/dbehm/test/baselineOverwrite/dbb-zappbuild/samples/MortgageApplication
+*** Obtaining hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
 ** Setting property :githash:MortgageApplication : 192adb8568b8179c7e537a339f1d8df7f2932f4a
 ** Setting property :giturl:MortgageApplication : git@github.com:dennis-behm/dbb-zappbuild.git
 ** Setting property :gitchangedfiles:MortgageApplication : https://github.com/ibm/dbb-zappbuild/compare/192adb8568b8179c7e537a339f1d8df7f2932f4a..192adb8568b8179c7e537a339f1d8df7f2932f4a
-** Writing build report data to /u/dbehm/test/out/build.20210830.095350.053/BuildReport.json
-** Writing build report to /u/dbehm/test/out/build.20210830.095350.053/BuildReport.html
+** Writing build report data to /var/dbb/out/MortgageApplication/build.20210830.095350.053/BuildReport.json
+** Writing build report to /var/dbb/out/MortgageApplication/build.20210830.095350.053/BuildReport.html
 ** Updating build result BuildGroup:MortgageApplication-baselineBranch BuildLabel:build.20210830.095350.053 at https://dbb-webapp:8080/dbb/rest/buildResult/54806
 ** Build ended at Mon Aug 30 09:53:59 GMT+01:00 2021
 ** Build State : CLEAN
@@ -947,6 +954,127 @@ required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkE
 
 </details>
 
+
+### Perform a Merge build
+
+`--mergeBuild` calculate the changes of a topic branch flowing back into the `mainBuildBranch` reference. This build type does not perform calculation of impacted files.
+
+The scenario is targeting for builds on topic branches. The scope of the build is focussing on the outgoing changes. It is not incremental. Any time you invoke this build, it will the changes which will be merged to the target reference. 
+
+It leverages the git triple-dot diff syntax to identify the changes, similar to what can be seen in a pull/merge request.      
+
+In the below case both `MortgageApplication/cobol/epsmlist.cbl` and `MortgageApplication/copybook/epsnbrpm.cpy` are changed, but only the `epsmlist.cbl` is built because it is mapped to a build script.  
+
+```
+groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --hlq DBB.ZAPP.CLEAN.MASTER --workDir /var/dbb/out/MortgageApplication --application MortgageApplication --logEncoding UTF-8 --mergeBuild --verbose
+```
+<details>
+  <summary>Build log</summary>
+
+```
++ /usr/lpp/dbb/v1r0/bin/groovyz /var/dbb/dbb-zappbuild/build.groovy --sourceDir /var/dbb/dbb-zappbuild/samples --workDir /var/dbb/out/MortgageApplication --hlq DBB.ZAPP.MERGE.BUILD --application MortgageApplication --verbose --mergeBuild --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties
+
+** Build start at 20211116.104234.042
+** Input args = /var/dbb/dbb-zappbuild/samples --workDir /var/dbb/out/MortgageApplication --hlq DBB.ZAPP.MERGE.BUILD --application MortgageApplication --verbose --mergeBuild --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/datasets.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/dependencyReport.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Assembler.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/MFS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PSBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/DBDgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ACBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/LinkEdit.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PLI.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/REXX.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ZunitConfig.properties
+** appConf = /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/file.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/LinkEdit.properties
+** Loading property file /var/dbb/dbb-zappbuild-config/build.properties
+** Loading property file /var/dbb/dbb-zappbuild-config/datasets.properties
+java.version=8.0.6.36 - pmz6480sr6fp36-20210913_01(SR6 FP36)
+java.home=/V2R4/usr/lpp/java/J8.0_64
+user.dir=/u/dbehm
+** Build properties at start up:
+..... // lists of all build properties
+** Repository client created for https://10.3.20.96:10443/dbb
+** Build output located at /var/dbb/out/MortgageApplication/build.20211116.104234.042
+** Build result created for BuildGroup:MortgageApplication-outgoingChangesBuild BuildLabel:build.20211116.104234.042 at https://10.3.20.96:10443/dbb/rest/buildResult/58773
+** --mergeBuild option selected. Building changed programs for application MortgageApplication flowing back to main
+** Calculating changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+** Triple-dot Diffing configuration baseline main -> current HEAD
+*** Changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
+!! (fixGitDiffPath) File not found.
+**** MortgageApplication/application-conf/application.properties
+**** MortgageApplication/cobol/epsmlist.cbl
+**** MortgageApplication/copybook/epsnbrpm.cpy
+!! (fixGitDiffPath) File not found.
+!! (fixGitDiffPath) File not found.
+!! (fixGitDiffPath) File not found.
+*** Deleted files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
+*** Renamed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication:
+** Updating collections MortgageApplication-outgoingChangesBuild and MortgageApplication-outgoingChangesBuild-outputs
+*** Sorted list of changed files: [MortgageApplication/cobol/epsmlist.cbl, MortgageApplication/copybook/epsnbrpm.cpy]
+*** Scanning file MortgageApplication/cobol/epsmlist.cbl (/var/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epsmlist.cbl)
+*** Scanning file with the default scanner
+*** Logical file for MortgageApplication/cobol/epsmlist.cbl =
+{"dli":false,"lname":"EPSMLIST","file":"MortgageApplication\/cobol\/epsmlist.cbl","mq":false,"cics":true,"logicalDependencies":[{"lname":"DFHAID","library":"SYSLIB","category":"COPY"},{"lname":"EPSMLIS","library":"SYSLIB","category":"COPY"},{"lname":"EPSMORTF","library":"SYSLIB","category":"COPY"},{"lname":"EPSMTCOM","library":"SYSLIB","category":"COPY"},{"lname":"EPSNBRPM","library":"SYSLIB","category":"COPY"}],"language":"COB","sql":false}
+*** Scanning file MortgageApplication/copybook/epsnbrpm.cpy (/var/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsnbrpm.cpy)
+*** Scanning file with the default scanner
+*** Logical file for MortgageApplication/copybook/epsnbrpm.cpy =
+{"dli":false,"lname":"EPSNBRPM","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","mq":false,"cics":false,"language":"COB","sql":false}
+** Storing 2 logical files in repository collection 'MortgageApplication-outgoingChangesBuild'
+HTTP/1.1 200 OK
+** Found build script mapping for MortgageApplication/cobol/epsmlist.cbl. Adding to build list
+** Writing build list file to /var/dbb/out/MortgageApplication/build.20211116.104234.042/buildList.txt
+MortgageApplication/cobol/epsmlist.cbl
+** Updating collections MortgageApplication-outgoingChangesBuild and MortgageApplication-outgoingChangesBuild-outputs
+*** Scanning file MortgageApplication/cobol/epsmlist.cbl (/var/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epsmlist.cbl)
+*** Scanning file with the default scanner
+*** Logical file for MortgageApplication/cobol/epsmlist.cbl =
+{"dli":false,"lname":"EPSMLIST","file":"MortgageApplication\/cobol\/epsmlist.cbl","mq":false,"cics":true,"logicalDependencies":[{"lname":"DFHAID","library":"SYSLIB","category":"COPY"},{"lname":"EPSMLIS","library":"SYSLIB","category":"COPY"},{"lname":"EPSMORTF","library":"SYSLIB","category":"COPY"},{"lname":"EPSMTCOM","library":"SYSLIB","category":"COPY"},{"lname":"EPSNBRPM","library":"SYSLIB","category":"COPY"}],"language":"COB","sql":false}
+** Storing 1 logical files in repository collection 'MortgageApplication-outgoingChangesBuild'
+HTTP/1.1 200 OK
+** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
+** Building files mapped to Cobol.groovy script
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.COBOL
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.COPY
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.OBJ
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.DBRM
+** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.LOAD
+*** Building file MortgageApplication/cobol/epsmlist.cbl
+*** Creating dependency resolver for MortgageApplication/cobol/epsmlist.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/var/dbb/dbb-zappbuild/samples", "directory": "MortgageApplication/copybook"} ]                }] rules
+*** Scanning file with the default scanner
+*** Resolution rules for MortgageApplication/cobol/epsmlist.cbl:
+{"library":"SYSLIB","searchPath":[{"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","directory":"MortgageApplication\/copybook"}]}
+*** Physical dependencies for MortgageApplication/cobol/epsmlist.cbl:
+{"excluded":false,"lname":"DFHAID","library":"SYSLIB","category":"COPY","resolved":false}
+{"excluded":false,"lname":"EPSMLIS","library":"SYSLIB","category":"COPY","resolved":false}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMORTF","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmortf.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/var\/dbb\/dbb-zappbuild\/samples","lname":"EPSNBRPM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","category":"COPY","resolved":true}
+Cobol compiler parms for MortgageApplication/cobol/epsmlist.cbl = LIB,CICS
+*** Obtaining hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+** Setting property :githash:MortgageApplication : d03087c5e4583be84cbe5c03a5fc7113074f46d2
+** Setting property :giturl:MortgageApplication : https://github.com/dennis-behm/dbb-zappbuild.git
+** Writing build report data to /var/dbb/out/MortgageApplication/build.20211116.104234.042/BuildReport.json
+** Writing build report to /var/dbb/out/MortgageApplication/build.20211116.104234.042/BuildReport.html
+** Updating build result BuildGroup:MortgageApplication-outgoingChangesBuild BuildLabel:build.20211116.104234.042 at https://10.3.20.96:10443/dbb/rest/buildResult/58773
+** Build ended at Tue Nov 16 22:42:40 GMT+01:00 2021
+** Build State : CLEAN
+** Total files processed : 1
+** Total build time  : 5.468 seconds
+```
+
+
+</details>
 
 ### Perform a Scan Source build
 
@@ -959,6 +1087,7 @@ groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --
 ```
 <details>
   <summary>Build log</summary>
+
 ```
 ** Build start at 20210622.104821.048
 ** Input args = /var/dbb/dbb-zappbuild/samples --hlq DBB.ZAPP.CLEAN.MASTER --workDir /var/dbb/out/MortgageApplication --application MortgageApplication --logEncoding UTF-8 --fullBuild --scanSource --verbose
@@ -1094,6 +1223,7 @@ groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --
 ```
 <details>
   <summary>Build log</summary>
+
 ```
 ** Build start at 20210622.105915.059
 ** Input args = /var/dbb/dbb-zappbuild/samples --hlq DBB.ZAPP.CLEAN.MASTER --workDir /var/dbb/out/MortgageApplication --application MortgageApplication --logEncoding UTF-8 --fullBuild --scanAll --verbose
@@ -1249,4 +1379,5 @@ HTTP/1.1 200 OK
 ** Total files processed : 15
 ** Total build time  : 23.718 seconds
 ```
+
 </details>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ zAppBuild supports a number of build scenarios:
 * **Impact Build** - Build only programs impacted by source files that have changed since the last successful build.
 * **Impact Build with baseline reference** - Build only programs impacted by source files that have changed by diff'ing to a previous configuration reference.
 * **Topic Branch Build** - Detects when building a topic branch for the first time and will automatically clone the dependency data collections from the main build branch in order to avoid having to rescan the entire application.
+* **Merge Build** - Build only changed programs which will be merged back into the mainBuildBranch by using a triple-dot git diff. 
 * **Scan Source** - Skip the actual building and only scan source files to store dependency data in collection (migration scenario).
 * **Scan Source + Outputs** - Skip the actual building and only scan source files and existing load modules to dependency data in source and output collection (migration scenario with static linkage scenarios).
 

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -43,6 +43,7 @@ impactBuildOnBuildPropertyChanges | Boolean property to activate impact builds o
 impactBuildOnBuildPropertyList | List of build property lists referencing which language properties should cause an impact build when the given property is changed 
 continueOnScanFailure | Determine the behavior when facing a scanner failure. true (default) to continue scanning. false will terminate the process. 
 createBuildOutputSubfolder | Option to create a subfolder with the build label within the build output dir (outDir). Default: true. 
+generateDb2BindInfoRecord | Flag to control the generation of a generic DBB build record for a build file to document the configured db2 bind information (application-conf/bind.properties). Default: false ** Can be overridden by a file property. 
 dbb.file.tagging | Controls compile log and build report file tagging. Default: true.
 dbb.LinkEditScanner.excludeFilter | DBB configuration property used by the link edit scanner to exclude load module entries
 dbb.RepositoryClient.url | DBB configuration property for web application URL.  ***Can be overridden by build.groovy option -url, --url***

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -38,6 +38,7 @@ buildPropFiles | Comma separated list of additional build property files to load
 buildListFileExt | File extension that indicates the build file is really a build list.
 languagePropertyQualifiers | List of language script property qualifiers. Each language script property has a unique qualifier to avoid collision with other language script properties.
 applicationConfRootDir | Alternate root directory for application-conf location.  Allows for the deployment of the application-conf directories to a static location.  Defaults to ${workspace}/${application}
+requiredDBBToolkitVersion | Minimum required DBB ToolkitVersion to run this version of zAppBuild.
 requiredBuildProperties | Comma separated list of required build properties for zAppBuild/build.groovy. Build and language scripts will validate that *required* build properties have been set before the script runs.  If any are missing or empty, then a validation error will be thrown.
 impactBuildOnBuildPropertyChanges | Boolean property to activate impact builds on changes of build properties within the application repository
 impactBuildOnBuildPropertyList | List of build property lists referencing which language properties should cause an impact build when the given property is changed 

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -251,3 +251,13 @@ zunit_loadOptions | BPXWDYN creation options for creating 'load module' type dat
 zunit_reportDatasets | Comma separated list of 'report' type data sets
 zunit_reportOptions | BPXWDYN creation options for creating 'report' type data sets
 
+### Transfer.properties
+Build properties used by zAppBuild/language/Transfer.groovy
+
+Property | Description 
+--- | --- 
+transfer_requiredBuildProperties | Comma separated list of required build properties for language/Transfer.groovy
+transfer_srcPDS | Dataset of any type of source
+transfer_jclPDS | Sample dataset for JCL members
+transfer_xmlPDS | Sample dataset for xml members
+transfer_srcOptions | BPXWDYN creation options for creating 'source' type data sets

--- a/build-conf/Transfer.properties
+++ b/build-conf/Transfer.properties
@@ -1,7 +1,7 @@
 # Releng properties used by language/Transfer.groovy
 
 # Comma separated list of required build properties for Cobol.groovy
-transfer_requiredBuildProperties=transfer_srcPDS,transfer_srcOptions,transfer_datasetMapping,\
+transfer_requiredBuildProperties=transfer_srcPDS,transfer_srcOptions,\
   transfer_deployType
 
 #

--- a/build-conf/Transfer.properties
+++ b/build-conf/Transfer.properties
@@ -1,0 +1,20 @@
+# Releng properties used by language/Transfer.groovy
+
+# Comma separated list of required build properties for Cobol.groovy
+transfer_requiredBuildProperties=transfer_srcPDS,transfer_srcOptions,transfer_datasetMapping,\
+  transfer_deployType
+
+#
+# transfer source data sets
+# Add additional dataset definitions, depending on your requirements
+#
+# Please note, that files in the repository require to be mapped by a PropertyMapping in file.properties
+# to one of the dataset definitions
+#
+transfer_srcPDS=${hlq}.SOURCE
+transfer_jclPDS=${hlq}.JCL
+transfer_xmlPDS=${hlq}.XML
+
+#
+# dataset creation options
+transfer_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of additional build property files to load
 # Supports both relative path (to zAppBuild/build-conf/) and absolute path
-buildPropFiles=datasets.properties,dependencyReport.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,REXX.properties,ZunitConfig.properties,Transfer.groovy
+buildPropFiles=datasets.properties,dependencyReport.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,REXX.properties,ZunitConfig.properties,Transfer.properties
 
 #
 # file extension that indicates the build file is really a build list or build list filter

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -43,6 +43,11 @@ gitRepositoryCompareService=/compare/
 applicationConfRootDir=
 
 #
+# Minimum required DBB ToolkitVersion to run this version of zAppBuild
+#  Build initialization process validates the DBB Toolkit Version in use and matches that against this setting 
+requiredDBBToolkitVersion=1.0.0
+
+#
 # Comma separated list of required build properties for zAppBuild/build.groovy
 requiredBuildProperties=buildOrder,buildListFileExt
 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of additional build property files to load
 # Supports both relative path (to zAppBuild/build-conf/) and absolute path
-buildPropFiles=datasets.properties,dependencyReport.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,REXX.properties,ZunitConfig.properties
+buildPropFiles=datasets.properties,dependencyReport.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,REXX.properties,ZunitConfig.properties,Transfer.groovy
 
 #
 # file extension that indicates the build file is really a build list or build list filter

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -66,6 +66,18 @@ impactBuildOnBuildPropertyList=[${assembler_impactPropertyList},${assembler_impa
 # Default: false
 createTestcaseDependency=false
 
+# generateDb2BindInfoRecord controls if zAppBuild generates a generic DBB build record for a build file
+# to document the configured db2 bind options (application-conf/bind.properties) .
+# This allows to pass the information into the packaging step and on to your deployment manager, like UCD.
+# Implemented in Assembler.groovy, Cobol.groovy and PLI.groovy
+# See also generateDb2BindInfoRecordProperties for the list of properties which are documented
+# Default: false
+generateDb2BindInfoRecord=false
+
+# generateDb2BindInfoRecordProperties is a comma-separated list of existing bind parameters configured to zAppBuild.
+# See application-conf/bind.properties for available properties.
+generateDb2BindInfoRecordProperties=bind_collectionID,bind_packageOwner,bind_qualifier
+
 # dbb.file.tagging controls compile log and build report file tagging. If true, files
 # written as UTF-8 or ASCII are tagged.
 # If the environment variable _BPXK_AUTOCVT is set ALL, file tagging may have an

--- a/build.groovy
+++ b/build.groovy
@@ -87,6 +87,14 @@ def initializeBuildProcess(String[] args) {
 
 	// build properties initial set
 	populateBuildProperties(args)
+	
+	// print dbb toolkit version in use
+	def dbbToolkitVersion = VersionInfo.getInstance().getVersion()
+	def dbbToolkitBuildDate = VersionInfo.getInstance().getDate()
+	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion} ${dbbToolkitBuildDate} "
+	
+	// verify required dbb toolkit
+	buildUtils.assertDbbBuildToolkitVersion(dbbToolkitVersion)
 
 	// verify required build properties
 	buildUtils.assertBuildProperties(props.requiredBuildProperties)

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -3,6 +3,8 @@ import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
+import com.ibm.dbb.build.report.*
+import com.ibm.dbb.build.report.records.*
 
 
 // define script properties
@@ -60,6 +62,13 @@ sortedList.each { buildFile ->
 			println(errorMsg)
 			props.error = "true"
 			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+		} else {
+			// Store db2 bind information as a generic property record in the BuildReport
+			String generateDb2BindInfoRecord = props.getFileProperty('generateDb2BindInfoRecord', buildFile)
+			if (generateDb2BindInfoRecord.toBoolean()){
+				PropertiesRecord db2BindInfoRecord = buildUtils.generateDb2InfoRecord(buildFile)
+				BuildReportFactory.getBuildReport().addRecord(db2BindInfoRecord)
+			}
 		}
 	}
 

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -4,6 +4,8 @@ import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
 import com.ibm.jzos.ZFile
+import com.ibm.dbb.build.report.*
+import com.ibm.dbb.build.report.records.*
 
 
 // define script properties
@@ -71,8 +73,15 @@ sortedList.each { buildFile ->
 		props.error = "true"
 		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
 	}
-	else {
-		// if this program needs to be link edited . . .
+	else { // if this program needs to be link edited . . .
+		
+		// Store db2 bind information as a generic property record in the BuildReport
+		String generateDb2BindInfoRecord = props.getFileProperty('generateDb2BindInfoRecord', buildFile)
+		if (buildUtils.isSQL(logicalFile) && generateDb2BindInfoRecord.toBoolean() ){
+			PropertiesRecord db2BindInfoRecord = buildUtils.generateDb2InfoRecord(buildFile)
+			BuildReportFactory.getBuildReport().addRecord(db2BindInfoRecord)
+		}
+		
 		String needsLinking = props.getFileProperty('cobol_linkEdit', buildFile)
 		if (needsLinking.toBoolean()) {
 			rc = linkEdit.execute()

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -4,6 +4,8 @@ import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
 import com.ibm.jzos.ZFile
+import com.ibm.dbb.build.report.*
+import com.ibm.dbb.build.report.records.*
 
 
 // define script properties
@@ -58,6 +60,14 @@ sortedList.each { buildFile ->
 	}
 	else {
 		// if this program needs to be link edited . . .
+
+		// Store db2 bind information as a generic property record in the BuildReport
+		String generateDb2BindInfoRecord = props.getFileProperty('generateDb2BindInfoRecord', buildFile)
+		if (buildUtils.isSQL(logicalFile) && generateDb2BindInfoRecord.toBoolean() ){
+			PropertiesRecord db2BindInfoRecord = buildUtils.generateDb2InfoRecord(buildFile)
+			BuildReportFactory.getBuildReport().addRecord(db2BindInfoRecord)
+		}
+
 		String needsLinking = props.getFileProperty('pli_linkEdit', buildFile)
 		if (needsLinking.toBoolean()) {
 			rc = linkEdit.execute()

--- a/languages/Transfer.groovy
+++ b/languages/Transfer.groovy
@@ -1,0 +1,89 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import com.ibm.dbb.repository.*
+import com.ibm.dbb.dependency.*
+import com.ibm.dbb.build.*
+import com.ibm.dbb.build.report.records.*
+import com.ibm.dbb.build.report.*
+import groovy.transform.*
+
+/***
+ * 
+ * Language script, which transfers files to the defined target dataset 
+ * and reports the file as a build output file in the build report.
+ * 
+ * Can be used for JCL, XML, Shared Copybooks and any other type of source code
+ * which needs to be packaged and processed by the pipeline.
+ * 
+ * Please note:
+ * 
+ * * Verify the allocation options and adjust to your needs.
+ * 
+ * * File names cannot exeed more than 8 characters, so they can be stored in
+ *   the target dataset.
+ * 
+ */
+
+// define script properties
+@Field BuildProperties props = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+// Set to keep information about which datasets where already checked/created
+@Field HashSet<String> verifiedBuildDatasets = new HashSet<String>()
+
+@Field RepositoryClient repositoryClient
+
+println("** Building files mapped to ${this.class.getName()}.groovy script")
+
+// verify required build properties
+buildUtils.assertBuildProperties(props.transfer_requiredBuildProperties)
+
+List<String> buildList = argMap.buildList
+
+// iterate through build list
+buildList.each { buildFile ->
+	println "*** Building file $buildFile"
+
+	// local variables and log file
+	String member = CopyToPDS.createMemberName(buildFile)
+
+	// evaluate the datasetmapping, which maps build files to targetDataset defintions 
+	PropertyMappings dsMapping = new PropertyMappings("transfer_datasetMapping")
+	
+	// obtain the target dataset based on the mapped dataset key
+	String targetDataset = props.getProperty(dsMapping.getValue(buildFile))
+	
+	if (targetDataset != null) {
+
+		// allocate target dataset
+		if (!verifiedBuildDatasets.contains(targetDataset)) { // using a cache not to allocate all defined datasets
+			verifiedBuildDatasets.add(targetDataset)
+			buildUtils.createDatasets(targetDataset.split(), props.transfer_srcOptions)
+		}
+
+		// copy the file to the target dataset
+		String deployType = buildUtils.getDeployType("transfer", buildFile, null)
+		int rc = new CopyToPDS().file(new File(buildUtils.getAbsolutePath(buildFile))).dataset(targetDataset).member(member).output(true).deployType(deployType).execute()
+		
+		if (props.verbose) println "** Copyied $buildFile to $targetDataset with deployTyoe $deployType; rc = $rc"
+		
+		if (rc!=0){
+			String errorMsg = "*! The CopyToPDS return code ($rc) for $buildFile exceeded the maximum return code allowed (0)."
+			println(errorMsg)
+			props.error = "true"
+			buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+		}
+	} else {
+		String errorMsg =  "*! Target dataset for $buildFile could not be obtained. "
+		println(errorMsg)
+		props.error = "true"
+		buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+	}
+}
+
+// internal methods
+ 
+def getRepositoryClient() {
+	if (!repositoryClient && props."dbb.RepositoryClient.url")
+		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
+
+	return repositoryClient
+}

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -18,7 +18,7 @@ buildOrder=BMS.groovy,Cobol.groovy,LinkEdit.groovy
 #
 # The main build branch.  Used for cloning collections for topic branch builds instead
 # of rescanning the entire application.
-mainBuildBranch=master
+mainBuildBranch=main
 
 #
 # The git repository URL of the application repository to establish links to the changed files 

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -250,3 +250,10 @@ rexx_deployType | default deployType | true
 rexx_cexec_deployType | default deployType CEXEC | true
 rexx_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
 rexx_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
+
+### nonBuildable.properties
+Application properties used by zAppBuild/language/Transfer.groovy
+
+Property | Description | Overridable
+--- | --- | ---
+transfer_deployType | deployType | true

--- a/samples/application-conf/Transfer.properties
+++ b/samples/application-conf/Transfer.properties
@@ -1,0 +1,5 @@
+# Application properties used by zAppBuild/language/Transfer.groovy
+
+#
+# default deployType
+transfer_deployType=TRANSFER

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -8,7 +8,7 @@
 #
 # Comma separated list of additional application property files to load
 # Supports both relative path (to ${application}/application-conf/) and absolute path
-applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,REXX.properties,ZunitConfig.properties
+applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,REXX.properties,ZunitConfig.properties,Transfer.properties
 
 #
 # Comma separated list all source directories included in application build. Supports both absolute
@@ -18,7 +18,7 @@ applicationSrcDirs=${application}
 
 #
 # Comma separated list of the build script processing order
-buildOrder=BMS.groovy,MFS.groovy,Cobol.groovy,Assembler.groovy,PLI.groovy,LinkEdit.groovy,DBDgen.groovy,PSBgen.groovy
+buildOrder=BMS.groovy,MFS.groovy,Cobol.groovy,Assembler.groovy,PLI.groovy,LinkEdit.groovy,DBDgen.groovy,PSBgen.groovy,Transfer.groovy
 
 #
 # Comma seperated list of the test script processing order

--- a/samples/application-conf/file.properties
+++ b/samples/application-conf/file.properties
@@ -11,6 +11,7 @@ dbb.scriptMapping = Cobol.groovy :: **/*.cbl
 dbb.scriptMapping = LinkEdit.groovy :: **/*.lnk
 dbb.scriptMapping = PLI.groovy :: **/*.pli
 dbb.scriptMapping = ZunitConfig.groovy :: **/*.bzucfg
+dbb.scriptMapping = Transfer.groovy :: **/*.jcl, **/*.xml
 
 #
 # Scanner mappings for application programs that require a custom scanner
@@ -32,3 +33,14 @@ dbb.scannerMapping = ZUnitConfigScanner :: **/*.bzucfg
 #
 # mapping for overwriting the impactResolution rules in application.properties
 # impactResolutionRules=[${copybookRule},${linkRule}] :: **/copy/*.cpy,**/cobol/*.cbl
+
+#
+# PropertyMapping to map files using the Transfer.groovy language script to different target datasets 
+#
+# transfer_datasetMapping = transfer_jclPDS :: **/*.jcl
+# transfer_datasetMapping = transfer_xmlPDS :: **/xml/*.*
+#
+# file mapping for overwriting the default deployType of the Transfer.groovy language script 
+#
+# transfer_deployType = JCL :: **/*.jcl
+# transfer_deployType = XML :: **/xml/*.*

--- a/test/applications/MortgageApplication/application-conf/Cobol.properties
+++ b/test/applications/MortgageApplication/application-conf/Cobol.properties
@@ -1,0 +1,85 @@
+# Application properties used by zAppBuild/language/Cobol.groovy
+
+#
+# default COBOL program build rank - used to sort language build file list
+# leave empty - overridden by file properties if sorting needed
+cobol_fileBuildRank=
+
+#
+# COBOL dependency resolution rules
+# Rules defined in application.properties
+cobol_resolutionRules=[${copybookRule}]
+
+#
+# default COBOL compiler version
+# can be overridden by file properties
+cobol_compilerVersion=V6
+
+#
+# default COBOL maximum RCs allowed
+# can be overridden by file properties
+cobol_compileMaxRC=4
+cobol_linkEditMaxRC=4
+
+#
+# lists of properties which should cause a rebuild after being changed
+cobol_impactPropertyList=cobol_compilerVersion,cobol_compileParms
+cobol_impactPropertyListCICS=cobol_compileCICSParms
+cobol_impactPropertyListSQL=cobol_compileSQLParms
+
+#
+# default COBOL compiler parameters
+# can be overridden by file properties
+cobol_compileParms=LIB,LIST
+cobol_compileCICSParms=CICS
+cobol_compileSQLParms=SQL
+cobol_compileErrorPrefixParms=ADATA,EX(ADX(ELAXMGUX))
+
+# Compile Options for IBM Debugger. Assuming to keep Dwarf Files inside the load.
+# If you would like to separate debug info, additional allocations needed (See COBOL + Debugger libraries)
+cobol_compileDebugParms=TEST
+
+#
+# default LinkEdit parameters
+# can be overridden by file properties
+cobol_linkEditParms=MAP,RENT,COMPAT(PM5)
+
+# If you would like to have a physical link card, we generated it for you given the below pattern
+# This property has priority over cobol_linkDebugExit
+# cobol_linkEditStream=    INCLUDE OBJECT(@{member})
+cobol_linkEditStream=
+
+# If using a debug exit, provide the SYSLIN instream DD
+# Samp: cobol_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
+cobol_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT)
+
+
+#
+# execute link edit step
+# can be overridden by file properties
+cobol_linkEdit=true
+
+#
+# default deployType
+cobol_deployType=LOAD
+
+#
+# default deployType
+cobol_deployTypeCICS=CICSLOAD
+
+#
+# default deployType
+cobol_deployTypeDLI=IMSLOAD
+
+#
+# scan link edit load module for link dependencies
+# can be overridden by file properties
+cobol_scanLoadModule=true
+
+#
+# additional libraries for compile SYSLIB concatenation, comma-separated
+cobol_compileSyslibConcatenation=
+
+#
+# additional libraries for linkEdit SYSLIB concatenation, comma-separated
+cobol_linkEditSyslibConcatenation=

--- a/test/applications/MortgageApplication/bms/epsmlis.bms
+++ b/test/applications/MortgageApplication/bms/epsmlis.bms
@@ -1,0 +1,112 @@
+*********************************************************************** 00010000
+EPSMLIS  DFHMSD TYPE=&SYSPARM,MODE=INOUT,LANG=COBOL,                   X
+               STORAGE=AUTO,TIOAPFX=YES,DSATTS=(COLOR,HILIGHT),        X 0009000
+               MAPATTS=(COLOR,HILIGHT)                                   0009100
+EPSMLIS  DFHMDI SIZE=(24,80),CTRL=(PRINT,FREEKB)                         0011000
+         DFHMDF POS=(1,24),LENGTH=26,INITIAL='Better Mortgage Rates',  *
+               ATTRB=(ASKIP,BRT)
+         DFHMDF POS=(24,58),LENGTH=0,                                  *
+               ATTRB=ASKIP
+*        MENU MORTGAGE LIST MERGE BUILD TEST.
+
+LITCOMP  DFHMDF POS=(3,1),LENGTH=24,INITIAL='Company',                 *
+               ATTRB=(ASKIP,NORM)
+LITPHN   DFHMDF POS=(3,26),LENGTH=13,INITIAL='Phone Number',           *
+               ATTRB=(PROT,NORM)
+EPDIFF1  DFHMDF POS=(3,40),LENGTH=13,INITIAL='Interest Rate',          *
+               ATTRB=(PROT,NORM)
+EPDIFF2  DFHMDF POS=(3,54),LENGTH=16,INITIAL='Monthly Payment',        *
+               ATTRB=(PROT,NORM)
+LITPHN1  DFHMDF POS=(3,71),LENGTH=7,INITIAL='# Years',                 *
+               ATTRB=(PROT,NORM)
+EPCMP1   DFHMDF POS=(4,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN1   DFHMDF POS=(4,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE1  DFHMDF POS=(4,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN1  DFHMDF POS=(4,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS1 DFHMDF POS=(4,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP2   DFHMDF POS=(5,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN2   DFHMDF POS=(5,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE2  DFHMDF POS=(5,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN2  DFHMDF POS=(5,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS2 DFHMDF POS=(5,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP3   DFHMDF POS=(6,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN3   DFHMDF POS=(6,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE3  DFHMDF POS=(6,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN3  DFHMDF POS=(6,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS3 DFHMDF POS=(6,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP4   DFHMDF POS=(7,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN4   DFHMDF POS=(7,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE4  DFHMDF POS=(7,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN4  DFHMDF POS=(7,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS4 DFHMDF POS=(7,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP5   DFHMDF POS=(8,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN5   DFHMDF POS=(8,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE5  DFHMDF POS=(8,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN5  DFHMDF POS=(8,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS5 DFHMDF POS=(8,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP6   DFHMDF POS=(9,1),LENGTH=24,                                   *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN6   DFHMDF POS=(9,26),LENGTH=13,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE6  DFHMDF POS=(9,45),LENGTH=5,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN6  DFHMDF POS=(9,56),LENGTH=12,                                  *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS6 DFHMDF POS=(9,74),LENGTH=2,                                   *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP7   DFHMDF POS=(10,1),LENGTH=24,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN7   DFHMDF POS=(10,26),LENGTH=13,                                 *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE7  DFHMDF POS=(10,45),LENGTH=5,                                  *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN7  DFHMDF POS=(10,56),LENGTH=12,                                 *
+               ATTRB=(NUM,IC,NORM)
+EPYEARS7 DFHMDF POS=(10,74),LENGTH=2,                                  *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPCMP8   DFHMDF POS=(11,1),LENGTH=24,                                  *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPPHN8   DFHMDF POS=(11,26),LENGTH=13,                                 *
+               ATTRB=(PROT,NORM),HILIGHT=OFF,COLOR=GREEN
+EPRATE8  DFHMDF POS=(11,45),LENGTH=5,                                  *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+EPLOAN8  DFHMDF POS=(11,56),LENGTH=12,                                 *
+               ATTRB=(NUM,IC,NORM)
+         DFHMDF POS=(11,69),                                           *
+               ATTRB=ASKIP
+EPYEARS8 DFHMDF POS=(11,74),LENGTH=2,                                  *
+               ATTRB=(NUM,NORM),COLOR=GREEN
+         DFHMDF POS=(11,77),LENGTH=0,                                  *
+               ATTRB=ASKIP
+         DFHMDF POS=(23,17),LENGTH=43,                                 *
+               INITIAL='Press F3 to quit or Enter to calculate loan',  *
+               ATTRB=(ASKIP,NORM),HILIGHT=OFF,COLOR=BLUE
+MSGERR   DFHMDF POS=(24,17),LENGTH=40,INITIAL='INVALID KEY PRESSED',   X
+               ATTRB=(PROT,DRK)
+EPSMLIS DFHMSD TYPE=FINAL
+        END

--- a/test/applications/MortgageApplication/build-conf/impactPropertyChanges.properties
+++ b/test/applications/MortgageApplication/build-conf/impactPropertyChanges.properties
@@ -1,0 +1,1 @@
+impactBuildOnBuildPropertyChanges=true

--- a/test/applications/MortgageApplication/build-conf/mergeBuildOpts.properties
+++ b/test/applications/MortgageApplication/build-conf/mergeBuildOpts.properties
@@ -1,0 +1,2 @@
+# mainBuildBranch requires to be overriden for the mergeBuild test scenario
+# mainBuildBranch=${props.branch}

--- a/test/applications/MortgageApplication/cobol/epscsmrt.cbl
+++ b/test/applications/MortgageApplication/cobol/epscsmrt.cbl
@@ -1,0 +1,61 @@
+   CBL NUMPROC(MIG),FLAG(I,W),RENT
+       ID DIVISION.
+       PROGRAM-ID. EPSCSMRT.
+      *    THIS IS A CALLED PROGRAM EXAMPLE FOR DEMONSTRATION
+      *
+      *    THIS PROGRAM IS INVOKED VIA A CICS LINK STATMENT
+      *    AND DYNAMICALLY CALLS THE ACTUAL PROGRAM
+      *
+      *    TEST CHANGE
+      *
+      *    (C) 2017 IBM JIM HILDNER.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. FLEX-ES.
+       OBJECT-COMPUTER. FLEX-ES.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+      *
+       01  WS-CALLED-PROGRAM    PIC X(8).
+
+       01  STATIC-CALLED-PROGRAMS.
+           03 STATIC-CALLED-PROGRAM-TABLE.
+              05 FILLER            PIC X(8) VALUE 'EPSMPMT'.
+              05 FILLER            PIC X(8) VALUE 'NOT VLD'.
+              05 FILLER            PIC X(8) VALUE ' '.
+           03 CALLED-PROGRAM-TABLE
+                        REDEFINES STATIC-CALLED-PROGRAM-TABLE
+                        OCCURS 3 TIMES.
+              05 CALLED-PROGRAM-NAME PIC X(8).
+
+       COPY EPSPDATA.
+
+       LINKAGE SECTION.
+      *
+       01 DFHCOMMAREA.
+       COPY EPSMTCOM.
+
+       PROCEDURE DIVISION USING DFHCOMMAREA.
+      *
+       A000-MAINLINE.
+           MOVE EPSPCOM-PRINCIPLE-DATA  TO EPSPDATA-PRINCIPLE-DATA.
+           MOVE EPSPCOM-NUMBER-OF-YEARS TO EPSPDATA-NUMBER-OF-YEARS.
+           MOVE 'Y'                     TO EPSPDATA-YEAR-MONTH-IND.
+           MOVE EPSPCOM-QUOTED-INTEREST-RATE
+                                        TO
+                                   EPSPDATA-QUOTED-INTEREST-RATE.
+           MOVE CALLED-PROGRAM-NAME(1)  TO WS-CALLED-PROGRAM.
+           MOVE SPACES                  TO EPSPDATA-RETURN-ERROR.
+      *     CALL 'EPSMPMT' USING EPSPDATA.
+           CALL WS-CALLED-PROGRAM USING EPSPDATA.
+           MOVE EPSPDATA-RETURN-MONTH-PAYMENT
+                                        TO
+                                        EPSPCOM-RETURN-MONTH-PAYMENT.
+           MOVE EPSPDATA-RETURN-ERROR   TO EPSPCOM-ERRMSG.
+           IF EPSPDATA-RETURN-ERROR = SPACES
+              MOVE ZERO TO EPSPCOM-PROGRAM-RETCODE
+           ELSE
+              MOVE 8 TO EPSPCOM-PROGRAM-RETCODE
+           END-IF.
+           GOBACK
+           .

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,7 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_renaming.groovy,resetBuild.groovy
+test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_properties.groovy,impactBuild_renaming.groovy,resetBuild.groovy
 
 
 #############################
@@ -45,3 +45,14 @@ impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: cobol/epscsmrt.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 
+###############################
+# impactBuild_properties.groovy properties
+###############################
+# changed source files to test impact builds
+impactBuild_properties_changedFile = application-conf/Cobol.properties
+# build properties file source files to test impact builds
+impactBuild_properties_buildPropSetting = build-conf/impactPropertyChanges.properties
+# Use file properties to associate expected files built for a changed build property
+impactBuild_properties_expectedFilesBuilt = epscmort.cbl,epscsmrd.cbl,epscsmrt.cbl,epsmlist.cbl,epsmpmt.cbl,epsnbrvl.cbl :: application-conf/Cobol.properties
+# list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
+impactBuild_properties_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -3,7 +3,25 @@
 ########################
 #
 # list of test scripts to run for this application
-test_testOrder=resetBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_properties.groovy,impactBuild_renaming.groovy,resetBuild.groovy
+#  the order of the list matters
+test_testOrder=resetBuild.groovy,mergeBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_properties.groovy,impactBuild_renaming.groovy,resetBuild.groovy
+
+
+###############################
+# mergeBuild.groovy properties
+###############################
+#
+# build properties to overwrite a set of options to enable test scenario in test framework
+mergeBuild_buildPropSetting = build-conf/mergeBuildOpts.properties
+# list of changed source files to test impact builds
+mergeBuild_changedFiles = bms/epsmlis.bms,cobol/epscsmrt.cbl
+#
+# list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
+mergeBuild_datasetsToCleanUp = BMS,COBOL,LINK
+#
+# Use file properties to associate expected files built to changed files
+mergeBuild_expectedFilesBuilt = epsmlis.bms :: bms/epsmlis.bms
+mergeBuild_expectedFilesBuilt = epsmlis.bms,epscsmrt.cbl :: cobol/epscsmrt.cbl
 
 
 #############################
@@ -33,6 +51,7 @@ impactBuild_expectedFilesBuilt = epsmlist.cbl,epsmlist.lnk :: cobol/epsmlist.cbl
 impactBuild_expectedFilesBuilt = epsmlist.cbl,epscsmrt.cbl,epscmort.cbl,epsmlist.lnk :: copybook/epsmtout.cpy
 impactBuild_expectedFilesBuilt = epsmlist.lnk :: link/epsmlist.lnk
 
+
 ###############################
 # impactBuild_rename.groovy properties
 ###############################
@@ -44,6 +63,7 @@ impactBuild_rename_renameFilesMapping = cobol/epscsmr2.cbl :: cobol/epscsmrt.cbl
 impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: cobol/epscsmrt.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
+
 
 ###############################
 # impactBuild_properties.groovy properties

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -1,0 +1,142 @@
+
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+import com.ibm.dbb.*
+import com.ibm.dbb.build.*
+import com.ibm.jzos.ZFile
+
+@Field BuildProperties props = BuildProperties.getInstance()
+println "\n### Executing test script impactBuild_properties.groovy"
+
+// Get the DBB_HOME location
+def dbbHome = EnvVars.getHome()
+if (props.verbose) println "** DBB_HOME = ${dbbHome}"
+
+// Create full build command to initilize property dependencies
+def fullBuildCommand = []
+fullBuildCommand << "${dbbHome}/bin/groovyz"
+fullBuildCommand << "${props.zAppBuildDir}/build.groovy"
+fullBuildCommand << "--workspace ${props.workspace}"
+fullBuildCommand << "--application ${props.app}"
+fullBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+fullBuildCommand << "--hlq ${props.hlq}"
+fullBuildCommand << "--logEncoding UTF-8"
+fullBuildCommand << "--url ${props.url}"
+fullBuildCommand << "--id ${props.id}"
+fullBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+fullBuildCommand << (props.verbose ? "--verbose" : "")
+fullBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
+fullBuildCommand << "--fullBuild"
+
+// create impact build command
+def impactBuildCommand = []
+impactBuildCommand << "${dbbHome}/bin/groovyz"
+impactBuildCommand << "${props.zAppBuildDir}/build.groovy"
+impactBuildCommand << "--workspace ${props.workspace}"
+impactBuildCommand << "--application ${props.app}"
+impactBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+impactBuildCommand << "--hlq ${props.hlq}"
+impactBuildCommand << "--logEncoding UTF-8"
+impactBuildCommand << "--url ${props.url}"
+impactBuildCommand << "--id ${props.id}"
+impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+impactBuildCommand << (props.verbose ? "--verbose" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
+impactBuildCommand << "--impactBuild"
+
+// iterate through change files to test impact build
+@Field def assertionList = []
+PropertyMappings filesBuiltMappings = new PropertyMappings('impactBuild_properties_expectedFilesBuilt')
+def changedPropFile = props.impactBuild_properties_changedFile
+println("** Processing changed files from impactBuild_properties_changedFiles property : ${changedPropFile}")
+try {
+		
+		println "\n** Running build to set baseline"
+				
+		// run impact build
+		println "** Executing ${fullBuildCommand.join(" ")}"
+		def outputStream = new StringBuffer()
+		def process = ['bash', '-c', fullBuildCommand.join(" ")].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+		
+		
+		println "\n** Running impact build test for changed file $changedPropFile"
+		
+		// update changed file in Git repo test branch
+		copyAndCommit(changedPropFile)
+		
+		// run impact build
+		println "** Executing ${impactBuildCommand.join(" ")}"
+		outputStream = new StringBuffer()
+		process = ['bash', '-c', impactBuildCommand.join(" ")].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+		
+		// validate build results
+		validateImpactBuild(changedPropFile, filesBuiltMappings, outputStream)
+}
+finally {
+	cleanUpDatasets()
+	if (assertionList.size()>0) {
+		println "\n***"
+	println "**START OF FAILED IMPACT BUILD ON PROPERTY CHANGE TEST RESULTS**\n"
+	println "*FAILED IMPACT BUILD ON PROPERT CHANGE TEST  RESULTS*\n" + assertionList
+	println "\n**END OF FAILED IMPACT BUILD ON PROPERTY CHANGE TEST RESULTS**"
+	println "***"
+  }
+}
+// script end
+
+//*************************************************************
+// Method Definitions
+//*************************************************************
+
+def copyAndCommit(String changedFile) {
+	println "** Copying and committing ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} to ${props.appLocation}/${changedFile}"
+	def commands = """
+	cp ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} ${props.appLocation}/${changedFile}
+	cd ${props.appLocation}/
+	git add .
+	git commit . -m "edited program file"
+"""
+	def task = ['bash', '-c', commands].execute()
+	def outputStream = new StringBuffer();
+	task.waitForProcessOutput(outputStream, System.err)
+}
+
+def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
+
+	println "** Validating impact build results"
+	def expectedFilesBuiltList = filesBuiltMappings.getValue(changedFile).split(',')
+	
+	try{
+	// Validate clean build
+	assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY $changedFile\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected number of files built
+	def numImpactFiles = expectedFilesBuiltList.size()
+	assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY  $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected built files in output stream
+	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+	
+	println "**"
+	println "** IMPACT BUILD ON PROPERTY CHANGE : PASSED FOR $changedFile **"
+	println "**"
+	}
+	catch(AssertionError e) {
+		def result = e.getMessage()
+		assertionList << result;
+ }
+}
+def cleanUpDatasets() {
+	def segments = props.impactBuild_properties_datasetsToCleanUp.split(',')
+	
+	println "Deleting impact build PDSEs ${segments}"
+	segments.each { segment ->
+		def pds = "'${props.hlq}.${segment}'"
+		if (ZFile.dsExists(pds)) {
+		   if (props.verbose) println "** Deleting ${pds}"
+		   ZFile.remove("//$pds")
+		}
+	}
+}

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -92,8 +92,6 @@ def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, 
 	println "** Validating impact build results"
 	def expectedFilesBuiltList = filesBuiltMappings.getValue(renameFile).split(',')
 
-	println("*** Outputstream: $outputStream")
-	
 	try{
 		// Validate clean build
 		assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $renameFile\nOUTPUT STREAM:\n$outputStream\n"

--- a/test/testScripts/mergeBuild.groovy
+++ b/test/testScripts/mergeBuild.groovy
@@ -1,0 +1,133 @@
+
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+import com.ibm.dbb.*
+import com.ibm.dbb.build.*
+import com.ibm.jzos.ZFile
+
+@Field BuildProperties props = BuildProperties.getInstance()
+println "\n** Executing test script mergeBuild.groovy"
+
+// Get the DBB_HOME location
+def dbbHome = EnvVars.getHome()
+if (props.verbose) println "** DBB_HOME = ${dbbHome}"
+
+// prepare properties file
+writePropsFile()
+
+// create merge build command
+def mergeBuildCommand = []
+mergeBuildCommand << "${dbbHome}/bin/groovyz"
+mergeBuildCommand << "${props.zAppBuildDir}/build.groovy"
+mergeBuildCommand << "--workspace ${props.workspace}"
+mergeBuildCommand << "--application ${props.app}"
+mergeBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+mergeBuildCommand << "--hlq ${props.hlq}"
+mergeBuildCommand << "--logEncoding UTF-8"
+mergeBuildCommand << "--url ${props.url}"
+mergeBuildCommand << "--id ${props.id}"
+mergeBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+mergeBuildCommand << (props.verbose ? "--verbose" : "")
+mergeBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.mergeBuild_buildPropSetting},${props.propFiles}" : "")
+mergeBuildCommand << "--mergeBuild"
+
+// iterate through change files to test merge build
+@Field def assertionList = []
+PropertyMappings filesBuiltMappings = new PropertyMappings('mergeBuild_expectedFilesBuilt')
+def changedFiles = props.mergeBuild_changedFiles.split(',')
+println("** Processing changed files from mergeBuild_changedFiles property : ${props.mergeBuild_changedFiles}")
+try {
+	changedFiles.each { changedFile ->
+		println "\n** Running merge build test for changed file $changedFile"
+		
+		// update changed file in Git repo test branch
+		copyAndCommit(changedFile)
+		
+		// run merge build
+		println "** Executing ${mergeBuildCommand.join(" ")}"
+		def outputStream = new StringBuffer()
+		def process = ['bash', '-c', mergeBuildCommand.join(" ")].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+		
+		// validate build results
+		validateMergeBuild(changedFile, filesBuiltMappings, outputStream)
+	}
+}
+finally {
+	cleanUpDatasets()
+	if (assertionList.size()>0) {
+        println "\n***"
+	println "**START OF FAILED MERGED BUILD TEST RESULTS**\n"
+	println "*FAILED MERGED BUILD TEST RESULTS*\n" + assertionList
+	println "\n**END OF FAILED MERGED BUILD TEST RESULTS**"
+	println "***"
+  }
+}
+// script end  
+
+//*************************************************************
+// Method Definitions
+//*************************************************************
+
+def writePropsFile() {
+	println "** Writing propFile ${props.mergeBuild_buildPropSetting} for overwriting the mainBuildBranch"
+	def commands = """
+    echo "# Overwriting the mainBuildBranch for the mergeBuild scenario \nmainBuildBranch=${props.branch}" > ${props.zAppBuildDir}/test/applications/${props.app}/${props.mergeBuild_buildPropSetting}
+    cat ${props.zAppBuildDir}/test/applications/${props.app}/${props.mergeBuild_buildPropSetting}
+"""
+		def task = ['bash', '-c', commands].execute()
+		def outputStream = new StringBuffer();
+		task.waitForProcessOutput(outputStream, System.err)
+	
+}
+
+def copyAndCommit(String changedFile) {
+	println "** Copying and committing ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} to ${props.appLocation}/${changedFile}"
+	def commands = """
+    cp ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} ${props.appLocation}/${changedFile}
+    cd ${props.appLocation}/
+    git add .
+    git commit . -m "edited program file"
+"""
+	def task = ['bash', '-c', commands].execute()
+	def outputStream = new StringBuffer();
+	task.waitForProcessOutput(outputStream, System.err)
+}
+
+def validateMergeBuild(String changedFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
+
+	println "** Validating merge build results"
+	def expectedFilesBuiltList = filesBuiltMappings.getValue(changedFile).split(',')
+	
+    try{
+	// Validate clean build
+	assert outputStream.contains("Build State : CLEAN") : "*! MERGED BUILD FAILED FOR $changedFile\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected number of files built
+	def numMergeFiles = expectedFilesBuiltList.size()
+	assert outputStream.contains("Total files processed : ${numMergeFiles}") : "*! MERGED BUILD FOR $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numMergeFiles}\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected built files in output stream
+	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! MERGED BUILD FOR $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+	
+	println "**"
+	println "** MERGED BUILD TEST : PASSED FOR $changedFile **"
+	println "**"
+    }
+    catch(AssertionError e) {
+        def result = e.getMessage()
+        assertionList << result;
+ }
+}
+def cleanUpDatasets() {
+	def segments = props.mergeBuild_datasetsToCleanUp.split(',')
+	
+	println "Deleting merge build PDSEs ${segments}"
+	segments.each { segment ->
+	    def pds = "'${props.hlq}.${segment}'"
+	    if (ZFile.dsExists(pds)) {
+	       if (props.verbose) println "** Deleting ${pds}"
+	       ZFile.remove("//$pds")
+	    }
+	}
+}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -29,6 +29,10 @@ def assertBuildProperties(String requiredProps) {
 	}
 }
 
+/*
+ * createFullBuildList() - returns all existing files of the build workspace for the --fullBuild build type
+ * 
+ */
 def createFullBuildList() {
 	Set<String> buildSet = new HashSet<String>()
 	// create the list of build directories
@@ -60,7 +64,6 @@ def getFileSet(String dir, boolean relativePaths, String includeFileList, String
 
 	return fileSet
 }
-
 
 /*
  * copySourceFiles - copies both the program being built and the program

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -5,6 +5,7 @@ import com.ibm.dbb.build.*
 import groovy.transform.*
 import groovy.json.JsonSlurper
 import com.ibm.dbb.build.DBBConstants.CopyMode
+import com.ibm.dbb.build.report.records.*
 
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()
@@ -510,6 +511,31 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 	}
 	return deployType
 }
+
+/*
+ * Creates a Generic PropertyRecord with the provided db2 information in bind.properties
+ */
+def generateDb2InfoRecord(String buildFile){
+	
+	// New Generic Property Record
+	PropertiesRecord db2BindInfo = new PropertiesRecord("db2BindInfo:${buildFile}")
+	
+	// Link to buildFile
+	db2BindInfo.addProperty("file", buildFile)
+
+	// Iterate over list of Db2InfoRecord properties
+	if (props.generateDb2BindInfoRecordProperties) {
+		String[] generateDb2InfoRecordPropertiesList = props.getFileProperty("generateDb2BindInfoRecordProperties", buildFile).split(',')
+		generateDb2InfoRecordPropertiesList.each { db2Prop ->
+			// Add all properties, which are defined for bind - see application-conf/bind.properties
+			String bindPropertyValue = props.getFileProperty("${db2Prop}", buildFile)
+			if (bindPropertyValue != null ) db2BindInfo.addProperty("${db2Prop}",bindPropertyValue)
+		}
+	}
+		
+	return db2BindInfo		
+}
+
 /*
  * parse and validates the user build dependency file 
  * returns a parsed json object 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -559,3 +559,30 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 	assert getAbsolutePath(depFileData.fileName) == getAbsolutePath(buildFile) : "*! Dependency file mismatch: fileName does not match build file"
 	return depFileData // return the parsed JSON object
 }
+
+/*
+ * Validates the current Dbb Toolkit version
+ * exits the process, if it does not meet the minimum required version of zAppBuild.
+ * 
+ */
+def assertDbbBuildToolkitVersion(String currentVersion){
+
+	try {
+		// Tokenize current version
+		List currentVersionList = currentVersion.tokenize(".")
+		List requiredVersionList = props.requiredDBBToolkitVersion.tokenize(".")
+
+		// validate the version formats, current version is allowed have more labels.
+		assert currentVersionList.size() >= requiredVersionList.size() : "Version syntax does not match."
+
+		// validate each label
+		currentVersionList.eachWithIndex{ it, i ->
+			if(requiredVersionList.size() >= i +1 )  assert (it as int) >= ((requiredVersionList[i]) as int)
+		}
+
+	} catch(AssertionError e) {
+		println "Current DBB Toolkit Version $currentVersion does not meet the minimum required version $requiredVersion. EXIT."
+		println e.getMessage()
+		System.exit(1)
+	}
+}

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -177,8 +177,30 @@ def getPreviousGitHash(String gitDir) {
 	}
 }
 
+/*
+ * getChangedFiles - assembles a git diff command to support the impactBuild for a given directory
+ *  returns the changed, deleted and renamed files.
+ * 
+ */
 def getChangedFiles(String gitDir, String baseHash, String currentHash) {
-	String cmd = "git -C $gitDir --no-pager diff --name-status $baseHash $currentHash"
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status $baseHash $currentHash"
+	return getChangedFiles(gitCmd)
+}
+
+/*
+ * getMergeChanges - assembles a git triple-dot diff command to support mergeBuild scenarios 
+ *  returns the changed, deleted and renamed files between current HEAD and the provided baseline.
+ *  
+ */
+def getMergeChanges(String gitDir, String baselineReference) {
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status remotes/origin/$baselineReference...HEAD"
+	return getChangedFiles(gitCmd)
+}
+
+/*
+ * getChangedFiles - internal method to submit the a gitDiff command and calucate and classify the idenfified changes 
+ */
+def getChangedFiles(String cmd) {
 	def git_diff = new StringBuffer()
 	def git_error = new StringBuffer()
 	def changedFiles = []

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -146,6 +146,48 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 }
 
 
+/*
+ * createMergeBuildList - calculates the changed and deleted files flowing back to the mainBuildBranch
+ *  implements the build type --mergeBuild
+ *
+ */
+
+def createMergeBuildList(RepositoryClient repositoryClient){
+	Set<String> changedFiles = new HashSet<String>()
+	Set<String> deletedFiles = new HashSet<String>()
+	Set<String> renamedFiles = new HashSet<String>()
+	Set<String> changedBuildProperties = new HashSet<String>()
+	
+	(changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = calculateChangedFiles(null)
+	
+	// scan files and update source collection
+	updateCollection(changedFiles, deletedFiles, renamedFiles, repositoryClient)
+	
+	// iterate over changed file and add them to the buildSet
+	
+	Set<String> buildSet = new HashSet<String>()
+	
+	
+	changedFiles.each { changedFile ->
+		// if the changed file has a build script then add to build list
+		if (ScriptMappings.getScriptName(changedFile)) {
+			buildSet.add(changedFile)
+			if (props.verbose) println "** Found build script mapping for $changedFile. Adding to build list"
+		}
+	}
+	
+	return [ buildSet, deletedFiles	]
+}
+
+
+/*
+ * calculateChangedFiles - method to caluclate the the changed files
+ * 
+ *  If a BuildResult is provided, this method will diff between the different states in the repository
+ *   if no BuildResult is provided, the method will diff the changes from the topic branch to the main build branch
+ * 
+ */
+
 def calculateChangedFiles(BuildResult lastBuildResult) {
 	// local variables
 	Map<String,String> currentHashes = new HashMap<String,String>()
@@ -160,58 +202,61 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 	if (props.applicationSrcDirs)
 		directories.addAll(props.applicationSrcDirs.split(','))
 
-	// get the current Git hash for all build directories
-	directories.each { dir ->
-		dir = buildUtils.getAbsolutePath(dir)
-		if (props.verbose) println "** Getting current hash for directory $dir"
-		String hash = null
-		if (gitUtils.isGitDir(dir)) {
-			hash = gitUtils.getCurrentGitHash(dir)
+	// when a build result is provided, calculate the baseline hash for each directory
+	if (lastBuildResult != null){
+		// get the current Git hash for all build directories
+		directories.each { dir ->
+			dir = buildUtils.getAbsolutePath(dir)
+			if (props.verbose) println "** Getting current hash for directory $dir"
+			String hash = null
+			if (gitUtils.isGitDir(dir)) {
+				hash = gitUtils.getCurrentGitHash(dir)
+			}
+			String relDir = buildUtils.relativizePath(dir)
+			if (props.verbose) println "** Storing $relDir : $hash"
+			currentHashes.put(relDir,hash)
 		}
-		String relDir = buildUtils.relativizePath(dir)
-		if (props.verbose) println "** Storing $relDir : $hash"
-		currentHashes.put(relDir,hash)
-	}
 
-	// get the baseline hash for all build directories
-	directories.each { dir ->
-		dir = buildUtils.getAbsolutePath(dir)
-		if (props.verbose) println "** Getting baseline hash for directory $dir"
-		String key = "$hashPrefix${buildUtils.relativizePath(dir)}"
-		String relDir = buildUtils.relativizePath(dir)
-		String hash
-		// retrieve baseline reference overwrite if set
-		if (props.baselineRef){
-			String[] baselineMap = (props.baselineRef).split(",")
-			baselineMap.each{
-				// case: baselineRef (gitref)
-				if(it.split(":").size()==1 && relDir.equals(props.application)){
-					if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
-					hash = it
-				}
-				// case: baselineRef (folder:gitref)
-				else if(it.split(":").size()>1){
-					(appSrcDir, gitReference) = it.split(":")
-					if (appSrcDir.equals(relDir)){
+		// get the baseline hash for all build directories
+		directories.each { dir ->
+			dir = buildUtils.getAbsolutePath(dir)
+			if (props.verbose) println "** Getting baseline hash for directory $dir"
+			String key = "$hashPrefix${buildUtils.relativizePath(dir)}"
+			String relDir = buildUtils.relativizePath(dir)
+			String hash
+			// retrieve baseline reference overwrite if set
+			if (props.baselineRef){
+				String[] baselineMap = (props.baselineRef).split(",")
+				baselineMap.each{
+					// case: baselineRef (gitref)
+					if(it.split(":").size()==1 && relDir.equals(props.application)){
 						if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
-						hash = gitReference
+						hash = it
+					}
+					// case: baselineRef (folder:gitref)
+					else if(it.split(":").size()>1){
+						(appSrcDir, gitReference) = it.split(":")
+						if (appSrcDir.equals(relDir)){
+							if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
+							hash = gitReference
+						}
 					}
 				}
-			}
-			// for build directories which are not specified in baselineRef mapping, return the info from lastBuildResult
-			if (hash == null && lastBuildResult) {
+				// for build directories which are not specified in baselineRef mapping, return the info from lastBuildResult
+				if (hash == null && lastBuildResult) {
+					hash = lastBuildResult.getProperty(key)
+				}
+			} else if (lastBuildResult){
+				// return from lastBuildResult
 				hash = lastBuildResult.getProperty(key)
 			}
-		} else if (lastBuildResult){
-			// return from lastBuildResult
-			hash = lastBuildResult.getProperty(key)
+			if (hash == null){
+				println "!** Could not obtain the baseline hash for directory $relDir."
+			}
+
+			if (props.verbose) println "** Storing $relDir : $hash"
+			baselineHashes.put(relDir,hash)
 		}
-		if (hash == null){
-			println "!** Could not obtain the baseline hash for directory $relDir."
-		}
-		
-		if (props.verbose) println "** Storing $relDir : $hash"
-		baselineHashes.put(relDir,hash)
 	}
 
 	// calculate the changed and deleted files by diff'ing the current and baseline hashes
@@ -221,16 +266,35 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 		def changed = []
 		def deleted = []
 		def renamed = []
-		String baseline = baselineHashes.get(buildUtils.relativizePath(dir))
-		String current = currentHashes.get(buildUtils.relativizePath(dir))
-		if (!baseline || !current) {
-			if (props.verbose) println "*! Skipping directory $dir because baseline or current hash does not exist.  baseline : $baseline current : $current"
-		}
-		else if (gitUtils.isGitDir(dir)) {
-			if (props.verbose) println "** Diffing baseline $baseline -> current $current"
-			(changed, deleted, renamed) = gitUtils.getChangedFiles(dir, baseline, current )
-
-		}
+		String baseline
+		String current
+		
+		if (gitUtils.isGitDir(dir)){
+			// when a build result is provided and build type impactBuild,
+			//   calculate changed between baseline and current state of the repository
+			if (lastBuildResult != null && props.impactBuild){
+				baseline = baselineHashes.get(buildUtils.relativizePath(dir))
+				current = currentHashes.get(buildUtils.relativizePath(dir))
+				if (!baseline || !current) {
+					if (props.verbose) println "*! Skipping directory $dir because baseline or current hash does not exist.  baseline : $baseline current : $current"
+				}
+				else {
+					if (props.verbose) println "** Diffing baseline $baseline -> current $current"
+					(changed, deleted, renamed) = gitUtils.getChangedFiles(dir, baseline, current)
+				}
+			}
+			// when no build result is provided but the outgoingChangesBuild,
+			//   calculate the outgoing changes
+			else if(props.mergeBuild) {
+				
+				// set git references
+				baseline = props.mainBuildBranch
+				current = "HEAD"
+				
+				if (props.verbose) println "** Triple-dot diffing configuration baseline remotes/origin/$baseline -> current HEAD"
+				(changed, deleted, renamed) = gitUtils.getMergeChanges(dir, baseline)
+			}
+		}	
 		else {
 			if (props.verbose) println "*! Directory $dir not a local Git repository. Skipping."
 		}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -91,7 +91,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 	}
 
 	// Perform impact analysis for property changes
-	if (props.impactBuildOnBuildPropertyChanges){
+	if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean()){
 		if (props.verbose) println "*** Perform impacted analysis for property changes."
 
 		changedBuildProperties.each { changedProp ->
@@ -250,7 +250,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 					if (props.verbose) println "**** $file"
 				}
 				//retrieving changed build properties
-				if (props.impactBuildOnBuildPropertyChanges && file.endsWith(".properties")){
+				if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean() && file.endsWith(".properties")){
 					if (props.verbose) println "**** $file"
 					String gitDir = new File(buildUtils.getAbsolutePath(file)).getParent()
 					String pFile =  new File(buildUtils.getAbsolutePath(file)).getName()


### PR DESCRIPTION
This update delivers 
* a new build type `--mergeBuild`
* a new language script `Transfer.groovy` to only copy files to a target datasets and mark them in the build report
* some additional minor updates