### PR TITLE
Store abbreviated git hash as SSI Info for load modules

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -539,7 +539,7 @@ def finalizeBuildProcess(Map args) {
 			if (gitUtils.isGitDir(dir)) {
 				// store current hash
 				String key = "$hashPrefix${buildUtils.relativizePath(dir)}"
-				String currenthash = gitUtils.getCurrentGitHash(dir)
+				String currenthash = gitUtils.getCurrentGitHash(dir, false)
 				if (props.verbose) println "** Setting property $key : $currenthash"
 				buildResult.setProperty(key, currenthash)
 				// store gitUrl

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -309,6 +309,10 @@ def createAssemblerCommand(String buildFile, LogicalFile logicalFile, String mem
 def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String member, File logFile) {
 	String parameters = props.getFileProperty('assembler_linkEditParms', buildFile)
 
+	// obtain githash for buildfile
+	String ssi = buildUtils.getShortGitHash(buildFile)
+	if (ssi != null) parameters = parameters + ",SSI=$ssi"
+	
 	// define the MVSExec command to link edit the program
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(props.assembler_linkEditor).parm(parameters)
 

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -121,6 +121,10 @@ def createCompileCommand(String buildFile, String member, File logFile) {
 def createLinkEditCommand(String buildFile, String member, File logFile) {
 	String parameters = props.getFileProperty('bms_linkEditParms', buildFile)
 	
+	// obtain githash for buildfile
+	String ssi = buildUtils.getShortGitHash(buildFile)
+	if (ssi != null) parameters = parameters + ",SSI=$ssi"
+	
 	// define the MVSExec command to link edit the program
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(props.bms_linkEditor).parm(parameters)
 	

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -266,6 +266,10 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	String linkEditStream = props.getFileProperty('cobol_linkEditStream', buildFile)
 	String linkDebugExit = props.getFileProperty('cobol_linkDebugExit', buildFile)
 
+	// obtain githash for buildfile
+	String ssi = buildUtils.getShortGitHash(buildFile)
+	if (ssi != null) parms = parms + ",SSI=$ssi"
+	
 	// define the MVSExec command to link edit the program
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(linker).parm(parms)
 

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -267,8 +267,11 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	String linkDebugExit = props.getFileProperty('cobol_linkDebugExit', buildFile)
 
 	// obtain githash for buildfile
-	String ssi = buildUtils.getShortGitHash(buildFile)
-	if (ssi != null) parms = parms + ",SSI=$ssi"
+	String cobol_storeSSI = props.getFileProperty('cobol_storeSSI', buildFile) 
+	if (cobol_storeSSI && cobol_storeSSI.toBoolean()) {
+		String ssi = buildUtils.getShortGitHash(buildFile)
+		if (ssi != null) parms = parms + ",SSI=$ssi"
+	}
 	
 	// define the MVSExec command to link edit the program
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(linker).parm(parms)

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -79,9 +79,11 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	String linker = props.getFileProperty('linkedit_linkEditor', buildFile)
 
 	// obtain githash for buildfile
-	String ssi = buildUtils.getShortGitHash(buildFile)
-	if (ssi != null) parms = parms + ",SSI=$ssi"
-	
+	String linkedit_storeSSI = props.getFileProperty('linkedit_storeSSI', buildFile) 
+	if (linkedit_storeSSI && linkedit_storeSSI.toBoolean()) {
+		String ssi = buildUtils.getShortGitHash(buildFile)
+		if (ssi != null) parms = parms + ",SSI=$ssi"
+	}
 	// define the MVSExec command to link edit the program
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(linker).parm(parms)
 

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -78,6 +78,10 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	String parms = props.getFileProperty('linkEdit_parms', buildFile)
 	String linker = props.getFileProperty('linkedit_linkEditor', buildFile)
 
+	// obtain githash for buildfile
+	String ssi = buildUtils.getShortGitHash(buildFile)
+	if (ssi != null) parms = parms + ",SSI=$ssi"
+	
 	// define the MVSExec command to link edit the program
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(linker).parm(parms)
 

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -207,6 +207,10 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	String linker = props.getFileProperty('pli_linkEditor', buildFile)
 	String linkEditStream = props.getFileProperty('pli_linkEditStream', buildFile)
 
+	// obtain githash for buildfile
+	String ssi = buildUtils.getShortGitHash(buildFile)
+	if (ssi != null) parms = parms + ",SSI=$ssi"
+	
 	// Create the link stream if needed
 	if ( linkEditStream != null ) {
 		def langQualifier = "linkedit"

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -208,8 +208,11 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	String linkEditStream = props.getFileProperty('pli_linkEditStream', buildFile)
 
 	// obtain githash for buildfile
-	String ssi = buildUtils.getShortGitHash(buildFile)
-	if (ssi != null) parms = parms + ",SSI=$ssi"
+	String pli_storeSSI = props.getFileProperty('pli_storeSSI', buildFile)
+	if (pli_storeSSI && pli_storeSSI.toBoolean()) {
+		String ssi = buildUtils.getShortGitHash(buildFile)
+		if (ssi != null) parms = parms + ",SSI=$ssi"
+	}
 	
 	// Create the link stream if needed
 	if ( linkEditStream != null ) {

--- a/samples/MortgageApplication/application-conf/Cobol.properties
+++ b/samples/MortgageApplication/application-conf/Cobol.properties
@@ -60,6 +60,11 @@ cobol_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT
 cobol_linkEdit=true
 
 #
+# store abbrev git hash in ssi field
+# can be overridden by file properties
+cobol_storeSSI=true 
+
+#
 # default deployType
 cobol_deployType=LOAD
 

--- a/samples/MortgageApplication/application-conf/LinkEdit.properties
+++ b/samples/MortgageApplication/application-conf/LinkEdit.properties
@@ -16,6 +16,11 @@ linkedit_maxRC=0
 linkEdit_parms=MAP,RENT,COMPAT(PM5)
 
 #
+# store abbrev git hash in ssi field
+# can be overridden by file properties
+linkedit_storeSSI=true
+
+#
 # default deployType
 linkedit_deployType=LOAD
 

--- a/samples/MortgageApplication/application-conf/PLI.properties
+++ b/samples/MortgageApplication/application-conf/PLI.properties
@@ -46,6 +46,11 @@ pli_linkEditParms=MAP,RENT,COMPAT(PM5)
 pli_linkEdit=true
 
 #
+# store abbrev git hash in ssi field
+# can be overridden by file properties
+pli_storeSSI=true 
+
+#
 # default deployType
 pli_deployType=LOAD
 

--- a/samples/MortgageApplication/application-conf/README.md
+++ b/samples/MortgageApplication/application-conf/README.md
@@ -64,6 +64,7 @@ cobol_impactPropertyList | List of build properties causing programs to rebuild 
 cobol_impactPropertyListCICS | List of CICS build properties causing programs to rebuild when changed | false
 cobol_impactPropertyListSQL | List of SQL build properties causing programs to rebuild when changed | false
 cobol_linkEdit | Flag indicating to execute the link edit step to produce a load module for the source file.  If false then a object deck will be created instead for later linking. | true
+cobol_storeSSI | Flag to store abbrev git hash in ssi field in link step | true
 cobol_isMQ | Flag indicating that the program contains MQ calls | true
 cobol_deployType | default deployType for build output | true
 cobol_deployTypeCICS | deployType for build output for build files where isCICS=true | true
@@ -81,6 +82,7 @@ linkedit_fileBuildRank | Default link card build rank. Used to sort link card bu
 linkedit_maxRC | Default link edit maximum RC allowed. | true
 linkedit_parms | Default link edit parameters. | true
 linkedit_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+linkedit_storeSSI | Flag to store abbrev git hash in ssi field in link step | true
 linkedit_deployType | default deployType for build output | true
 linkedit_deployTypeCICS | deployType for build output for build files where isCICS=true set as file property | true
 linkedit_deployTypeDLI | deployType for build output for build files with isDLI=true set as file property | true

--- a/samples/application-conf/Cobol.properties
+++ b/samples/application-conf/Cobol.properties
@@ -60,6 +60,11 @@ cobol_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT
 cobol_linkEdit=true
 
 #
+# store abbrev git hash in ssi field
+# can be overridden by file properties
+cobol_storeSSI=true 
+
+#
 # default deployType
 cobol_deployType=LOAD
 

--- a/samples/application-conf/LinkEdit.properties
+++ b/samples/application-conf/LinkEdit.properties
@@ -20,6 +20,11 @@ linkedit_impactPropertyList=linkEdit_parms
 linkEdit_parms=MAP,RENT,COMPAT(PM5)
 
 #
+# store abbrev git hash in ssi field
+# can be overridden by file properties
+linkedit_storeSSI=true 
+
+#
 # default deployType
 linkedit_deployType=LOAD
 

--- a/samples/application-conf/PLI.properties
+++ b/samples/application-conf/PLI.properties
@@ -46,6 +46,11 @@ pli_linkEditParms=MAP,RENT,COMPAT(PM5)
 pli_linkEdit=true
 
 #
+# store abbrev git hash in ssi field
+# can be overridden by file properties
+pli_storeSSI=true 
+
+#
 # default deployType
 pli_deployType=LOAD
 

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -100,6 +100,7 @@ cobol_compileCICSParms | Default CICS compile parameters. Appended to base param
 cobol_compileSQLParms | Default SQL compile parameters. Appended to base parameters if has value. | true
 cobol_compileErrorPrefixParms | IDz user build parameters. Appended to base parameters if has value. | true
 cobol_linkEditParms | Default link edit parameters. | true
+cobol_storeSSI | Flag to store abbrev git hash in ssi field in link step | true
 cobol_impactPropertyList | List of build properties causing programs to rebuild when changed | false
 cobol_impactPropertyListCICS | List of CICS build properties causing programs to rebuild when changed | false
 cobol_impactPropertyListSQL | List of SQL build properties causing programs to rebuild when changed | false
@@ -121,6 +122,7 @@ linkedit_fileBuildRank | Default link card build rank. Used to sort link card bu
 linkedit_maxRC | Default link edit maximum RC allowed. | true
 linkedit_parms | Default link edit parameters. | true
 linkedit_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+linkedit_storeSSI | Flag to store abbrev git hash in ssi field in link step | true
 linkedit_deployType | default deployType for build output | true
 linkedit_deployTypeCICS | deployType for build output for build files where isCICS=true set as file property | true
 linkedit_deployTypeDLI | deployType for build output for build files with isDLI=true set as file property | true
@@ -145,6 +147,7 @@ pli_impactPropertyList | List of build properties causing programs to rebuild wh
 pli_impactPropertyListCICS | List of CICS build properties causing programs to rebuild when changed | false
 pli_impactPropertyListSQL | List of SQL build properties causing programs to rebuild when changed | false
 pli_linkEditParms | Default link edit parameters. | true
+pli_storeSSI | Flag to store abbrev git hash in ssi field in link step | true
 pli_impactPropertyList | List of build properties causing programs to rebuild when changed | false
 pli_impactPropertyListCICS | List of CICS build properties causing programs to rebuild when changed | false
 pli_impactPropertyListSQL | List of SQL build properties causing programs to rebuild when changed | false

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -35,6 +35,10 @@ def assertBuildProperties(String requiredProps) {
  */
 def createFullBuildList() {
 	Set<String> buildSet = new HashSet<String>()
+	
+	// PropertyMappings
+	PropertyMappings githashBuildableFilesMap = new PropertyMappings("githashBuildableFilesMap")
+	
 	// create the list of build directories
 	List<String> srcDirs = []
 	if (props.applicationSrcDirs)
@@ -42,7 +46,15 @@ def createFullBuildList() {
 
 	srcDirs.each{ dir ->
 		dir = getAbsolutePath(dir)
-		buildSet.addAll(getFileSet(dir, true, '**/*.*', props.excludeFileList))
+		Set<String> fileSet =getFileSet(dir, true, '**/*.*', props.excludeFileList)
+		buildSet.addAll(fileSet)
+		
+		// capture abbreviated gitHash for all buildable files
+		String abbrevHash = gitUtils.getCurrentGitHash(dir, true)
+		buildSet.forEach { buildableFile ->
+			githashBuildableFilesMap.addFilePattern(abbrevHash, buildableFile)
+		}
+		
 	}
 
 	return buildSet
@@ -588,4 +600,18 @@ def assertDbbBuildToolkitVersion(String currentVersion){
 		println e.getMessage()
 		System.exit(1)
 	}
+}
+
+/*
+*
+*
+*
+*/
+def getShortGitHash(String buildFile) {
+	def abbrevGitHash
+	PropertyMappings githashChangedFilesMap = new PropertyMappings("githashBuildableFilesMap")
+	abbrevGitHash = githashChangedFilesMap.getValue(buildFile)
+	if (abbrevGitHash != null ) return abbrevGitHash
+	println "*! Could not obtain abbreviated githash for buildFile $buildFile"	
+	return null	
 }

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -102,8 +102,9 @@ def isGitDetachedHEAD(String gitDir) {
  * @param  String gitDir  		Local Git repository directory
  * @return String gitHash       The current Git hash
  */
-def getCurrentGitHash(String gitDir) {
+def getCurrentGitHash(String gitDir, boolean abbrev) {
 	String cmd = "git -C $gitDir rev-parse HEAD"
+	if (abbrev) cmd = "git -C $gitDir rev-parse --short=8 HEAD"
 	StringBuffer gitHash = new StringBuffer()
 	StringBuffer gitError = new StringBuffer()
 


### PR DESCRIPTION
This enhancement retrieves the current abbreviated git hash for changed and impacted files for the following build types: fullBuild, impactBuild and mergeBuild.

Several areas are updated in buildUtils and impactUtils to populate a PropertyMappings  object `githashBuildableFilesMap` to store a DBB build property map with these information.

The language scripts pass the abbreviated hash to the linker.

It also supports builds across multiple repositories:

![image](https://user-images.githubusercontent.com/28918869/145575537-589eeaef-4f4a-4fa6-bf27-b888906ccca4.png)

