### PR TITLE
report and validate concurrent changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ zAppBuild supports a number of build scenarios:
 
 Links to additional documentation is provided in the table below.  Instructions on invoking a zAppBuild is included in [BUILD.md](BUILD.md) as well as invocation samples for the above mentioned build scenarios including sample console log.
 
+zAppBuild additionally delivers a set of reporting features to support the developer in answering questions about impact of changes across multiple applications or potential conflicts due to concurrent development activities within their application. An overview of these features are documented in [REPORT.md](REPORT.md).
+
 ## Repository Legend
 Folder/File | Description | Documentation Link
 --- | --- | ---

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ zAppBuild supports a number of build scenarios:
 
 Links to additional documentation is provided in the table below.  Instructions on invoking a zAppBuild is included in [BUILD.md](BUILD.md) as well as invocation samples for the above mentioned build scenarios including sample console log.
 
-zAppBuild additionally delivers a set of reporting features to support the developer in answering questions about impact of changes across multiple applications or potential conflicts due to concurrent development activities within their application. An overview of these features are documented in [REPORT.md](REPORT.md).
+zAppBuild comes with a set of reporting features. It helps development teams to understand the impact of changed files across multiple applications. Another feature helps to identify conflicts due to concurrent development activities within their application. An overview of these features are documented in [REPORT.md](REPORT.md).
 
 ## Repository Legend
 Folder/File | Description | Documentation Link

--- a/REPORT.md
+++ b/REPORT.md
@@ -62,7 +62,7 @@ The _Report potential conflicts_ feature can be activated to generate reports to
 
 ### Functionality
 
-This feature compares two different configurations via a `git diff`. It runs a git diff between the configured upstream target branch (`reportUpstreamChangesUpstreamBranch`) and the current configuration to capture changes of the upstream configuration, which are not yet applied to the topic branch. These changes are reported within the build console output (when running in verbose mode) as well produce a log file within the build output directory. 
+This feature compares two different configurations via a `git diff`. It runs a git diff between the configured upstream target branch (`reportConcurrentChangesUpstreamBranch`) and the current configuration to capture changes of the upstream configuration, which are not yet applied to the topic branch. These changes are reported within the build console output (when running in verbose mode) as well produce a log file within the build output directory. 
 
 Additionally to the reporting, it verifies if the list of the current build files intersect with the identified changes of the upstream branch. If the lists intersect, another notification is reported in the build log which can make the build be marked as failed and force the development team to integrate changes and rebase the code before they move on.  
 
@@ -79,7 +79,7 @@ Please review the build properties defined in [application-conf/reports.properti
 
 To document the functionality of the feature, the source code `MortgageApplication/cobol/epscsmrt.cbl` was changed on the main branch after the feature branch was forked. 
 
-In the first sample, the communication copybook `MortgageApplication/copybook/epsmtcom.cpy` was changed on the branch `reportUpstreamChanges`. The impactBuild build type, identifies the the below build list: 
+In the first sample, the communication copybook `MortgageApplication/copybook/epsmtcom.cpy` was changed on the branch `reportConcurrentChanges`. The impactBuild build type, identifies the the below build list: 
 
 ```
 MortgageApplication/cobol/epsmlist.cbl
@@ -87,12 +87,12 @@ MortgageApplication/cobol/epscsmrt.cbl
 MortgageApplication/cobol/epscmort.cbl
 MortgageApplication/link/epsmlist.lnk 
 ```
-While the above build list intersects with the changes on the upstream branch main and the setting `reportUpstreamChangesIntersectionFailsBuild=true` is activated, a warning is written to the build console output and the build state is flagged as Error:
+While the above build list intersects with the changes on the upstream branch main and the setting `reportConcurrentChangesIntersectionFailsBuild=true` is activated, a warning is written to the build console output and the build state is flagged as Error:
 ```
 ** Build start at 20211221.110944.009
 ** Repository client created for https://10.3.20.96:10443/dbb
 ** Build output located at /u/ibmuser/outDir/mortgageout/build.20211221.110944.009
-** Build result created for BuildGroup:MortgageApplication-reportUpstreamChanges BuildLabel:build.20211221.110944.009 at https://10.3.20.96:10443/dbb/rest/buildResult/62001
+** Build result created for BuildGroup:MortgageApplication-reportConcurrentChanges BuildLabel:build.20211221.110944.009 at https://10.3.20.96:10443/dbb/rest/buildResult/62001
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication
 ** Writing report of upstream changes to /u/ibmuser/outDir/mortgageout/build.20211221.110944.009/upstreamChanges.txt
 *!! MortgageApplication/cobol/epscsmrt.cbl is changed on the mainBuildBranch (main) and intersects with the current build list.
@@ -107,7 +107,7 @@ While the above build list intersects with the changes on the upstream branch ma
 *** Building file MortgageApplication/link/epsmlist.lnk
 ** Writing build report data to /u/ibmuser/outDir/mortgageout/build.20211221.110944.009/BuildReport.json
 ** Writing build report to /u/ibmuser/outDir/mortgageout/build.20211221.110944.009/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-reportUpstreamChanges BuildLabel:build.20211221.110944.009 at https://10.3.20.96:10443/dbb/rest/buildResult/62001
+** Updating build result BuildGroup:MortgageApplication-reportConcurrentChanges BuildLabel:build.20211221.110944.009 at https://10.3.20.96:10443/dbb/rest/buildResult/62001
 ** Build ended at Tue Dec 21 23:09:56 GMT+01:00 2021
 ** Build State : ERROR
 ** Total files processed : 4
@@ -127,7 +127,7 @@ In a mergeBuild scenario, where the build list does not intersect with the chang
 ** Build start at 20211221.111003.010
 ** Repository client created for https://10.3.20.96:10443/dbb
 ** Build output located at /u/ibmuser/outDir/mortgageout/build.20211221.111003.010
-** Build result created for BuildGroup:MortgageApplication-reportUpstreamChanges BuildLabel:build.20211221.111003.010 at https://10.3.20.96:10443/dbb/rest/buildResult/62013
+** Build result created for BuildGroup:MortgageApplication-reportConcurrentChanges BuildLabel:build.20211221.111003.010 at https://10.3.20.96:10443/dbb/rest/buildResult/62013
 ** --mergeBuild option selected. Building changed programs for application MortgageApplication flowing back to main
 ** Writing report of upstream changes to /u/ibmuser/outDir/mortgageout/build.20211221.111003.010/upstreamChanges.txt
 ** Writing build list file to /u/ibmuser/outDir/mortgageout/build.20211221.111003.010/buildList.txt
@@ -136,7 +136,7 @@ In a mergeBuild scenario, where the build list does not intersect with the chang
 *** Building file MortgageApplication/cobol/epsmlist.cbl
 ** Writing build report data to /u/ibmuser/outDir/mortgageout/build.20211221.111003.010/BuildReport.json
 ** Writing build report to /u/ibmuser/outDir/mortgageout/build.20211221.111003.010/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-reportUpstreamChanges BuildLabel:build.20211221.111003.010 at https://10.3.20.96:10443/dbb/rest/buildResult/62013
+** Updating build result BuildGroup:MortgageApplication-reportConcurrentChanges BuildLabel:build.20211221.111003.010 at https://10.3.20.96:10443/dbb/rest/buildResult/62013
 ** Build ended at Tue Dec 21 23:10:09 GMT+01:00 2021
 ** Build State : CLEAN
 ** Total files processed : 1

--- a/REPORT.md
+++ b/REPORT.md
@@ -83,6 +83,9 @@ In the below sample configuration for reportConcurrentChangesGitBranchReferenceP
 ```
 reportConcurrentChangesGitBranchReferencePatterns=${mainBuildBranch},.*main.*,main,deployTypes,feature.*
 ```
+
+The results are written to a file called `report_concurrentChanges.txt' within the build workspace within the build out directory.   
+
 ### Sample invocation
 
 To document the functionality of the feature, the source code `MortgageApplication/cobol/epscsmrt.cbl` was changed on the main branch after the feature branch was forked to simulate concurrent development activities. 
@@ -102,7 +105,6 @@ While the above build list intersects with the changes on the branch main and th
 ** Build output located at /u/ibmuser/outDir/mortgageout/build.20211221.110944.009
 ** Build result created for BuildGroup:MortgageApplication-reportConcurrentChanges BuildLabel:build.20211221.110944.009 at https://10.3.20.96:10443/dbb/rest/buildResult/62001
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication
-** Writing report of concurent changes to /u/ibmuser/outDir/mortgageout/build.20211221.110944.009/report_concurrentChanges_main.txt
 *!! MortgageApplication/cobol/epscsmrt.cbl is changed on branch (main) and intersects with the current build list.
 ** Writing build list file to /u/ibmuser/outDir/mortgageout/build.20211221.110944.009/buildList.txt
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
@@ -122,10 +124,13 @@ While the above build list intersects with the changes on the branch main and th
 
 ** Build finished
 ````
-Contents of the report_concurrentChanges_main.txt file look like:
+Contents of the report_concurrentChanges.txt file look like:
 ```
-** Changed Files 
-MortgageApplication/cobol/epscsmrt.cbl                            
+===============================================
+** Report for configuration: main
+========
+** Changed Files
+* MortgageApplication/cobol/epscmort.cbl is changed and intersects with the current build list.                       
 ````
 
 In a mergeBuild scenario, where the build list does not intersect with the changes on the concurrent branch, the build passes as expected. The report for concurrent development activities is written to the build output directory.
@@ -136,7 +141,6 @@ In a mergeBuild scenario, where the build list does not intersect with the chang
 ** Build output located at /u/ibmuser/outDir/mortgageout/build.20211221.111003.010
 ** Build result created for BuildGroup:MortgageApplication-reportConcurrentChanges BuildLabel:build.20211221.111003.010 at https://10.3.20.96:10443/dbb/rest/buildResult/62013
 ** --mergeBuild option selected. Building changed programs for application MortgageApplication flowing back to main
-** Writing report of concurent changes to /u/ibmuser/outDir/mortgageout/build.20211221.111003.010/report_concurrentChanges_main.txt
 ** Writing build list file to /u/ibmuser/outDir/mortgageout/build.20211221.111003.010/buildList.txt
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script
@@ -153,6 +157,10 @@ In a mergeBuild scenario, where the build list does not intersect with the chang
 ```
 Contents of the reported report_concurrentChanges_main.txt file look like:
 ```
-** Changed Files 
-MortgageApplication/cobol/epscsmrt.cbl                            
+===============================================
+** Report for configuration: main
+========
+** Changed Files
+  MortgageApplication/cobol/epscmort.cbl
+
 ````

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,76 @@
+# Reporting capabilities within zAppBuild
+
+zAppBuild provides a set of reporting capabilities, which are part of the build framework itself to address some common demands of mainframe development teams.
+
+Developers are particularly interested if
+* a change of an element impacts other application components which are managed in a different repository.
+* their changes on an isolated feature branch potentially cause a conflict with some concurrent development done by others within the same repository.
+
+While during the analysis phase of a new task, the developer leverages application dependency understanding tools such as IBM Application Discovery, it is beneficial to enable also the build framework to automatically generate reports to answer the above questions.
+
+By default these reporting capabilities are turned off, while they don't belong to the core functionalities of a build framewoek.
+
+## Report External Impacts 
+
+### Purpose
+
+The _Reporting External Impacts_ feature enables the build framework to generate reports about impacted files in other application contexts to document cross application impacts for files that were changed within your application scope.
+
+### Pre-requisites
+
+Technically, this feature analyzes the list of changed files and queries the collection of other applications within the DBB WebApp, so it requires that the other applications are also processed through the CI/CD pipeline with DBB. It requires a repository connection.
+
+### Configuration
+
+You can configure the feature through [application-conf/reports.properties](samples/application-conf/reports.properties). Within the property file, you can activate it and further configure a filter to run the analysis only for a subset of files in your repository see `reportExternalImpactsAnalysisFileFilter` and limit the scope of the external collections (see `reportExternalImpactsCollectionPatterns`), which should be queried.
+
+### Sample invocation
+
+In the below sample, the MortgageApplication was split into two applications App-EPSC and App-EPSM to demonstrate the feature from a user perspective:
+
+App-EPSM provides a shared copybook `epsmtcom.cpy`, which is included in programs of App-EPSC. While the overall build strategy does not intend to force an automated rebuild in App-EPSC for the changed shared artifact, however would like the capabilitiy to provide a report to the application team, which owns this shared element.
+
+The build console output for App-EPSM will contain the below section (with `--verbose`):
+
+```
+** Analyse and report external impacted files.
+*** Identified external impacted files for changed file App-EPSM/copybooks-public/epsmtcom.cpy
+*** Writing report of external impacts to file /var/jenkins/workspace/App-EPSM-S4/outputs/build.20210722.032455.024/externalImpacts_App-EPSC-master.txt
+```
+
+For each collection in scoope of the analysis with impacted files a report is generated and written (in this case `externalImpacts_App-EPSC-master.txt`) to the `workdir`. A report will contain three columns (logicalFile, filePath and collectionName) with the external impacted files: 
+
+```
+EPSCMORT 	 App-EPSC/cobol/epscmort.cbl 	 App-EPSC-master
+```
+
+
+**Important considerations**
+- Use the pattern configuration to limit the query to those collections which are relevant and avoid unnecessary processing.
+- In most cases it is sufficient to run with the **simple** mode, which performs much faster, because it does not resolve impacts recursively. **deep** mode in fact requires searchPaths with the rules been correctly configured for the ImpactResolver API.
+
+## Report potential conflicts
+
+### Purpose
+
+Concurrent development activies in separated isolated branches on the same source code, lead to the need to merge the code at some point in time. Git does an excellent job for this task and supports the developer for this task. 
+
+While pessimistic locking is a common practise on the mainframe, developer will need to keep an eye on what is happening on the repository.
+
+The _Report potential conflicts_ feature can be activated to generate reports to document changes in the common code base configuration.
+
+### Functionality
+
+This feature compares two different configurations via a `git diff`. It runs a git diff between the `mainBuildBranch` and the current configuration to capture changes on the mainBuildBranch. These changes are reported within the build console output. 
+
+Additionally to the reporting, it verifies if the list of the current build files intersect with the identified changes of the mainBuildBranch. If the lists intesect, another notification is reported in the build log which can make the build be marked as failed and force the development team to integrate changes and rebase the code before they move on.  
+
+### Pre-requisites
+
+The feature relies on git functionality. Therefore it is only available in pipeline builds and not for user build scenarios.
+
+It requires that the cloned repository in the build workspace contains the git references (git-refs) to function.
+
+### Sample invocation
+
+to be documented

--- a/REPORT.md
+++ b/REPORT.md
@@ -78,10 +78,10 @@ Please review the build properties defined in [application-conf/reports.properti
 
 You can specify a list of regex patterns for those git references (branches) which should be considered in the analysis of potential conflicts. It also takes fully qualified names. Please note, that the implementation performs a `git branch -r` to dynamically obtain other branches based on the applicationSrcDirs . Limitation: It does not support the analysis across multiple git repositories configured in the build scope!
 
-In the below sample configuration for `reportConcurrentChangesGitBranchReferencePatterns`, the analysis will run for the mainBuildBranch, all branches containing the word `main`, the branches `main` and `release`, and all branches starting with `feature`.
+In the below sample configuration for `reportConcurrentChangesGitBranchReferencePatterns`, the analysis will run for the configured mainBuildBranch, all branches containing the word `main`, the branches `develop` and `release`, and all branches starting with `feature`.
 
 ```
-reportConcurrentChangesGitBranchReferencePatterns=${mainBuildBranch},.*main.*,main,release,feature.*
+reportConcurrentChangesGitBranchReferencePatterns=${mainBuildBranch},.*main.*,develop,release,feature.*
 ```
 
 The results of the analysis are written to a file called `report_concurrentChanges.txt' within the build workspace within the build out directory.   

--- a/REPORT.md
+++ b/REPORT.md
@@ -62,9 +62,9 @@ The _Report potential conflicts_ feature can be activated to generate reports to
 
 ### Functionality
 
-This feature compares two different configurations via a `git diff`. It runs a git diff between the `mainBuildBranch` and the current configuration to capture changes on the mainBuildBranch, which are not yet applied to the topic branch. These changes are reported within the build console output (when running in verbose mode) as well produce a log file within the build output directory. 
+This feature compares two different configurations via a `git diff`. It runs a git diff between the configured upstream target branch (`reportUpstreamChangesUpstreamBranch`) and the current configuration to capture changes of the upstream configuration, which are not yet applied to the topic branch. These changes are reported within the build console output (when running in verbose mode) as well produce a log file within the build output directory. 
 
-Additionally to the reporting, it verifies if the list of the current build files intersect with the identified changes of the mainBuildBranch. If the lists intersect, another notification is reported in the build log which can make the build be marked as failed and force the development team to integrate changes and rebase the code before they move on.  
+Additionally to the reporting, it verifies if the list of the current build files intersect with the identified changes of the upstream branch. If the lists intersect, another notification is reported in the build log which can make the build be marked as failed and force the development team to integrate changes and rebase the code before they move on.  
 
 ### Pre-requisites
 
@@ -74,7 +74,7 @@ It requires that the cloned repository in the build workspace contains the git r
 
 ### Configuration
 
-Please review the build properties defined in [application-conf/reports.properties](samples/application-conf/reports.properties) to configure the reporting of upstream changes. This feature is not available for builds of the git branch which is configured as the mainBuildBranch.
+Please review the build properties defined in [application-conf/reports.properties](samples/application-conf/reports.properties) to configure the reporting of upstream changes. This feature is not available for builds of the git branch which is configured as the upstream branch.
 ### Sample invocation
 
 To document the functionality of the feature, the source code `MortgageApplication/cobol/epscsmrt.cbl` was changed on the main branch after the feature branch was forked. 
@@ -87,7 +87,7 @@ MortgageApplication/cobol/epscsmrt.cbl
 MortgageApplication/cobol/epscmort.cbl
 MortgageApplication/link/epsmlist.lnk 
 ```
-While the above build list intersects with the changes on the mainBuildBranch main and the setting `reportUpstreamChangesIntersectionFailsBuild=true` is activated, a warning is written to the build console output and the build state is flagged as Error:
+While the above build list intersects with the changes on the upstream branch main and the setting `reportUpstreamChangesIntersectionFailsBuild=true` is activated, a warning is written to the build console output and the build state is flagged as Error:
 ```
 ** Build start at 20211221.110944.009
 ** Repository client created for https://10.3.20.96:10443/dbb
@@ -96,6 +96,7 @@ While the above build list intersects with the changes on the mainBuildBranch ma
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication
 ** Writing report of upstream changes to /u/ibmuser/outDir/mortgageout/build.20211221.110944.009/upstreamChanges.txt
 *!! MortgageApplication/cobol/epscsmrt.cbl is changed on the mainBuildBranch (main) and intersects with the current build list.
+*!! (ReportUpstreamChanges) The build list intersects with identified upstream changes.
 ** Writing build list file to /u/ibmuser/outDir/mortgageout/build.20211221.110944.009/buildList.txt
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script
@@ -120,7 +121,7 @@ Contents of the upstreamChanges.txt file look like:
 MortgageApplication/cobol/epscsmrt.cbl                            
 ````
 
-In a mergeBuild scenario, where the build list does not intersect with the changes on the mainBuildBranch, the build passes as expected.
+In a mergeBuild scenario, where the build list does not intersect with the changes on the upstream branch, the build passes as expected.
 
 ```
 ** Build start at 20211221.111003.010

--- a/REPORT.md
+++ b/REPORT.md
@@ -105,7 +105,7 @@ While the above build list intersects with the change on the branch main and the
 ** Build output located at /u/ibmuser/outDir/mortgageout/build.20211221.110944.009
 ** Build result created for BuildGroup:MortgageApplication-feature-1122 BuildLabel:build.20211221.110944.009 at https://10.3.20.96:10443/dbb/rest/buildResult/62001
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication
-* MortgageApplication/cobol/epscmort.cbl is changed on branch main and intersects with the current build list.
+*!! MortgageApplication/cobol/epscmort.cbl is changed on branch main and intersects with the current build list.
 ** Writing build list file to /u/ibmuser/outDir/mortgageout/build.20211221.110944.009/buildList.txt
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script

--- a/REPORT.md
+++ b/REPORT.md
@@ -6,7 +6,7 @@ Developers are particularly interested if:
 * A change of an element impacts other application components which are managed in a different repository.
 * Their changes on an isolated feature branch potentially cause a conflict with some concurrent development done by others within the same repository.
 
-During the analysis phase, while a developer can leverages application dependency tools such as IBM Application Discovery, it is also beneficial to enable the build framework to automatically generate reports to answer the above questions.
+During the analysis phase, while a developer might leverage tools for application understanding such as IBM Application Discovery, it is also beneficial to enable the build framework to automatically generate reports to answer the above questions.
 
 By default these reporting capabilities are turned off since it is normally not part of the standard build framework workflow.
 
@@ -16,20 +16,22 @@ By default these reporting capabilities are turned off since it is normally not 
 
 The _Reporting External Impacts_ feature enables the build framework to generate reports about impacted files in other application contexts to document cross application impacts for files that were changed within your application scope.
 
+The reports is meant to be used to start the collaboration process with the other application teams about their adoption process of the shared resource, typically a copybook. A future idea is to use the reports to add files to the build list so that the consuming application can built their impacted files.
+
 ### Pre-requisites
 
 Technically, this feature analyzes the list of changed files for the current application and then queries the collections of other applications within the DBB WebApp. Therefore, to fully analyze cross application impacts, the other applications must also be part of and processed through the CI/CD pipeline with DBB. It requires a DBB WebApp repository connection.
 
 ### Configuration
 
-You can configure the feature through [application-conf/reports.properties](samples/application-conf/reports.properties). Please check out the description of the properties also in [README.md](samples/application-conf/README.md#reportsproperties)
+You can configure the feature through [application-conf/reports.properties](samples/application-conf/reports.properties). Please check out the description of the properties in [README.md](samples/application-conf/README.md#reportsproperties)
 
-Within the property file, you can activate it and further configure a filter to run the analysis only for a subset of files in your repository see `reportExternalImpactsAnalysisFileFilter` and limit the scope of the external collections (see `reportExternalImpactsCollectionPatterns`), which should be queried.
+Use the build property in property file to activate the feature and further configure it like defining a filter to run the analysis only for a subset of files in your repository see `reportExternalImpactsAnalysisFileFilter` and to limit the scope of the external collections (see `reportExternalImpactsCollectionPatterns`), which should be queried.
 ### Sample invocation
 
 In the below sample, the MortgageApplication was split into two applications App-EPSC and App-EPSM to demonstrate the feature from a user perspective:
 
-App-EPSM provides a shared copybook `epsmtcom.cpy`, which is included in programs of App-EPSC. While the overall build strategy does not intend to force an automated rebuild in App-EPSC for the changed shared artifact, however would like the capabilitiy to provide a report to the application team, which owns this shared element.
+App-EPSM provides a shared copybook `epsmtcom.cpy`, which is included in programs of App-EPSC. While the overall build strategy does not intend to force an automated rebuild in App-EPSC for the changed shared artifact, however would like the capability to provide a report to the application team, which owns this shared element.
 
 The build console output for App-EPSM will contain the below section (with `--verbose`):
 
@@ -39,7 +41,7 @@ The build console output for App-EPSM will contain the below section (with `--ve
 *** Writing report of external impacts to file /var/jenkins/workspace/App-EPSM-S4/outputs/build.20210722.032455.024/externalImpacts_App-EPSC-master.txt
 ```
 
-For each collection in scoope of the analysis with impacted files a report is generated and written (in this case `externalImpacts_App-EPSC-master.txt`) to the `workdir`. A report will contain three columns (logicalFile, filePath and collectionName) with the external impacted files: 
+For each collection in scope of the analysis with impacted files a report is generated and written (in this case `externalImpacts_App-EPSC-master.txt`) to the `workdir`. A report will contain three columns (logicalFile, filePath and collectionName) with the external impacted files: 
 
 ```
 EPSCMORT 	 App-EPSC/cobol/epscmort.cbl 	 App-EPSC-master
@@ -54,32 +56,30 @@ EPSCMORT 	 App-EPSC/cobol/epscmort.cbl 	 App-EPSC-master
 
 ### Purpose
 
-Concurrent development activies in separated isolated branches on the same source code, lead to the need to merge the code at some point in time. Git does an excellent job for this task and supports the developer for this task. 
-
-While pessimistic locking is a common practise on the mainframe, developers will need to keep an eye on what is happening on the repository.
+Concurrent development activies in separated isolated branches on the same source code, lead to the need to merge the code at some point in time. Git does an excellent job for this task and supports the developer for this task. While pessimistic locking is a common practise on the mainframe, developers will need to keep an eye on what is happening on the repository.
 
 The _Report potential conflicts_ feature can be activated to generate reports to document changes in the common code base configuration.
 
 ### Functionality
 
-This feature compares two different configurations via a `git diff`. It runs a git diff between the `mainBuildBranch` and the current configuration to capture changes on the mainBuildBranch. These changes are reported within the build console output. 
+This feature compares two different configurations via a `git diff`. It runs a git diff between the `mainBuildBranch` and the current configuration to capture changes on the mainBuildBranch, which are not yet applied to the topic branch. These changes are reported within the build console output (when running in verbose mode) as well produce a log file within the build output directory. 
 
-Additionally to the reporting, it verifies if the list of the current build files intersect with the identified changes of the mainBuildBranch. If the lists intesect, another notification is reported in the build log which can make the build be marked as failed and force the development team to integrate changes and rebase the code before they move on.  
+Additionally to the reporting, it verifies if the list of the current build files intersect with the identified changes of the mainBuildBranch. If the lists intersect, another notification is reported in the build log which can make the build be marked as failed and force the development team to integrate changes and rebase the code before they move on.  
 
 ### Pre-requisites
 
-The feature relies on git functionality. Therefore it is only available in pipeline builds and not for user build scenarios.
+The feature relies on git functionality. Therefore it is only available in pipeline builds for the build types `--impactBuild` and `--mergeBuild` and not for user build scenarios.
 
-It requires that the cloned repository in the build workspace contains the git references (git-refs) to function.
+It requires that the cloned repository in the build workspace contains the git references (git-refs) to function. Please verify this in a test environment first, while not all pipeline orchestrators fetch the git references by default. 
 
 ### Configuration
 
-Please review the build properties defined in [application-conf/reports.properties](samples/application-conf/reports.properties) to configure the reporting of upstream changes. This features does not work on the git branch which is configured as the mainBuildBranch.
+Please review the build properties defined in [application-conf/reports.properties](samples/application-conf/reports.properties) to configure the reporting of upstream changes. This feature is not available for builds of the git branch which is configured as the mainBuildBranch.
 ### Sample invocation
 
 To document the functionality of the feature, the source code `MortgageApplication/cobol/epscsmrt.cbl` was changed on the main branch after the feature branch was forked. 
 
-In the first sample, the communication copybook `MortgageApplication/copybook/epsmtcom.cpy` was changed on the branch `reportUpstreamChanges`. During an impactBuild scenario, the the below build list is identified: 
+In the first sample, the communication copybook `MortgageApplication/copybook/epsmtcom.cpy` was changed on the branch `reportUpstreamChanges`. The impactBuild build type, identifies the the below build list: 
 
 ```
 MortgageApplication/cobol/epsmlist.cbl
@@ -87,7 +87,7 @@ MortgageApplication/cobol/epscsmrt.cbl
 MortgageApplication/cobol/epscmort.cbl
 MortgageApplication/link/epsmlist.lnk 
 ```
-While the above build list intersects with the changes on the mainBuildBranch main, a warning is written to the build console output:
+While the above build list intersects with the changes on the mainBuildBranch main and the setting `reportUpstreamChangesIntersectionFailsBuild=true` is activated, a warning is written to the build console output and the build state is flagged as Error:
 ```
 ** Build start at 20211221.110944.009
 ** Repository client created for https://10.3.20.96:10443/dbb
@@ -120,7 +120,7 @@ Contents of the upstreamChanges.txt file look like:
 MortgageApplication/cobol/epscsmrt.cbl                            
 ````
 
-Applying the feature in a mergeBuild scenario, where the build list does not intersect with the changes on the mainBuildBranch, the build passes as expected.
+In a mergeBuild scenario, where the build list does not intersect with the changes on the mainBuildBranch, the build passes as expected.
 
 ```
 ** Build start at 20211221.111003.010
@@ -143,7 +143,7 @@ Applying the feature in a mergeBuild scenario, where the build list does not int
 
 ** Build finished
 ```
-Contents of the upstreamChanges.txt file look like:
+Contents of the reported upstreamChanges.txt file look like:
 ```
 ** Upstream Changed Files 
 MortgageApplication/cobol/epscsmrt.cbl                            

--- a/REPORT.md
+++ b/REPORT.md
@@ -105,7 +105,7 @@ While the above build list intersects with the change on the branch main and the
 ** Build output located at /u/ibmuser/outDir/mortgageout/build.20211221.110944.009
 ** Build result created for BuildGroup:MortgageApplication-feature-1122 BuildLabel:build.20211221.110944.009 at https://10.3.20.96:10443/dbb/rest/buildResult/62001
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication
-*!! MortgageApplication/cobol/epscsmrt.cbl is changed on branch (main) and intersects with the current build list.
+* MortgageApplication/cobol/epscmort.cbl is changed on branch main and intersects with the current build list.
 ** Writing build list file to /u/ibmuser/outDir/mortgageout/build.20211221.110944.009/buildList.txt
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -47,6 +47,7 @@ reportExternalImpactsAnalysisDepths | Configuration of the analysis depths when 
 reportExternalImpactsAnalysisFileFilter | Comma-separated list of pathMatcher filters to limit the analysis of external impacts to a subset of the changed files
 reportExternalImpactsCollectionPatterns | Comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
 reportUpstreamChanges | Flag to indicate if a topic branch build creates reports of upstream changes to understand recent changes on the mainBuildBranch which don't exist on your configuration
+reportUpstreamChangesIntersectionFailsBuild | Flag to indicated if the build is marked as error, when the verification identifies, that the list of changes on the mainBuildBranch overlap with the current build list
 
 ### Assembler.properties
 Application properties used by zAppBuild/language/Assembler.groovy

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -46,8 +46,8 @@ reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and 
 reportExternalImpactsAnalysisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep)
 reportExternalImpactsAnalysisFileFilter | Comma-separated list of pathMatcher filters to limit the analysis of external impacts to a subset of the changed files
 reportExternalImpactsCollectionPatterns | Comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
-reportUpstreamChanges | Flag to indicate if a topic branch build creates reports of upstream changes to understand recent changes on the mainBuildBranch which don't exist on your configuration
-reportUpstreamChangesIntersectionFailsBuild | Flag to indicated if the build is marked as error, when the verification identifies, that the list of changes on the mainBuildBranch overlap with the current build list
+reportConcurrentChanges | Flag to indicate if a topic branch build creates reports of upstream changes to understand recent changes on the mainBuildBranch which don't exist on your configuration
+reportConcurrentChangesIntersectionFailsBuild | Flag to indicated if the build is marked as error, when the verification identifies, that the list of changes on the mainBuildBranch overlap with the current build list
 
 ### Assembler.properties
 Application properties used by zAppBuild/language/Assembler.groovy

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -1,5 +1,5 @@
 # Application Configuration
-This folder contains application specific configuration properties used by the zAppBuild Groovy build and utility scripts. It is intended to be copied as a high level folder in the application repository or main application repository if the application source files are distributed across multiple repositories. Once copied to the application repository, users should review the default property files and modify any values as needed. 
+This folder contains application specific configuration properties used by the zAppBuild Groovy build and utility scripts. It is intended to be copied as a high level folder in the application repository or main application repository if the application source files are distributed across multiple repositories. Once copied to the application repository, users should review the default property files and modify any values as needed.
 
 At the beginning of the build, the `application-conf/application.properties` file will automatically be loaded into the [DBB BuildProperties class](https://www.ibm.com/support/knowledgecenter/SS6T76_1.0.4/scriptorg.html#build-properties-class). Use the `applicationPropFiles` property (see table below) to load additional application property files.
 
@@ -25,10 +25,10 @@ jobCard | JOBCARD for JCL execs | false
 impactResolutionRules | Comma separated list of resolution rule properties used for impact builds.  Sample resolution rule properties (in JSON format) are included below. | true, recommended in file.properties
 
 ### file.properties
-Location of file properties, script mappings and file level property overrides.  All file properties for the entire application, including source files in distributed repositories of the application need to be contained either in this file or in other property files in the `application-conf` directory. Look for column 'Overridable' in the tables below for build properties that can have file level property overrides. 
+Location of file properties, script mappings and file level property overrides.  All file properties for the entire application, including source files in distributed repositories of the application need to be contained either in this file or in other property files in the `application-conf` directory. Look for column 'Overridable' in the tables below for build properties that can have file level property overrides.
 
-Property | Description 
---- | --- 
+Property | Description
+--- | ---
 dbb.scriptMapping | DBB configuration file properties association build files to language scripts
 dbb.scannerMapping | DBB scanner mapping to overwrite the file scanner. File property
 isSQL | File property overwrite to indicate that a file requires to include SQL parameters
@@ -37,15 +37,15 @@ isMQ | File property overwrite to indicate that a file requires to include MQ pa
 isDLI | File property overwrite to indicate that a file requires to include DLI parameters
 cobol_testcase | File property to indicate a generated zUnit cobol test case to use a different set of source and output libraries
 
-### dependencyReport.properties
-Properties used by the impact utilities to generate a report of external impacted files. Sample properties file to all application-conf to overwrite central build-conf configuration.
+### reports.properties
+Properties used by the build framework to generate reports. Sample properties file to all application-conf to overwrite central build-conf configuration.
 
 --- | ---
-reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and report external impacted files in other collections 
-reportExternalImpactsAnalysisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep) 
-reportExternalImpactsAnalysisFileFilter | Comma-separated list of pathMatcher filters to limit the analysis of external impacts to a subset of the changed files 
-reportExternalImpactsCollectionPatterns | Comma-separated list of regex patterns of DBB collection names for which external impacts should be documented 
-
+reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and report external impacted files in other collections
+reportExternalImpactsAnalysisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep)
+reportExternalImpactsAnalysisFileFilter | Comma-separated list of pathMatcher filters to limit the analysis of external impacts to a subset of the changed files
+reportExternalImpactsCollectionPatterns | Comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
+reportUpstreamChanges | Flag to indicate if a topic branch build creates reports of upstream changes to understand recent changes on the mainBuildBranch which don't exist on your configuration
 
 ### Assembler.properties
 Application properties used by zAppBuild/language/Assembler.groovy
@@ -230,8 +230,8 @@ zunit_maxPassRC | Default zUnit maximum RC allowed for a Pass. | true
 zunit_maxWarnRC | Default zUnit maximum RC allowed for a Warninig (everything beyond this value will Fail). | true
 zunit_playbackFileExtension | Default zUnit Playback File Extension. | true
 zunit_resolutionRules | Default resolution rules for zUnit. | true
-zunit_CodeCoverageHost | Headless Code Coverage Collector host (if not specified IDz will be used for reporting) | true 
-zunit_CodeCoveragePort | Headless Code Coverage Collector port (if not specified IDz will be used for reporting) | true 
+zunit_CodeCoverageHost | Headless Code Coverage Collector host (if not specified IDz will be used for reporting) | true
+zunit_CodeCoveragePort | Headless Code Coverage Collector port (if not specified IDz will be used for reporting) | true
 zunit_CodeCoverageOptions | Headless Code Coverage Collector Options | true
 
 ### REXX.properties

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -46,8 +46,9 @@ reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and 
 reportExternalImpactsAnalysisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep)
 reportExternalImpactsAnalysisFileFilter | Comma-separated list of pathMatcher filters to limit the analysis of external impacts to a subset of the changed files
 reportExternalImpactsCollectionPatterns | Comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
-reportConcurrentChanges | Flag to indicate if a topic branch build creates reports of upstream changes to understand recent changes on the mainBuildBranch which don't exist on your configuration
-reportConcurrentChangesIntersectionFailsBuild | Flag to indicated if the build is marked as error, when the verification identifies, that the list of changes on the mainBuildBranch overlap with the current build list
+reportConcurrentChanges | Flag to indicate if the build generates reports of concurrent changes to understand recent changes in concurrent configurations (branches)
+reportConcurrentChangesGitBranchReferencePatterns | Comma-seperated list of regex patterns defining the branches for which concurrent changes should be calculated
+reportConcurrentChangesIntersectionFailsBuild | Flag to indicated if the build is marked as error, when build list intersects with changes on concurrent configurations
 
 ### Assembler.properties
 Application properties used by zAppBuild/language/Assembler.groovy

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -40,6 +40,7 @@ cobol_testcase | File property to indicate a generated zUnit cobol test case to 
 ### reports.properties
 Properties used by the build framework to generate reports. Sample properties file to all application-conf to overwrite central build-conf configuration.
 
+Property | Description 
 --- | ---
 reportExternalImpacts | Flag to indicate if an *impactBuild* should analyze and report external impacted files in other collections
 reportExternalImpactsAnalysisDepths | Configuration of the analysis depths when performing impact analysis for external impacts (simple|deep)

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -8,7 +8,7 @@
 #
 # Comma separated list of additional application property files to load
 # Supports both relative path (to ${application}/application-conf/) and absolute path
-applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,REXX.properties,ZunitConfig.properties
+applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,REXX.properties,ZunitConfig.properties,reports.properties
 
 #
 # Comma separated list all source directories included in application build. Supports both absolute

--- a/samples/application-conf/reports.properties
+++ b/samples/application-conf/reports.properties
@@ -64,8 +64,8 @@ reportConcurrentChanges=false
 # typically this is the branch into which changes of the topic branch are planned to be merged into.
 #
 # sample:
-#   reportConcurrentChangesGitBranchReferencePatterns=${mainBuildBranch},.*main.*,main,release,feature.*
-#   will inspect the mainBuildBranch, branches containing the word main, the main and release branches as
+#   reportConcurrentChangesGitBranchReferencePatterns=${mainBuildBranch},.*main.*,develop,release,feature.*
+#   will inspect the mainBuildBranch, branches containing the word main, the develop and release branches as
 #   well as all branches starting with feature    
 # 
 # default: ${mainBuildBranch} 

--- a/samples/application-conf/reports.properties
+++ b/samples/application-conf/reports.properties
@@ -8,43 +8,58 @@
 #
 ###########################################################
 #
-# Flag to indicate if an *impactBuild* should analyze and report external impacted files
-# in other collections. cli option (-re, reportExternalImpacts) passed to build.groovy takes precedences.
-# 
-# For further configuration see reportExternalImpacts* properties
-# 
+# Flag to indicate if an *impactBuild* or *mergeBuild* should analyze and report external impacted files
+# in other collections. cli option (-re, reportExternalImpacts) passed to build.groovy will take precedence.
+#  
 # Default: false
 # reportExternalImpacts=false
 
 #
 # AnalysisDepths when performing impact analysis for external impacts
 # Options: (simple/deep)
-#  simple will not allow recursion and only find files which have a direct dependency to the changed file 
-#  deep   will recursively resolve impacts, which is more expensive compared to simple mode
+#  - simple will not allow recursion and only find files which have a direct dependency to the changed file 
+#  - deep   will recursively resolve impacts, which is more expensive compared to simple mode
+#
+# Default: simple
 # reportExternalImpactsAnalysisDepths=simple
 
 # comma-separated list of pathMatcher filters to limit the analysis
-# of external impacts to a subset of the changed files 
-#  Default setting: excludeFileList=**/* (all)
-#  sample only files with file extension cpy: reportExternalImpactsAnalysisFilter=**/*.cpy
+# of external impacts to a subset of the changed files within the current application.
+# 
+# Sample setting to perform the analysis for all changes within the current application:
+#      reportExternalImpactsAnalysisFileFilter=**/*
+# 
+# Sample setting to perform the analysis only for files with file extension cpy:
+#      reportExternalImpactsAnalysisFilter=**/*.cpy
+# 
 # reportExternalImpactsAnalysisFileFilter=**/*
 
 #
 # comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
-# Uses regex patterns sample: collectionPatternsReportExternalImpacts=.*-dev.* --> all collections which contain "-dev"
-# reportExternalImpactsCollectionPatterns=.*-master.*
+# Uses regex patterns. 
+#  Sample: collectionPatternsReportExternalImpacts=.*-dev.* --> all collections which contain "-dev"
+# 
+# reportExternalImpactsCollectionPatterns=.*-main.*
 
 ###########################################################
 #
-# The reportUpstreamChanges capability allows for your feature/topic branches:
+# The reportUpstreamChanges capability allows for your topic branches:
 #  * to generate reports of changes on the mainBuildBranch
 #    which are ahead of your configuration (branch)
 #  * it leverages a triple-dot diff to compare the remote/origin/props.mainBuildBranch
 #    with the current HEAD 
-#
+#  * if verifies, that the build list does not intersect with the list of changes of 
+#    the mainBuildBranch
 ###########################################################
 #
 # boolean flag to activate the reporting of upstream changes
-#  to understand recent changes on the mainBuildBranch which don't exist on your configuration
+#  to report recent changes on the mainBuildBranch which don't exist on your configuration
+#
 # default:false 
 reportUpstreamChanges=false
+
+# boolean flag to mark the build as error, when the verification identifies, that 
+#  the list of changes on the mainBuildBranch overlap with the current build list
+#
+# default:false 
+reportUpstreamChangesIntersectionFailsBuild=false

--- a/samples/application-conf/reports.properties
+++ b/samples/application-conf/reports.properties
@@ -44,7 +44,7 @@
 ###########################################################
 #
 # The reportUpstreamChanges capability allows for your topic branches:
-#  * to generate reports of changes on the mainBuildBranch
+#  * to generate reports of changes on the defined upstream branch
 #    which are ahead of your configuration (branch)
 #  * it leverages a triple-dot diff to compare the remote/origin/props.mainBuildBranch
 #    with the current HEAD 
@@ -57,6 +57,12 @@
 #
 # default:false 
 reportUpstreamChanges=false
+
+# build property to define the upstream branch for which the changes should be calculated.
+#  typically the branch into which changes of the topic branch are planned to be merged into.
+#
+# default: mainBuildBranch 
+reportUpstreamChangesUpstreamBranch=${mainBuildBranch}
 
 # boolean flag to mark the build as error, when the verification identifies, that 
 #  the list of changes on the mainBuildBranch overlap with the current build list

--- a/samples/application-conf/reports.properties
+++ b/samples/application-conf/reports.properties
@@ -1,6 +1,12 @@
-# Application properties to configure analysis and reporting of external dependencies
+# Application properties to configure analysis and reporting of external dependencies and changes
 # Sample to override the configuration  
 
+###########################################################
+#
+# reportExternalImpacts capability to report externally impacted files 
+#  in other application systems which are also built with zAppBuild
+#
+###########################################################
 #
 # Flag to indicate if an *impactBuild* should analyze and report external impacted files
 # in other collections. cli option (-re, reportExternalImpacts) passed to build.groovy takes precedences.
@@ -27,3 +33,18 @@
 # comma-separated list of regex patterns of DBB collection names for which external impacts should be documented
 # Uses regex patterns sample: collectionPatternsReportExternalImpacts=.*-dev.* --> all collections which contain "-dev"
 # reportExternalImpactsCollectionPatterns=.*-master.*
+
+###########################################################
+#
+# The reportUpstreamChanges capability allows for your feature/topic branches:
+#  * to generate reports of changes on the mainBuildBranch
+#    which are ahead of your configuration (branch)
+#  * it leverages a triple-dot diff to compare the remote/origin/props.mainBuildBranch
+#    with the current HEAD 
+#
+###########################################################
+#
+# boolean flag to activate the reporting of upstream changes
+#  to understand recent changes on the mainBuildBranch which don't exist on your configuration
+# default:false 
+reportUpstreamChanges=false

--- a/samples/application-conf/reports.properties
+++ b/samples/application-conf/reports.properties
@@ -43,13 +43,13 @@
 
 ###########################################################
 #
-# The reportConcurrentChanges capability allows for your topic branches:
-#  * to generate reports of changes on the defined upstream branch
+# The reportConcurrentChanges capability allows:
+#  * to generate reports of changes on the defined concurrent branch
 #    which are ahead of your configuration (branch)
-#  * it leverages a triple-dot diff to compare the remote/origin/props.mainBuildBranch
-#    with the current HEAD 
-#  * if verifies, that the build list does not intersect with the list of changes of 
-#    the mainBuildBranch
+#  * it leverages a triple-dot diff to compare the banch
+#    with the current HEAD of your build workspace
+#  * if verifies, that the build list does not intersect with the list of 
+#    concurrent changes
 ###########################################################
 #
 # boolean flag to activate the reporting of upstream changes
@@ -58,11 +58,19 @@
 # default:false 
 reportConcurrentChanges=false
 
-# build property to define the upstream branch for which the changes should be calculated.
-#  typically the branch into which changes of the topic branch are planned to be merged into.
+# build property to define comma-seperated List of regex patterns defining the branches
+# for which concurrent changes should be calculated and reported.
+# 
+# typically this is the branch into which changes of the topic branch are planned to be merged into.
 #
-# default: mainBuildBranch 
-reportConcurrentChangesGitBranchReferencePatterns=remotes/origin/${mainBuildBranch}
+# sample:
+#   reportConcurrentChangesGitBranchReferencePatterns=${mainBuildBranch},.*main.*,main,release,feature.*
+#   will inspect the mainBuildBranch, branches containing the word main, the main and release branches as
+#   well as all branches starting with feature    
+# 
+# default: ${mainBuildBranch} 
+#
+reportConcurrentChangesGitBranchReferencePatterns=${mainBuildBranch}
 
 # boolean flag to mark the build as error, when the verification identifies, that 
 #  the list of changes on the mainBuildBranch overlap with the current build list

--- a/samples/application-conf/reports.properties
+++ b/samples/application-conf/reports.properties
@@ -43,7 +43,7 @@
 
 ###########################################################
 #
-# The reportUpstreamChanges capability allows for your topic branches:
+# The reportConcurrentChanges capability allows for your topic branches:
 #  * to generate reports of changes on the defined upstream branch
 #    which are ahead of your configuration (branch)
 #  * it leverages a triple-dot diff to compare the remote/origin/props.mainBuildBranch
@@ -56,16 +56,16 @@
 #  to report recent changes on the mainBuildBranch which don't exist on your configuration
 #
 # default:false 
-reportUpstreamChanges=false
+reportConcurrentChanges=false
 
 # build property to define the upstream branch for which the changes should be calculated.
 #  typically the branch into which changes of the topic branch are planned to be merged into.
 #
 # default: mainBuildBranch 
-reportUpstreamChangesUpstreamBranch=${mainBuildBranch}
+reportConcurrentChangesUpstreamBranch=${mainBuildBranch}
 
 # boolean flag to mark the build as error, when the verification identifies, that 
 #  the list of changes on the mainBuildBranch overlap with the current build list
 #
 # default:false 
-reportUpstreamChangesIntersectionFailsBuild=false
+reportConcurrentChangesIntersectionFailsBuild=false

--- a/samples/application-conf/reports.properties
+++ b/samples/application-conf/reports.properties
@@ -62,7 +62,7 @@ reportConcurrentChanges=false
 #  typically the branch into which changes of the topic branch are planned to be merged into.
 #
 # default: mainBuildBranch 
-reportConcurrentChangesUpstreamBranch=${mainBuildBranch}
+reportConcurrentChangesGitBranchReferencePatterns=remotes/origin/${mainBuildBranch}
 
 # boolean flag to mark the build as error, when the verification identifies, that 
 #  the list of changes on the mainBuildBranch overlap with the current build list

--- a/samples/application-conf/reports.properties
+++ b/samples/application-conf/reports.properties
@@ -17,8 +17,8 @@
 #
 # AnalysisDepths when performing impact analysis for external impacts
 # Options: (simple/deep)
-#  - simple will not allow recursion and only find files which have a direct dependency to the changed file 
-#  - deep   will recursively resolve impacts, which is more expensive compared to simple mode
+#   simple - will not allow recursion and only find files which have a direct dependency to the changed file 
+#   deep -  will recursively resolve impacts, which is more expensive compared to simple mode
 #
 # Default: simple
 # reportExternalImpactsAnalysisDepths=simple

--- a/samples/application-conf/reports.properties
+++ b/samples/application-conf/reports.properties
@@ -46,7 +46,7 @@
 # The reportConcurrentChanges capability allows:
 #  * to generate reports of changes on the defined concurrent branch
 #    which are ahead of your configuration (branch)
-#  * it leverages a triple-dot diff to compare the banch
+#  * it leverages a triple-dot diff to compare the branch
 #    with the current HEAD of your build workspace
 #  * if verifies, that the build list does not intersect with the list of 
 #    concurrent changes

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -198,6 +198,16 @@ def getMergeChanges(String gitDir, String baselineReference) {
 }
 
 /*
+ * getMergeChanges - assembles a git triple-dot diff command to support mergeBuild scenarios
+ *  returns the changed, deleted and renamed files between current HEAD and the provided baseline.
+ *
+ */
+def getUpstreamChanges(String gitDir, String baselineReference) {
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status HEAD...remotes/origin/$baselineReference"
+	return getChangedFiles(gitCmd)
+}
+
+/*
  * getChangedFiles - internal method to submit the a gitDiff command and calucate and classify the idenfified changes 
  */
 def getChangedFiles(String cmd) {

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -87,7 +87,7 @@ def getRemoteGitBranches(String applicationSrcDirs) {
 
 	Set<String> remoteBranches = new HashSet<String>()
 	applicationSrcDirs.split(',').each{dir ->
-		String cmd = "git -C $gitDir branch -r"
+		String cmd = "git -C $dir branch -r"
 
 		StringBuffer gitOut = new StringBuffer()
 		StringBuffer gitError = new StringBuffer()

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -97,7 +97,7 @@ def getRemoteGitBranches(String gitDir) {
 		println("*! Error executing Git command: $cmd error: $gitError")
 	} else {
 		for (line in gitOut.toString().split("\n")) {
-			remoteBranches.add(line)
+			remoteBranches.add(line.replaceAll(".*?/", ""))
 		}
 	}
 	return remoteBranches
@@ -229,7 +229,7 @@ def getMergeChanges(String gitDir, String baselineReference) {
  *
  */
 def getConcurrentChanges(String gitDir, String baselineReference) {
-	String gitCmd = "git -C $gitDir --no-pager diff --name-status HEAD...$baselineReference"
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status HEAD...remotes/origin/$baselineReference"
 	return getChangedFiles(gitCmd)
 }
 

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -80,26 +80,24 @@ def getCurrentGitDetachedBranch(String gitDir) {
 /*
  * Returns the current Git branch
  *
- * @param  String applicationSrcDirs  		list of applicationSrcDirs
+ * @param  String gitGit            		git directory
  * @return List 							list of remote branches
  */
-def getRemoteGitBranches(String applicationSrcDirs) {
+def getRemoteGitBranches(String gitDir) {
 
 	Set<String> remoteBranches = new HashSet<String>()
-	applicationSrcDirs.split(',').each{dir ->
-		String cmd = "git -C $dir branch -r"
+	String cmd = "git -C $gitDir branch -r"
 
-		StringBuffer gitOut = new StringBuffer()
-		StringBuffer gitError = new StringBuffer()
+	StringBuffer gitOut = new StringBuffer()
+	StringBuffer gitError = new StringBuffer()
 
-		Process process = cmd.execute()
-		process.waitForProcessOutput(gitOut, gitError)
-		if (gitError) {
-			println("*! Error executing Git command: $cmd error: $gitError")
-		} else {
-			for (line in gitOut.toString().split("\n")) {
-				remoteBranches.add(line)
-			}
+	Process process = cmd.execute()
+	process.waitForProcessOutput(gitOut, gitError)
+	if (gitError) {
+		println("*! Error executing Git command: $cmd error: $gitError")
+	} else {
+		for (line in gitOut.toString().split("\n")) {
+			remoteBranches.add(line)
 		}
 	}
 	return remoteBranches

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -78,6 +78,34 @@ def getCurrentGitDetachedBranch(String gitDir) {
 }
 
 /*
+ * Returns the current Git branch
+ *
+ * @param  String applicationSrcDirs  		list of applicationSrcDirs
+ * @return List 							list of remote branches
+ */
+def getRemoteGitBranches(String applicationSrcDirs) {
+
+	Set<String> remoteBranches = new HashSet<String>()
+	applicationSrcDirs.split(',').each{dir ->
+		String cmd = "git -C $gitDir branch -r"
+
+		StringBuffer gitOut = new StringBuffer()
+		StringBuffer gitError = new StringBuffer()
+
+		Process process = cmd.execute()
+		process.waitForProcessOutput(gitOut, gitError)
+		if (gitError) {
+			println("*! Error executing Git command: $cmd error: $gitError")
+		} else {
+			for (line in gitOut.toString().split("\n")) {
+				remoteBranches.add(line)
+			}
+		}
+	}
+	return remoteBranches
+}
+
+/*
  * Returns true if this is a detached HEAD
  *
  * @param  String gitDir  		Local Git repository directory
@@ -203,7 +231,7 @@ def getMergeChanges(String gitDir, String baselineReference) {
  *
  */
 def getConcurrentChanges(String gitDir, String baselineReference) {
-	String gitCmd = "git -C $gitDir --no-pager diff --name-status HEAD...remotes/origin/$baselineReference"
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status HEAD...$baselineReference"
 	return getChangedFiles(gitCmd)
 }
 

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -202,7 +202,7 @@ def getMergeChanges(String gitDir, String baselineReference) {
  *  returns the changed, deleted and renamed files between current HEAD and the provided baseline.
  *
  */
-def getUpstreamChanges(String gitDir, String baselineReference) {
+def getConcurrentChanges(String gitDir, String baselineReference) {
 	String gitCmd = "git -C $gitDir --no-pager diff --name-status HEAD...remotes/origin/$baselineReference"
 	return getChangedFiles(gitCmd)
 }

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -199,7 +199,7 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 		Set<String> upstreamRenamedFiles = new HashSet<String>()
 		Set<String> upstreamDeletedFiles = new HashSet<String>()
 		
-		if (props.verbose) println "***  Analysing and validating changes for ${props.reportUpstreamChangesUpstreamBranch} ."
+		if (props.verbose) println "***  Analysing and validating changes for BRANCH ${props.reportUpstreamChangesUpstreamBranch} ."
 		
 		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(props.reportUpstreamChangesUpstreamBranch)
 		
@@ -394,44 +394,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateUpstream
 				if (props.verbose) println "**** $file"
 			}
 		}
-		
-		// calculate upstream changed files
-		if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() && gitUtils.isGitDir(dir)) {
-			if (props.verbose) println "** Calculating upstream changes for directory $dir"
-			if (props.verbose) println "** Triple-dot diffing configuration baseline current HEAD -> remotes/origin/${props.reportUpstreamChangesUpstreamBranch} to capture upstream changes"
-			(upstreamChanged, upstreamDeleted, upstreamRenamed) = gitUtils.getUpstreamChanges(dir, props.reportUpstreamChangesUpstreamBranch)
-
-
-			if (props.verbose) println "*** Changed upstream files for directory $dir:"
-			upstreamChanged.each { file ->
-				(file, mode) = fixGitDiffPath(file, dir, true, null)
-				if ( file != null ) {
-					if ( !matches(file, excludeMatchers)) {
-						upstreamChangedFiles << file
-						if (props.verbose) println "**** $file"
-					}
-				}
-			}
-
-			if (props.verbose) println "*** Deleted upstream files for directory $dir:"
-			upstreamDeleted.each { file ->
-				if ( !matches(file, excludeMatchers)) {
-					(file, mode) = fixGitDiffPath(file, dir, false, mode)
-					upstreamDeletedFiles << file
-					if (props.verbose) println "**** $file"
-				}
-			}
-
-			if (props.verbose) println "*** Renamed upstream files for directory $dir:"
-			upstreamRenamed.each { file ->
-				if ( !matches(file, excludeMatchers)) {
-					(file, mode) = fixGitDiffPath(file, dir, false, mode)
-					upstreamRenamedFiles << file
-					if (props.verbose) println "**** $file"
-				}
-			}
-		}
-		
+	
 	}
 
 	return [

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -142,7 +142,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 	}
 
 	// Document and validate concurrent changes
-	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean()){
+	if (props.reportConcurrentChanges && props.reportConcurrentChanges.toBoolean()){
 		if (props.verbose) println "*** Calculate and document concurrent changes."
 		calculateConcurrentChanges(repositoryClient, buildSet)
 	}
@@ -182,7 +182,7 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 	}
 
 	// Document and validate concurrent changes
-	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean()){
+	if (props.reportConcurrentChanges && props.reportConcurrentChanges.toBoolean()){
 		if (props.verbose) println "*** Calculate and document concurrent changes."
 		calculateConcurrentChanges(repositoryClient, buildSet)
 	}
@@ -207,7 +207,7 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
 	
 	//a loop
 
-	String gitReference = props.reportUpstreamChangesUpstreamBranch
+	String gitReference = props.reportConcurrentChangesUpstreamBranch
 
 	Set<String> concurrentChangedFiles = new HashSet<String>()
 	Set<String> concurrentRenamedFiles = new HashSet<String>()
@@ -586,13 +586,13 @@ def generateConcurrentChangesReports(Set<String> concurrentChangedFiles, Set<Str
  */
 def verifyBuildListAgainstConcurrentChanges(Set<String> buildList, Set<String> concurrentChanges, RepositoryClient repositoryClient, String gitReference) {
 	// Validate potential mismatches and report mismatches
-	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() ){
+	if (props.reportConcurrentChanges && props.reportConcurrentChanges.toBoolean() ){
 		Set<String> intersection = new HashSet<String>(buildList)
 		intersection.retainAll(concurrentChanges) // intersection contains all elements on both sets
 		intersection.each { it ->
 			String msg = "*!! $it is changed on branch ($gitReference) and intersects with the current build list."
 			println(msg)
-			if (props.reportUpstreamChangesIntersectionFailsBuild && props.reportUpstreamChangesIntersectionFailsBuild.toBoolean()) {
+			if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 				props.error = "true"
 				buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
 			} else {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -601,13 +601,16 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
  */
 
 def generateConcurrentChangesReports(Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference){
-	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges_${gitReference}.txt"
-	println("** Writing report of concurrent changes to $concurrentChangesReportLoc for configuration $gitReference")
+	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges.txt"
+	if (props.verbose) println("** Writing report of concurrent changes to $concurrentChangesReportLoc for configuration $gitReference")
 
 	File concurrentChangesReportFile = new File(concurrentChangesReportLoc)
 	String enc = props.logEncoding ?: 'IBM-1047'
 	concurrentChangesReportFile.withWriter(enc) { writer ->
 
+		writer.write("\n** Report for configuration: $gitReference \n")
+		writer.write("=============================================== \n")
+		
 		writer.write("** Changed Files \n")
 		if (concurrentChangedFiles.size() != 0) {
 			concurrentChangedFiles.each { file ->

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -618,6 +618,9 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (buildList.contains(file)) {
 						writer.write("* $file is changed and intersects with the current build list.\n")
 						String msg = "* $file is changed on branch $gitReference and intersects with the current build list."
+						println msg
+						
+						// update build result
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
 							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
@@ -637,6 +640,9 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (buildList.contains(file)) {
 						writer.write("* $file got renamed and intersects with the current build list.\n")
 						String msg = "* $file is renamed on branch $gitReference and intersects with the current build list."
+						println msg
+						
+						// update build result
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
 							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
@@ -656,6 +662,9 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (buildList.contains(file)) {
 						writer.write("* $file is deleted and intersects with the current build list.\n")
 						String msg = "* $file is deleted on branch $gitReference and intersects with the current build list."
+						println msg
+						
+						// update build result
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
 							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -619,8 +619,10 @@ def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> ups
 		intersection.each { it ->
 			println "*!! $it is changed on the mainBuildBranch (${props.mainBuildBranch}) and intersects with the current build list."
 			if (props.reportUpstreamChangesIntersectionFailsBuild && props.reportUpstreamChangesIntersectionFailsBuild.toBoolean()) {
-				println "*!!   Flag build state as ERROR. 
+				String errorMsg = "*!! (ReportUpstreamChanges) The build list intersects with identified upstream changes."
+				println(errorMsg)
 				props.error = "true"
+				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
 			}
 		}
 	}
@@ -1030,4 +1032,14 @@ def sortFileList(list) {
 			}
 		}
 	}
+}
+
+/**
+ * getRepositoryClient
+ */
+def getRepositoryClient() {
+	if (!repositoryClient && props."dbb.RepositoryClient.url")
+		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
+
+	return repositoryClient
 }

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -618,8 +618,12 @@ def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> ups
 		intersection.retainAll(upstreamChanges) // intersection contains all elements on both sets
 		intersection.each { it ->
 			println "*!! $it is changed on the mainBuildBranch (${props.mainBuildBranch}) and intersects with the current build list."
-			if (props.reportUpstreamChangesIntersectionFailsBuild && props.reportUpstreamChangesIntersectionFailsBuild.toBoolean()) props.error = "true"
+			if (props.reportUpstreamChangesIntersectionFailsBuild && props.reportUpstreamChangesIntersectionFailsBuild.toBoolean()) {
+				println "*!!   Flag build state as ERROR. 
+				props.error = "true"
+			}
 		}
+	}
 	}
 }
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -617,7 +617,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (props.verbose) println " Changed: ${file}"
 					if (buildList.contains(file)) {
 						writer.write("* $file is changed and intersects with the current build list.\n")
-						String msg = "* $file is changed on branch $gitReference and intersects with the current build list."
+						String msg = "*!! $file is changed on branch $gitReference and intersects with the current build list."
 						println msg
 						
 						// update build result
@@ -639,7 +639,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (props.verbose) println " Renamed: ${file}"
 					if (buildList.contains(file)) {
 						writer.write("* $file got renamed and intersects with the current build list.\n")
-						String msg = "* $file is renamed on branch $gitReference and intersects with the current build list."
+						String msg = "*!! $file is renamed on branch $gitReference and intersects with the current build list."
 						println msg
 						
 						// update build result
@@ -661,7 +661,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (props.verbose) println " Deleted: ${file}"
 					if (buildList.contains(file)) {
 						writer.write("* $file is deleted and intersects with the current build list.\n")
-						String msg = "* $file is deleted on branch $gitReference and intersects with the current build list."
+						String msg = "*!! $file is deleted on branch $gitReference and intersects with the current build list."
 						println msg
 						
 						// update build result

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -576,7 +576,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 
 def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String> upstreamRenamedFiles, Set<String> upstreamDeletedFiles){
 	String upstreamChangesReportLoc = "${props.buildOutDir}/upstreamChanges.${props.buildListFileExt}"
-	println("*** Writing report of upstream changes to $upstreamChangesReportLoc")
+	println("** Writing report of upstream changes to $upstreamChangesReportLoc")
 
 	File upstreamChangesReportFile = new File(upstreamChangesReportLoc)
 	String enc = props.logEncoding ?: 'IBM-1047'
@@ -588,7 +588,7 @@ def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String>
 				if (props.verbose) println "Changed: ${file}"
 				writer.write("$file\n")
 			}
-		} else { if (props.verbose) println "** No upstream changed files found." }
+		}
 
 		if (upstreamRenamedFiles.size() != 0) {
 			writer.write("** Upstream Renamed Files \n")
@@ -596,7 +596,7 @@ def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String>
 				if (props.verbose) println "Renamed: ${file}"
 				writer.write("$file\n")
 			}
-		} else { if (props.verbose) println "** No upstream renamed files found." }
+		}
 
 		if (upstreamDeletedFiles.size() != 0) {
 			writer.write("** Upstream Deleted Files \n")
@@ -604,7 +604,7 @@ def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String>
 				if (props.verbose) println "Deleted: ${file}"
 				writer.write("$file\n")
 			}
-		} else { if (props.verbose) println "** No upstream deleted files found." }
+		}
 	}
 }
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -626,7 +626,6 @@ def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> ups
 			}
 		}
 	}
-	}
 }
 
 def createImpactResolver(String changedFile, String rules, RepositoryClient repositoryClient) {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -198,7 +198,7 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 	// Validate potential mismatches
 	// && reportMismatches
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() ){
-		upstreamChangedFiles.intersects(changedFiles).each { it ->
+		changedFiles.retainAll(upstreamChangedFiles).each { it ->
 			println "*!! $it is changed on the mainBuildBranch and the current branch."
 			props.error = "true"
 		}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -617,12 +617,14 @@ def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> ups
 		Set<String> intersection = new HashSet<String>(buildList)
 		intersection.retainAll(upstreamChanges) // intersection contains all elements on both sets
 		intersection.each { it ->
-			println "*!! $it is changed on the mainBuildBranch (${props.mainBuildBranch}) and intersects with the current build list."
+			String msg = "*!! $it is changed on the mainBuildBranch (${props.mainBuildBranch}) and intersects with the current build list."
+			println(msg)
 			if (props.reportUpstreamChangesIntersectionFailsBuild && props.reportUpstreamChangesIntersectionFailsBuild.toBoolean()) {
 				String errorMsg = "*!! (ReportUpstreamChanges) The build list intersects with identified upstream changes."
 				println(errorMsg)
 				props.error = "true"
 				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+				buildUtils.updateBuildResult(errorMsg:msg,client:getRepositoryClient())
 			}
 		}
 	}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -617,7 +617,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (props.verbose) println " Changed: ${file}"
 					if (buildList.contains(file)) {
 						writer.write("* $file is changed and intersects with the current build list.\n")
-						String msg = "* $file is changed on branch $gitBranch and intersects with the current build list."
+						String msg = "* $file is changed on branch $gitReference and intersects with the current build list."
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
 							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
@@ -636,7 +636,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (props.verbose) println " Renamed: ${file}"
 					if (buildList.contains(file)) {
 						writer.write("* $file got renamed and intersects with the current build list.\n")
-						String msg = "* $file is renamed on branch $gitBranch and intersects with the current build list."
+						String msg = "* $file is renamed on branch $gitReference and intersects with the current build list."
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
 							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
@@ -655,7 +655,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (props.verbose) println " Deleted: ${file}"
 					if (buildList.contains(file)) {
 						writer.write("* $file is deleted and intersects with the current build list.\n")
-						String msg = "* $file is deleted on branch $gitBranch and intersects with the current build list."
+						String msg = "* $file is deleted on branch $gitReference and intersects with the current build list."
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
 							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -157,7 +157,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(upstreamReference)
 		
 		// generate reports
-		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
+		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, upstreamReference)
 		// verify that build set does not intersect with upstream changes
 		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles, repositoryClient, upstreamReference)
 		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles, repositoryClient, upstreamReference)
@@ -216,7 +216,7 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(upstreamReference)
 		
 		// generate reports
-		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
+		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, upstreamReference)
 		// verify that build set does not intersect with upstream changes
 		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles, repositoryClient, upstreamReference)
 		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles, repositoryClient, upstreamReference)
@@ -600,13 +600,13 @@ def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String>
 /**
  * Method to verify if the list of upstream changes intersects with the build list
  */
-def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> upstreamChanges, RepositoryClient repositoryClient) {
+def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> upstreamChanges, RepositoryClient repositoryClient, String upstreamReference) {
 	// Validate potential mismatches and report mismatches
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() ){
 		Set<String> intersection = new HashSet<String>(buildList)
 		intersection.retainAll(upstreamChanges) // intersection contains all elements on both sets
 		intersection.each { it ->
-			String msg = "*!! $it is changed on the upstream branch (${props.reportUpstreamChangesUpstreamBranch}) and intersects with the current build list."
+			String msg = "*!! $it is changed on branch ($upstreamReference) and intersects with the current build list."
 			println(msg)
 			if (props.reportUpstreamChangesIntersectionFailsBuild && props.reportUpstreamChangesIntersectionFailsBuild.toBoolean()) {
 				props.error = "true"

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -617,7 +617,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 					if (props.verbose) println " Changed: ${file}"
 					if (buildList.contains(file)) {
 						writer.write("* $file is changed and intersects with the current build list.\n")
-
+						String msg = "* $file is changed on branch $gitBranch and intersects with the current build list."
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
 							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
@@ -634,8 +634,16 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 				writer.write("** Renamed Files \n")
 				concurrentRenamedFiles.each { file ->
 					if (props.verbose) println " Renamed: ${file}"
-					if (buildList.contains(file))
+					if (buildList.contains(file)) {
 						writer.write("* $file got renamed and intersects with the current build list.\n")
+						String msg = "* $file is renamed on branch $gitBranch and intersects with the current build list."
+						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
+							props.error = "true"
+							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
+						} else {
+							buildUtils.updateBuildResult(warningMsg:msg,client:repositoryClient)
+						}
+					}
 					else
 						writer.write("  $file\n")
 				}
@@ -645,8 +653,16 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 				writer.write("** Deleted Files \n")
 				concurrentDeletedFiles.each { file ->
 					if (props.verbose) println " Deleted: ${file}"
-					if (buildList.contains(file))
+					if (buildList.contains(file)) {
 						writer.write("* $file is deleted and intersects with the current build list.\n")
+						String msg = "* $file is deleted on branch $gitBranch and intersects with the current build list."
+						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
+							props.error = "true"
+							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
+						} else {
+							buildUtils.updateBuildResult(warningMsg:msg,client:repositoryClient)
+						}
+					}
 					else
 						writer.write("  $file\n")
 				}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -209,9 +209,13 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
 	List<Pattern> gitRefMatcherPatterns = createMatcherPatterns(props.reportConcurrentChangesGitBranchReferencePatterns)
 
 	// obtain all current remote branches
-	// TODO: Handle branches from other repositories
-	Set<String> remoteBranches = gitUtils.getRemoteGitBranches(props.applicationSrcDirs)
-
+	// TODO: Handle / Exclude branches from other repositories
+	Set<String> remoteBranches = new HashSet<String>()
+	props.applicationSrcDirs.split(",").each { dir ->
+		dir = buildUtils.getAbsolutePath(dir)
+		remoteBranches.addAll(gitUtils.getRemoteGitBranches(dir))
+	}
+	
 	// Run analysis for each remoteBranch, which matches the configured criteria
 	remoteBranches.each { gitReference ->
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -606,7 +606,7 @@ def generateConcurrentChangesReports(Set<String> concurrentChangedFiles, Set<Str
 
 	File concurrentChangesReportFile = new File(concurrentChangesReportLoc)
 	String enc = props.logEncoding ?: 'IBM-1047'
-	concurrentChangesReportFile.withWriter(enc) { writer ->
+	concurrentChangesReportFile.withWriterAppend(enc) { writer ->
 
 		writer.write("\n** Report for configuration: $gitReference \n")
 		writer.write("=============================================== \n")

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -22,11 +22,6 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()
 	Set<String> changedBuildProperties = new HashSet<String>()
-	Set<String> upstreamChangedFiles = new HashSet<String>()
-	Set<String> upstreamRenamedFiles = new HashSet<String>()
-	Set<String> upstreamDeletedFiles = new HashSet<String>()
-	
-	
 	
 	// get the last build result to get the baseline hashes
 	def lastBuildResult = buildUtils.retrieveLastBuildResult(repositoryClient)
@@ -148,13 +143,24 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 
 	// Document and validate upstream changes
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() && props.topicBranchBuild){
-		if (props.verbose) println "*** Document upstream changes."
+		if (props.verbose) println "*** Calculate and document upstream changes."
+		//a loop
+		Set<String> upstreamChangedFiles = new HashSet<String>()
+		Set<String> upstreamRenamedFiles = new HashSet<String>()
+		Set<String> upstreamDeletedFiles = new HashSet<String>()
+		
+		if (props.verbose) println "***  Analysing and validating changes for BRANCH ${props.reportUpstreamChangesUpstreamBranch} ."
+		
+		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(props.reportUpstreamChangesUpstreamBranch)
+		
 		// generate reports
 		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
 		// verify that build set does not intersect with upstream changes
 		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles, repositoryClient)
 		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles, repositoryClient)
 		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamDeletedFiles, repositoryClient)
+		
+		//loop end
 	}
 
 	return [buildSet, deletedFiles]

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -147,7 +147,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 	}
 
 	// Document and validate upstream changes
-	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean()){
+	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() && props.topicBranchBuild){
 		if (props.verbose) println "*** Document upstream changes."
 		// generate reports
 		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
@@ -195,7 +195,7 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 	}
 	
 	// Document and validate upstream changes
-	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean()){
+	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() && props.topicBranchBuild){
 		if (props.verbose) println "*** Document upstream changes."
 		// generate reports
 		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
@@ -617,8 +617,8 @@ def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> ups
 		Set<String> intersection = new HashSet<String>(buildList)
 		intersection.retainAll(upstreamChanges) // intersection contains all elements on both sets
 		intersection.each { it ->
-			println "*!! $it is changed on the mainBuildBranch and the current branch."
-			props.error = "true"
+			println "*!! $it is changed on the mainBuildBranch (${props.mainBuildBranch}) and intersects with the current build list."
+			if (props.reportUpstreamChangesIntersectionFailsBuild && props.reportUpstreamChangesIntersectionFailsBuild.toBoolean()) props.error = "true"
 		}
 	}
 }

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -322,8 +322,8 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 			}
 			
 			// calculate upstream changed files
-			if (props.reportUpstreamChanges) {
-				if (props.verbose) println "** Triple-dot diffing configuration baseline current HEAD -> remotes/origin/$baseline to capture upstream changes"
+			if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean()) {
+				if (props.verbose) println "** Triple-dot diffing configuration baseline current HEAD -> remotes/origin/${props.mainBuildBranch} to capture upstream changes"
 				(upstreamChanged, upstreamDeleted, upstreamRenamed) = gitUtils.getUpstreamChanges(dir, props.mainBuildBranch)
 			}
 			

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -589,7 +589,7 @@ def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String>
 				if (props.verbose) println "Changed: ${file}"
 				writer.write("$file\n")
 			}
-		} else { println "** No upstream changed files found." }
+		} else { if (props.verbose) println "** No upstream changed files found." }
 
 		if (upstreamRenamedFiles.size() != 0) {
 			writer.write("** Upstream Renamed Files \n")
@@ -597,7 +597,7 @@ def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String>
 				if (props.verbose) println "Renamed: ${file}"
 				writer.write("$file\n")
 			}
-		} else { println "** No upstream renamed files found." }
+		} else { if (props.verbose) println "** No upstream renamed files found." }
 
 		if (upstreamDeletedFiles.size() != 0) {
 			writer.write("** Upstream Deleted Files \n")
@@ -605,7 +605,7 @@ def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String>
 				if (props.verbose) println "Deleted: ${file}"
 				writer.write("$file\n")
 			}
-		} else { println "** No upstream deleted files found." }
+		} else { if (props.verbose) println "** No upstream deleted files found." }
 	}
 }
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -615,7 +615,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 		if (concurrentChangedFiles.size() != 0) {
 			concurrentChangedFiles.each { file ->
 				if (props.verbose) println " Changed: ${file}"
-				if (buildList.contains($file))
+				if (buildList.contains(file))
 					writer.write("* $file is changed on branch ($gitReference) and intersects with the current build list.")
 				else 
 					writer.write("  $file\n")
@@ -626,7 +626,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 			writer.write("** Renamed Files \n")
 			concurrentRenamedFiles.each { file ->
 				if (props.verbose) println " Renamed: ${file}"
-				if (buildList.contains($file))
+				if (buildList.contains(file))
 					writer.write("* $file got renamed on branch ($gitReference) and intersects with the current build list.")
 				else 
 					writer.write("  $file\n")
@@ -637,7 +637,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 			writer.write("** Deleted Files \n")
 			concurrentDeletedFiles.each { file ->
 				if (props.verbose) println " Deleted: ${file}"
-				if (buildList.contains($file))
+				if (buildList.contains(file))
 					writer.write("* $file is deleted on branch ($gitReference) and intersects with the current build list.")
 				else 
 					writer.write("  $file\n")

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -607,16 +607,17 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 	File concurrentChangesReportFile = new File(concurrentChangesReportLoc)
 	String enc = props.logEncoding ?: 'IBM-1047'
 	concurrentChangesReportFile.withWriterAppend(enc) { writer ->
-
-		writer.write("\n** Report for configuration: $gitReference \n")
-		writer.write("=============================================== \n")
 		
-		writer.write("** Changed Files \n")
+		writer.write("\n=============================================== \n")
+		writer.write("** Report for configuration: $gitReference \n")
+		writer.write("========\n")
+		
 		if (concurrentChangedFiles.size() != 0) {
+			writer.write("** Changed Files \n")
 			concurrentChangedFiles.each { file ->
 				if (props.verbose) println " Changed: ${file}"
 				if (buildList.contains(file))
-					writer.write("* $file is changed on branch ($gitReference) and intersects with the current build list.")
+					writer.write("* $file is changed on branch ($gitReference) and intersects with the current build list.\n")
 				else 
 					writer.write("  $file\n")
 			}
@@ -627,7 +628,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 			concurrentRenamedFiles.each { file ->
 				if (props.verbose) println " Renamed: ${file}"
 				if (buildList.contains(file))
-					writer.write("* $file got renamed on branch ($gitReference) and intersects with the current build list.")
+					writer.write("* $file got renamed on branch ($gitReference) and intersects with the current build list.\n")
 				else 
 					writer.write("  $file\n")
 			}
@@ -638,7 +639,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 			concurrentDeletedFiles.each { file ->
 				if (props.verbose) println " Deleted: ${file}"
 				if (buildList.contains(file))
-					writer.write("* $file is deleted on branch ($gitReference) and intersects with the current build list.")
+					writer.write("* $file is deleted on branch ($gitReference) and intersects with the current build list.\n")
 				else 
 					writer.write("  $file\n")
 			}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -198,7 +198,9 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 	// Validate potential mismatches
 	// && reportMismatches
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() ){
-		changedFiles.retainAll(upstreamChangedFiles).each { it ->
+		Set<String> intersection = new HashSet<String>(changedFiles)
+		intersection.retainAll(upstreamChangedFiles) // intersection contains all elements on both sets
+		intersection.each { it ->
 			println "*!! $it is changed on the mainBuildBranch and the current branch."
 			props.error = "true"
 		}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -145,20 +145,23 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() && props.topicBranchBuild){
 		if (props.verbose) println "*** Calculate and document upstream changes."
 		//a loop
+		
+		String upstreamReference = props.reportUpstreamChangesUpstreamBranch
+		
 		Set<String> upstreamChangedFiles = new HashSet<String>()
 		Set<String> upstreamRenamedFiles = new HashSet<String>()
 		Set<String> upstreamDeletedFiles = new HashSet<String>()
 		
 		if (props.verbose) println "***  Analysing and validating changes for BRANCH ${props.reportUpstreamChangesUpstreamBranch} ."
 		
-		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(props.reportUpstreamChangesUpstreamBranch)
+		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(upstreamReference)
 		
 		// generate reports
 		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
 		// verify that build set does not intersect with upstream changes
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles, repositoryClient)
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles, repositoryClient)
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamDeletedFiles, repositoryClient)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles, repositoryClient, upstreamReference)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles, repositoryClient, upstreamReference)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamDeletedFiles, repositoryClient, upstreamReference)
 		
 		//loop end
 	}
@@ -201,20 +204,23 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() && props.topicBranchBuild){
 		if (props.verbose) println "*** Calculate and document upstream changes."
 		//a loop
+		
+		String upstreamReference = props.reportUpstreamChangesUpstreamBranch
+		
 		Set<String> upstreamChangedFiles = new HashSet<String>()
 		Set<String> upstreamRenamedFiles = new HashSet<String>()
 		Set<String> upstreamDeletedFiles = new HashSet<String>()
 		
 		if (props.verbose) println "***  Analysing and validating changes for BRANCH ${props.reportUpstreamChangesUpstreamBranch} ."
 		
-		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(props.reportUpstreamChangesUpstreamBranch)
+		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(upstreamReference)
 		
 		// generate reports
 		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
 		// verify that build set does not intersect with upstream changes
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles, repositoryClient)
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles, repositoryClient)
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamDeletedFiles, repositoryClient)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles, repositoryClient, upstreamReference)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles, repositoryClient, upstreamReference)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamDeletedFiles, repositoryClient, upstreamReference)
 		
 		//loop end
 	}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -152,9 +152,9 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 		// generate reports
 		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
 		// verify that build set does not intersect with upstream changes
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles)
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles)
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamDeletedFiles)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles, repositoryClient)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles, repositoryClient)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamDeletedFiles, repositoryClient)
 	}
 
 	return [buildSet, deletedFiles]
@@ -200,9 +200,9 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 		// generate reports
 		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
 		// verify that build set does not intersect with upstream changes
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles)
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles)
-		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamDeletedFiles)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamChangedFiles, repositoryClient)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamRenamedFiles, repositoryClient)
+		verifyBuildListAgainstUpstreamChanges(buildSet, upstreamDeletedFiles, repositoryClient)
 	}
 	
 	return [ buildSet, deletedFiles	]
@@ -611,7 +611,7 @@ def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String>
 /**
  * Method to verify if the list of upstream changes intersects with the build list
  */
-def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> upstreamChanges) {
+def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> upstreamChanges, RepositoryClient repositoryClient) {
 	// Validate potential mismatches and report mismatches
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() ){
 		Set<String> intersection = new HashSet<String>(buildList)
@@ -623,8 +623,8 @@ def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> ups
 				String errorMsg = "*!! (ReportUpstreamChanges) The build list intersects with identified upstream changes."
 				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
-				buildUtils.updateBuildResult(errorMsg:msg,client:getRepositoryClient())
+				buildUtils.updateBuildResult(errorMsg:errorMsg,client:repositoryClient)
+				buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
 			}
 		}
 	}
@@ -1033,14 +1033,4 @@ def sortFileList(list) {
 			}
 		}
 	}
-}
-
-/**
- * getRepositoryClient
- */
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
-
-	return repositoryClient
 }

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -144,7 +144,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 	// Document and validate concurrent changes
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean()){
 		if (props.verbose) println "*** Calculate and document concurrent changes."
-		calculateConcurrentChanges()
+		calculateConcurrentChanges(repositoryClient, buildSet)
 	}
 
 	return [buildSet, deletedFiles]
@@ -184,7 +184,7 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 	// Document and validate concurrent changes
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean()){
 		if (props.verbose) println "*** Calculate and document concurrent changes."
-		calculateConcurrentChanges()
+		calculateConcurrentChanges(repositoryClient, buildSet)
 	}
 
 	return [buildSet, deletedFiles]
@@ -203,7 +203,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 	return calculateChangedFiles(lastBuildResult, false, null)
 }
 
-def calculateConcurrentChanges() {
+def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> buildSet) {
 	
 	//a loop
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -210,7 +210,7 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
 
 	// obtain all current remote branches
 	// TODO: Handle branches from other repositories
-	Set<String> remoteBranches = getRemoteGitBranches(props.applicationSrcDirs)
+	Set<String> remoteBranches = gitUtils.getRemoteGitBranches(props.applicationSrcDirs)
 
 	// Run analysis for each remoteBranch, which matches the configured criteria
 	remoteBranches.each { gitReference ->

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -232,16 +232,12 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
 
 			// generate reports
 			generateConcurrentChangesReports(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference)
+
 			// verify that build set does not intersect with any conrurrent changes
 			verifyBuildListAgainstConcurrentChanges(buildSet, concurrentChangedFiles, repositoryClient, gitReference)
 			verifyBuildListAgainstConcurrentChanges(buildSet, concurrentRenamedFiles, repositoryClient, gitReference)
 			verifyBuildListAgainstConcurrentChanges(buildSet, concurrentDeletedFiles, repositoryClient, gitReference)
-
 		}
-		else {
-			println "gitReference ... $gitReference excluded"
-		}
-
 	}
 
 }

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -215,7 +215,7 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
 	// Run analysis for each remoteBranch, which matches the configured criteria
 	remoteBranches.each { gitReference ->
 
-		if (matchesPattern(gitReference,gitRefMatcherPatterns){
+		if (matchesPattern(gitReference,gitRefMatcherPatterns)){
 
 			Set<String> concurrentChangedFiles = new HashSet<String>()
 			Set<String> concurrentRenamedFiles = new HashSet<String>()
@@ -233,7 +233,9 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
 			verifyBuildListAgainstConcurrentChanges(buildSet, concurrentRenamedFiles, repositoryClient, gitReference)
 			verifyBuildListAgainstConcurrentChanges(buildSet, concurrentDeletedFiles, repositoryClient, gitReference)
 
-			//loop end
+		}
+		else {
+			println "gitReference ... $gitReference excluded"
 		}
 
 	}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -229,8 +229,9 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 
 def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateUpstreamChanges, String upstreamReference) {
 	String msg
-    if (reportUpstreamChanges) {
+    if (calculateUpstreamChanges) {
 		msg = "upstream changes in config" 
+		println "###" + msg
 	}
 	
 	// local variables

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -603,7 +603,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 	String enc = props.logEncoding ?: 'IBM-1047'
 	concurrentChangesReportFile.withWriterAppend(enc) { writer ->
 
-		if (concurrentChangedFiles.size() != 0 ||  concurrentRenamedFiles.size() != 0 || concurrentDeletedFiles.size() != 0) {
+		if (!(concurrentChangedFiles.size() == 0 &&  concurrentRenamedFiles.size() == 0 && concurrentDeletedFiles.size() == 0)) {
 
 			if (props.verbose) println("** Writing report of concurrent changes to $concurrentChangesReportLoc for configuration $gitReference")
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -620,11 +620,10 @@ def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> ups
 			String msg = "*!! $it is changed on the mainBuildBranch (${props.mainBuildBranch}) and intersects with the current build list."
 			println(msg)
 			if (props.reportUpstreamChangesIntersectionFailsBuild && props.reportUpstreamChangesIntersectionFailsBuild.toBoolean()) {
-				String errorMsg = "*!! (ReportUpstreamChanges) The build list intersects with identified upstream changes."
-				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,client:repositoryClient)
 				buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
+			} else {
+				buildUtils.updateBuildResult(warningMsg:msg,client:repositoryClient)
 			}
 		}
 	}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -245,7 +245,7 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
 	// Run analysis for each remoteBranch, which matches the configured criteria
 	remoteBranches.each { gitReference ->
 
-		if (matchesPattern(gitReference,gitRefMatcherPatterns)){
+		if (matchesPattern(gitReference,gitRefMatcherPatterns) && !gitReference.equals(props.applicationCurrentBranch)){
 
 			Set<String> concurrentChangedFiles = new HashSet<String>()
 			Set<String> concurrentRenamedFiles = new HashSet<String>()

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -240,10 +240,9 @@ def calculateUpstreamChanges(String upstreamReference) {
 }
 
 def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateUpstreamChanges, String upstreamReference) {
-	String msg
+	String msg = ""
     if (calculateUpstreamChanges.toBoolean()) {
-		msg = "upstream changes in config" 
-		println "###" + msg
+		msg = "in configuration $upstreamReference" 
 	}
 	
 	// local variables
@@ -365,7 +364,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateUpstream
 		// make sure file is not an excluded file
 		List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
 
-		if (props.verbose) println "*** Changed files for directory $dir:"
+		if (props.verbose) println "*** Changed files for directory $dir $msg:"
 		changed.each { file ->
 			(file, mode) = fixGitDiffPath(file, dir, true, null)
 			if ( file != null ) {
@@ -383,7 +382,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateUpstream
 			}
 		}
 
-		if (props.verbose) println "*** Deleted files for directory $dir:"
+		if (props.verbose) println "*** Deleted files for directory $dir $msg:"
 		deleted.each { file ->
 			if ( !matches(file, excludeMatchers)) {
 				(file, mode) = fixGitDiffPath(file, dir, false, mode)
@@ -392,7 +391,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateUpstream
 			}
 		}
 
-		if (props.verbose) println "*** Renamed files for directory $dir:"
+		if (props.verbose) println "*** Renamed files for directory $dir $msg:"
 		renamed.each { file ->
 			if ( !matches(file, excludeMatchers)) {
 				(file, mode) = fixGitDiffPath(file, dir, false, mode)
@@ -558,9 +557,9 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
  * Method to generate the Upstream Changes reports 
  */
 
-def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String> upstreamRenamedFiles, Set<String> upstreamDeletedFiles){
-	String upstreamChangesReportLoc = "${props.buildOutDir}/upstreamChanges_${props.reportUpstreamChangesUpstreamBranch}.${props.buildListFileExt}"
-	println("** Writing report of upstream changes to $upstreamChangesReportLoc")
+def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String> upstreamRenamedFiles, Set<String> upstreamDeletedFiles, String upstreamReference){
+	String upstreamChangesReportLoc = "${props.buildOutDir}/upstreamChanges_$upstreamReference.${props.buildListFileExt}"
+	println("** Writing report of upstream changes to $upstreamChangesReportLoc for configuration $upstreamReference")
 
 	File upstreamChangesReportFile = new File(upstreamChangesReportLoc)
 	String enc = props.logEncoding ?: 'IBM-1047'

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -566,7 +566,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
  */
 
 def generateConcurrentChangesReports(Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference){
-	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges_$gitReference.txt"
+	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges_${gitReference}.txt"
 	println("** Writing report of concurrent changes to $concurrentChangesReportLoc for configuration $gitReference")
 
 	File concurrentChangesReportFile = new File(concurrentChangesReportLoc)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -324,7 +324,7 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 			// calculate upstream changed files
 			if (props.reportUpstreamChanges) {
 				if (props.verbose) println "** Triple-dot diffing configuration baseline current HEAD -> remotes/origin/$baseline to capture upstream changes"
-				(upstreamChanged, upstreamDeleted, upstreamRenamed) = gitUtils.getUpstreamChanges(dir, baseline)
+				(upstreamChanged, upstreamDeleted, upstreamRenamed) = gitUtils.getUpstreamChanges(dir, props.mainBuildBranch)
 			}
 			
 		}	

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -195,6 +195,15 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
 	}
 	
+	// Validate potential mismatches
+	// && reportMismatches
+	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() ){
+		upstreamChangedFiles.intersects(changedFiles).each { it ->
+			println "*!! $it is changed on the mainBuildBranch and the current branch."
+			props.error = "true"
+		}
+	}
+	
 	return [ buildSet, deletedFiles	]
 }
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -257,7 +257,7 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
 			(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, concurrentBuildProperties) = calculateChangedFiles(null, true, gitReference)
 
 			// generate reports
-			generateConcurrentChangesReports(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference)
+			generateConcurrentChangesReports(buildSet, concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference)
 
 			// verify that build set does not intersect with any conrurrent changes
 			verifyBuildListAgainstConcurrentChanges(buildSet, concurrentChangedFiles, repositoryClient, gitReference)
@@ -600,7 +600,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
  * Method to generate the Concurrent Changes reports 
  */
 
-def generateConcurrentChangesReports(Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference){
+def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference){
 	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges.txt"
 	if (props.verbose) println("** Writing report of concurrent changes to $concurrentChangesReportLoc for configuration $gitReference")
 
@@ -615,7 +615,10 @@ def generateConcurrentChangesReports(Set<String> concurrentChangedFiles, Set<Str
 		if (concurrentChangedFiles.size() != 0) {
 			concurrentChangedFiles.each { file ->
 				if (props.verbose) println " Changed: ${file}"
-				writer.write("$file\n")
+				if (buildList.contains($file))
+					writer.write()"* $file is changed on branch ($gitReference) and intersects with the current build list.")
+				else 
+					writer.write("  $file\n")
 			}
 		}
 
@@ -623,7 +626,10 @@ def generateConcurrentChangesReports(Set<String> concurrentChangedFiles, Set<Str
 			writer.write("** Renamed Files \n")
 			concurrentRenamedFiles.each { file ->
 				if (props.verbose) println " Renamed: ${file}"
-				writer.write("$file\n")
+				if (buildList.contains($file))
+					writer.write()"* $file got renamed on branch ($gitReference) and intersects with the current build list.")
+				else 
+					writer.write("  $file\n")
 			}
 		}
 
@@ -631,7 +637,10 @@ def generateConcurrentChangesReports(Set<String> concurrentChangedFiles, Set<Str
 			writer.write("** Deleted Files \n")
 			concurrentDeletedFiles.each { file ->
 				if (props.verbose) println " Deleted: ${file}"
-				writer.write("$file\n")
+				if (buildList.contains($file))
+					writer.write()"* $file is deleted on branch ($gitReference) and intersects with the current build list.")
+				else 
+					writer.write("  $file\n")
 			}
 		}
 	}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -199,7 +199,7 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 		Set<String> upstreamRenamedFiles = new HashSet<String>()
 		Set<String> upstreamDeletedFiles = new HashSet<String>()
 		
-		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateChangedFiles(null, props.reportUpstreamChangesUpstreamBranch)
+		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(props.reportUpstreamChangesUpstreamBranch)
 		
 		// generate reports
 		generateUpstreamChangesReports(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles)
@@ -225,6 +225,10 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 
 def calculateChangedFiles(BuildResult lastBuildResult) {
 	return calculateChangedFiles(lastBuildResult, false, null)
+}
+
+def calculateUpstreamChanges(String upstreamReference) {
+	return calculateChangedFiles(null, true, upstreamReference)
 }
 
 def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateUpstreamChanges, String upstreamReference) {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -616,7 +616,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 			concurrentChangedFiles.each { file ->
 				if (props.verbose) println " Changed: ${file}"
 				if (buildList.contains($file))
-					writer.write()"* $file is changed on branch ($gitReference) and intersects with the current build list.")
+					writer.write("* $file is changed on branch ($gitReference) and intersects with the current build list.")
 				else 
 					writer.write("  $file\n")
 			}
@@ -627,7 +627,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 			concurrentRenamedFiles.each { file ->
 				if (props.verbose) println " Renamed: ${file}"
 				if (buildList.contains($file))
-					writer.write()"* $file got renamed on branch ($gitReference) and intersects with the current build list.")
+					writer.write("* $file got renamed on branch ($gitReference) and intersects with the current build list.")
 				else 
 					writer.write("  $file\n")
 			}
@@ -638,7 +638,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 			concurrentDeletedFiles.each { file ->
 				if (props.verbose) println " Deleted: ${file}"
 				if (buildList.contains($file))
-					writer.write()"* $file is deleted on branch ($gitReference) and intersects with the current build list.")
+					writer.write("* $file is deleted on branch ($gitReference) and intersects with the current build list.")
 				else 
 					writer.write("  $file\n")
 			}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -380,8 +380,8 @@ def calculateChangedFiles(BuildResult lastBuildResult) {
 		// calculate upstream changed files
 		if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() && gitUtils.isGitDir(dir)) {
 			if (props.verbose) println "** Calculating upstream changes for directory $dir"
-			if (props.verbose) println "** Triple-dot diffing configuration baseline current HEAD -> remotes/origin/${props.mainBuildBranch} to capture upstream changes"
-			(upstreamChanged, upstreamDeleted, upstreamRenamed) = gitUtils.getUpstreamChanges(dir, props.mainBuildBranch)
+			if (props.verbose) println "** Triple-dot diffing configuration baseline current HEAD -> remotes/origin/${props.reportUpstreamChangesUpstreamBranch} to capture upstream changes"
+			(upstreamChanged, upstreamDeleted, upstreamRenamed) = gitUtils.getUpstreamChanges(dir, props.reportUpstreamChangesUpstreamBranch)
 
 
 			if (props.verbose) println "*** Changed upstream files for directory $dir:"
@@ -575,7 +575,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
  */
 
 def generateUpstreamChangesReports(Set<String> upstreamChangedFiles, Set<String> upstreamRenamedFiles, Set<String> upstreamDeletedFiles){
-	String upstreamChangesReportLoc = "${props.buildOutDir}/upstreamChanges.${props.buildListFileExt}"
+	String upstreamChangesReportLoc = "${props.buildOutDir}/upstreamChanges_${props.reportUpstreamChangesUpstreamBranch}.${props.buildListFileExt}"
 	println("** Writing report of upstream changes to $upstreamChangesReportLoc")
 
 	File upstreamChangesReportFile = new File(upstreamChangesReportLoc)
@@ -617,7 +617,7 @@ def verifyBuildListAgainstUpstreamChanges(Set<String> buildList, Set<String> ups
 		Set<String> intersection = new HashSet<String>(buildList)
 		intersection.retainAll(upstreamChanges) // intersection contains all elements on both sets
 		intersection.each { it ->
-			String msg = "*!! $it is changed on the mainBuildBranch (${props.mainBuildBranch}) and intersects with the current build list."
+			String msg = "*!! $it is changed on the upstream branch (${props.reportUpstreamChangesUpstreamBranch}) and intersects with the current build list."
 			println(msg)
 			if (props.reportUpstreamChangesIntersectionFailsBuild && props.reportUpstreamChangesIntersectionFailsBuild.toBoolean()) {
 				props.error = "true"

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -193,11 +193,13 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 	
 	// Document and validate upstream changes
 	if (props.reportUpstreamChanges && props.reportUpstreamChanges.toBoolean() && props.topicBranchBuild){
-		if (props.verbose) println "*** Caluclate and document upstream changes."
+		if (props.verbose) println "*** Calculate and document upstream changes."
 		//a loop
 		Set<String> upstreamChangedFiles = new HashSet<String>()
 		Set<String> upstreamRenamedFiles = new HashSet<String>()
 		Set<String> upstreamDeletedFiles = new HashSet<String>()
+		
+		if (props.verbose) println "***  Analysing and validating changes for ${props.reportUpstreamChangesUpstreamBranch} ."
 		
 		(upstreamChangedFiles, upstreamRenamedFiles, upstreamDeletedFiles, changedBuildProperties) = calculateUpstreamChanges(props.reportUpstreamChangesUpstreamBranch)
 		
@@ -233,7 +235,7 @@ def calculateUpstreamChanges(String upstreamReference) {
 
 def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateUpstreamChanges, String upstreamReference) {
 	String msg
-    if (calculateUpstreamChanges) {
+    if (calculateUpstreamChanges.toBoolean()) {
 		msg = "upstream changes in config" 
 		println "###" + msg
 	}


### PR DESCRIPTION
zAppBuild provides a set of reporting capabilities, which are part of the build framework itself to address some common demands of mainframe development teams.

 Developers are particularly interested if:
 * A change of an element impacts other application components which are managed in a different repository, which was contributed via #128 
 * Their changes on an isolated feature branch potentially cause a conflict with some concurrent development done by others within the same repository, which is the new contribution with this PR.

This contribution contains:
* the implementation of the second capability to document and verify conflicts due to concurrent development. 
* a detailed documentation for both reporting features.