### PR TITLE
Managing Alternate Libraries for Dependencies

### DIFF
--- a/build-conf/Assembler.properties
+++ b/build-conf/Assembler.properties
@@ -47,3 +47,6 @@ dbb.DependencyScanner.languageHint=ASM :: **/*.asm, **/*.mac
 #
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # assembler_linkEditSyslibConcatenation=
+
+# dbb property mapping to map dependencies to different target datasets
+assembler_dependeciesDatasetMapping = assembler_macroPDS :: **/*

--- a/build-conf/Assembler.properties
+++ b/build-conf/Assembler.properties
@@ -48,5 +48,14 @@ dbb.DependencyScanner.languageHint=ASM :: **/*.asm, **/*.mac
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # assembler_linkEditSyslibConcatenation=
 
-# dbb property mapping to map dependencies to different target datasets
-assembler_dependeciesDatasetMapping = assembler_macroPDS :: **/*
+# assembler_dependenciesDatasetMapping - an optional dbb property mapping to map dependencies to different target datasets
+#  this property is used when dependencies are copied to the different build libraries, e.q dclgens going into to a dedicated library
+#  note, that a dependency file needs to match a single rule, target dataset definitions need to exist
+#
+#  sample:
+#   assembler_dependenciesDatasetMapping = assembler_macroPDS :: **/macro/*.mac
+#   assembler_dependenciesDatasetMapping = assembler_cpyPDS :: **/copy/*.asmcpy
+#
+#  default copies all dependencies into the dependency dataset definition which was previously passed to the utilities/BuildUitilities.copySourceFiles method
+#   assembler_dependenciesDatasetMapping = assembler_macroPDS :: **/* 
+assembler_dependenciesDatasetMapping = assembler_macroPDS :: **/*

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -18,7 +18,6 @@ cobol_linkEditor=IEWBLINK
 # COBOL source data sets
 cobol_srcPDS=${hlq}.COBOL
 cobol_cpyPDS=${hlq}.COPY
-cobol_myfilePDS=${hlq}.MYCOPY
 cobol_objPDS=${hlq}.OBJ
 cobol_dbrmPDS=${hlq}.DBRM
 cobol_BMS_PDS=${team}.BMS.COPY

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -83,6 +83,7 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 #  this property is used to 
 #   * copy files the to mapped dataset definition (PLEASE NOTE! This setting takes precendence over cobol_dependenciesDatasetMapping)
 #   * defining additional allocations in the compile step
+#
 #  note that the SYSLIB is defaulted to the dataset definition 'cobol_cpyPDS' and is not required to be set here
 #  sample: cobol_dependenciesAlternativeLibraryNameMapping = [MYFILE: 'cobol_myfilePDS', DCLGEN : 'cobol_dclgenPDS']
 cobol_dependenciesAlternativeLibraryNameMapping=

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -79,7 +79,8 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # cobol_linkEditSyslibConcatenation=
 
-
+# 
+cobol_dependeciesDatasetMapping = cobol_cpyPDS :: **/*
 
 
 

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -79,7 +79,7 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # cobol_linkEditSyslibConcatenation=
 
-# 
+# dbb property mapping to map dependencies to different target datasets
 cobol_dependeciesDatasetMapping = cobol_cpyPDS :: **/*
 
 

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -18,6 +18,7 @@ cobol_linkEditor=IEWBLINK
 # COBOL source data sets
 cobol_srcPDS=${hlq}.COBOL
 cobol_cpyPDS=${hlq}.COPY
+cobol_myfilePDS=${hlq}.MYCOPY
 cobol_objPDS=${hlq}.OBJ
 cobol_dbrmPDS=${hlq}.DBRM
 cobol_BMS_PDS=${team}.BMS.COPY
@@ -36,7 +37,7 @@ cobol_testcase_loadPDS=${hlq}.TEST.LOAD
 
 #
 # List the data sets that need to be created and their creation options
-cobol_srcDatasets=${cobol_srcPDS},${cobol_cpyPDS},${cobol_objPDS},${cobol_dbrmPDS}
+cobol_srcDatasets=${cobol_srcPDS},${cobol_cpyPDS},${cobol_objPDS},${cobol_dbrmPDS},${cobol_myfilePDS}
 cobol_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
 
 cobol_loadDatasets=${cobol_loadPDS}
@@ -70,10 +71,6 @@ dbb.DependencyScanner.languageHint=COB :: **/*.cbl, **/*.cpy
 # The following filter excludes CICS and LE Library references.
 dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
-# an optional map to define alternate libraries to the target dataset
-# these information are included in the allocations for the Compile step 
-cobol_alternativeLibraryNamesMapping = [MYLIB: 'cobol_cpyPDS']
-
 #
 # additional libraries for compile SYSLIB concatenation, comma-separated, see definitions in application-conf
 # cobol_compileSyslibConcatenation=
@@ -82,7 +79,22 @@ cobol_alternativeLibraryNamesMapping = [MYLIB: 'cobol_cpyPDS']
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # cobol_linkEditSyslibConcatenation=
 
-# dbb property mapping to map dependencies to different target datasets
-cobol_dependeciesDatasetMapping = cobol_cpyPDS :: **/*
+# cobol_dependenciesAlternativeLibraryNameMapping - an *optional* map to define target dataset definition for alternate include libraries
+#  this property is used to 
+#   * copy files the to mapped dataset definition (PLEASE NOTE! This setting takes precendence over cobol_dependenciesDatasetMapping)
+#   * defining additional allocations in the compile step
+#  note that the SYSLIB is defaulted to the dataset definition 'cobol_cpyPDS' and is not required to be set here
+#  sample: cobol_dependenciesAlternativeLibraryNameMapping = [MYFILE: 'cobol_myfilePDS', DCLGEN : 'cobol_dclgenPDS']
+cobol_dependenciesAlternativeLibraryNameMapping=
 
-
+# cobol_dependenciesDatasetMapping - an optional dbb property mapping to map dependencies to different target datasets
+#  this property is used when dependencies are copied to the different build libraries, e.q dclgens going into to a dedicated library
+#  note, that a dependency file needs to match a single rule
+#
+#  sample:
+#   cobol_dependenciesDatasetMapping = cobol_cpyPDS :: **/copybook/*.cpy
+#   cobol_dependenciesDatasetMapping = cobol_dclgenPDS :: **/dclgens/*.cpy
+#
+#  default copies all dependencies into the dependency dataset definition which was previously passed to the utilities/BuildUitilities.copySourceFiles method
+#   cobol_dependenciesDatasetMapping = cobol_cpyPDS :: **/* 
+cobol_dependenciesDatasetMapping = cobol_cpyPDS :: **/*

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -70,6 +70,9 @@ dbb.DependencyScanner.languageHint=COB :: **/*.cbl, **/*.cpy
 # The following filter excludes CICS and LE Library references.
 dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
+# an optional map to define alternate libraries to the target dataset
+# these information are included in the allocations for the Compile step 
+cobol_alternativeLibraryNamesMapping = [MYLIB: 'cobol_cpyPDS']
 
 #
 # additional libraries for compile SYSLIB concatenation, comma-separated, see definitions in application-conf
@@ -81,6 +84,5 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
 # dbb property mapping to map dependencies to different target datasets
 cobol_dependeciesDatasetMapping = cobol_cpyPDS :: **/*
-
 
 

--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -52,6 +52,23 @@ dbb.DependencyScanner.languageHint=PLI :: **/*.pli, **/*.inc, **/*.cpy
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # pli_linkEditSyslibConcatenation=
 
-# dbb property mapping to map dependencies to different target datasets
-pli_dependeciesDatasetMapping = pli_incPDS :: **/*
+# pli_dependenciesAlternativeLibraryNameMapping - an *optional* map to define target dataset definition for alternate include libraries
+#  this property is used to 
+#   * copy files the to mapped dataset definition (this setting takes precendence over pli_dependenciesDatasetMapping)
+#   * defining additional allocations in the compile step
+#  note that the SYSLIB is defaulted to the dataset definition 'pli_cpyPDS' and is not required to be set here
+#  sample: pli_dependenciesAlternativeLibraryNameMapping = [MYFILE: 'pli_myfilePDS', DCLGEN : 'pli_dclgenPDS']
+pli_dependenciesAlternativeLibraryNameMapping=
+
+# pli_dependenciesDatasetMapping - an optional dbb property mapping to map dependencies to different target datasets
+#  this property is used when dependencies are copied to the different build libraries, e.q dclgens going into to a dedicated library
+#  note, that a dependency file needs to match a single rule
+#
+#  sample:
+#   pli_dependenciesDatasetMapping = pli_incPDS :: **/includes/*.cpy
+#   pli_dependenciesDatasetMapping = pli_dclgenPDS :: **/dclgens/*.cpy
+#
+#  default copies all dependencies into the dependency dataset definition which was previously passed to the utilities/BuildUitilities.copySourceFiles method
+#   pli_dependenciesDatasetMapping = pli_incPDS :: **/* 
+pli_dependenciesDatasetMapping = pli_incPDS :: **/*
 

--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -51,3 +51,7 @@ dbb.DependencyScanner.languageHint=PLI :: **/*.pli, **/*.inc, **/*.cpy
 #
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # pli_linkEditSyslibConcatenation=
+
+# dbb property mapping to map dependencies to different target datasets
+pli_dependeciesDatasetMapping = pli_incPDS :: **/*
+

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -81,6 +81,7 @@ assembler_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD
 assembler_pgm | MVS program name of the high level assembler
 assembler_linkEditor | MVS program name of the link editor
 dbb.DependencyScanner.languageHint | DBB configuration property used by the dependency scanner to disambiguate a source file's language
+assembler_dependenciesDatasetMapping | DBB property mapping to map dependencies to different target datasets
 
 ### BMS.properties
 Build properties used by zAppBuild/language/BMS.groovy
@@ -98,6 +99,7 @@ bms_loadOptions | BPXWDYN creation options for 'load module' type data sets
 bms_tempOptions | BPXWDYN creation options for temporary data sets
 bms_assembler | MVS program name of the high level assembler
 bms_linkEditor | MVS program name of the link editor
+bms_dependenciesDatasetMapping | DBB property mapping to map dependencies to different target datasets
 
 ### Cobol.properties
 Build properties used by zAppBuild/language/Cobol.groovy
@@ -124,6 +126,9 @@ cobol_test_loadOptions | BPXWDYN creation options for creating 'load module' typ
 cobol_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
 cobol_compiler | MVS program name of the COBOL compiler
 cobol_linkEditor | MVS program name of the link editor
+cobol_dependenciesAlternativeLibraryNameMapping | a map to define target dataset definition for alternate include libraries
+cobol_dependenciesDatasetMapping | dbb property mapping to map dependencies to different target datasets
+
 dbb.DependencyScanner.languageHint | DBB configuration property used by the dependency scanner to disambiguate a source file's language
 
 ### LinkEdit.properties
@@ -162,6 +167,8 @@ pli_loadOptions | BPXWDYN creation options for 'load module' type data sets
 pli_tempOptions | BPXWDYN creation options for temporary data sets
 pli_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
 pli_listOptions | BPXWDYN creation options for LIST data sets
+pli_dependenciesAlternativeLibraryNameMapping | a map to define target dataset definition for alternate include libraries
+pli_dependenciesDatasetMapping | dbb property mapping to map dependencies to different target datasets
 dbb.DependencyScanner.languageHint | DBB configuration property used by the dependency scanner to disambiguate a source file's language
 
 ### MFS.properties
@@ -250,6 +257,7 @@ zunit_loadDatasets | Comma separated list of 'load module' type data sets
 zunit_loadOptions | BPXWDYN creation options for creating 'load module' type data sets
 zunit_reportDatasets | Comma separated list of 'report' type data sets
 zunit_reportOptions | BPXWDYN creation options for creating 'report' type data sets
+zunit_dependenciesDatasetMapping | DBB property mapping to map dependencies to different target datasets
 
 ### Transfer.properties
 Build properties used by zAppBuild/language/Transfer.groovy

--- a/build-conf/REXX.properties
+++ b/build-conf/REXX.properties
@@ -54,3 +54,5 @@ dbb.DependencyScanner.languageHint=rexx :: **/*.rexx
 # The following filter excludes CICS and LE Library references.
 dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
+# dbb property mapping to map dependencies to different target datasets
+rexx_dependeciesDatasetMapping = rexx_srcPDS :: **/*

--- a/build-conf/REXX.properties
+++ b/build-conf/REXX.properties
@@ -54,5 +54,14 @@ dbb.DependencyScanner.languageHint=rexx :: **/*.rexx
 # The following filter excludes CICS and LE Library references.
 dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 
-# dbb property mapping to map dependencies to different target datasets
-rexx_dependeciesDatasetMapping = rexx_srcPDS :: **/*
+# rexx_dependenciesDatasetMapping - an optional dbb property mapping to map dependencies to different target datasets
+#  this property is used when dependencies are copied to the different build libraries, e.q dclgens going into to a dedicated library
+#  note, that a dependency file needs to match a single rule
+#
+#  sample:
+#   rexx_dependenciesDatasetMapping = rexx_includePDS :: **/rexxinclude/*.rexx
+#   rexx_dependenciesDatasetMapping = rexx_macroPDS :: **/rexxmacros/*.rexx
+#
+#  default copies all dependencies into the dependency dataset definition which was previously passed to the utilities/BuildUitilities.copySourceFiles method
+#   rexx_dependenciesDatasetMapping = rexx_srcPDS :: **/* 
+rexx_dependenciesDatasetMapping = rexx_srcPDS :: **/*

--- a/build-conf/ZunitConfig.properties
+++ b/build-conf/ZunitConfig.properties
@@ -18,5 +18,14 @@ zunit_loadOptions=cyl space(1,1) dsorg(PO) lrecl(256) recfm(F,B) blksize(32512) 
 zunit_reportDatasets=${zunit_bzureportPDS}
 zunit_reportOptions=tracks space(200,40) dsorg(PO) blksize(32760) lrecl(16383) recfm(v,b) dsntype(library)
 
-# dbb property mapping to map dependencies to different target datasets
+# zunit_dependenciesDatasetMapping - an optional dbb property mapping to map dependencies to different target datasets
+#  this property is used when dependencies are copied to the different build libraries, e.q dclgens going into to a dedicated library
+#  note, that a dependency file needs to match a single rule
+#
+#  sample:
+#   zunit_dependenciesDatasetMapping = zunit_bzuplayPDS :: **/bzuplay/*.bzuplay
+#   zunit_dependenciesDatasetMapping = zunit_bzuplayPDS :: **/bzuplay_vtp/*.bzuplay
+#
+#  default copies all dependencies into the dependency dataset definition which was previously passed to the utilities/BuildUitilities.copySourceFiles method
+#   zunit_dependenciesDatasetMapping = zunit_bzuplayPDS :: **/*
 zunit_dependenciesDatasetMapping = zunit_bzuplayPDS :: **/*

--- a/build-conf/ZunitConfig.properties
+++ b/build-conf/ZunitConfig.properties
@@ -19,4 +19,4 @@ zunit_reportDatasets=${zunit_bzureportPDS}
 zunit_reportOptions=tracks space(200,40) dsorg(PO) blksize(32760) lrecl(16383) recfm(v,b) dsntype(library)
 
 # dbb property mapping to map dependencies to different target datasets
-zunit_dependeciesDatasetMapping = zunit_bzuplayPDS :: **/*
+zunit_dependenciesDatasetMapping = zunit_bzuplayPDS :: **/*

--- a/build-conf/ZunitConfig.properties
+++ b/build-conf/ZunitConfig.properties
@@ -17,3 +17,6 @@ zunit_loadOptions=cyl space(1,1) dsorg(PO) lrecl(256) recfm(F,B) blksize(32512) 
 
 zunit_reportDatasets=${zunit_bzureportPDS}
 zunit_reportOptions=tracks space(200,40) dsorg(PO) blksize(32760) lrecl(16383) recfm(v,b) dsntype(library)
+
+# dbb property mapping to map dependencies to different target datasets
+zunit_dependeciesDatasetMapping = zunit_bzuplayPDS :: **/*

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -33,7 +33,7 @@ sortedList.each { buildFile ->
 	String rules = props.getFileProperty('assembler_resolutionRules', buildFile)
 	String assembler_srcPDS = props.getFileProperty('assembler_srcPDS', buildFile)
 	DependencyResolver dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
-	buildUtils.copySourceFiles(buildFile, assembler_srcPDS, 'assembler_dependeciesDatasetMapping', dependencyResolver)
+	buildUtils.copySourceFiles(buildFile, assembler_srcPDS, 'assembler_dependenciesDatasetMapping', null ,dependencyResolver)
 
 	// create mvs commands
 	LogicalFile logicalFile = dependencyResolver.getLogicalFile()
@@ -270,7 +270,14 @@ def createAssemblerCommand(String buildFile, LogicalFile logicalFile, String mem
 
 	// create a SYSLIB concatenation with optional MACLIB and MODGEN
 	assembler.dd(new DDStatement().name("SYSLIB").dsn(props.assembler_macroPDS).options("shr"))
-	// add custom concatenation
+	
+	// add additional datasets with dependencies based on the dependenciesDatasetMapping
+	PropertyMapping dsMapping = new PropertyMappings('assembler_dependenciesDatasetMapping')
+	dsMapping.getProperties().values().each { targetDatasets ->
+		if (targetDatasets != 'assembler_macroPDS')	assembler.dd(new DDStatement().dsn(props.getProperty(targetDatasets)).options("shr"))
+	}
+	
+	// add custom external concatenations
 	def assemblySyslibConcatenation = props.getFileProperty('assembler_assemblySyslibConcatenation', buildFile) ?: ""
 	if (assemblySyslibConcatenation) {
 		def String[] syslibDatasets = assemblySyslibConcatenation.split(',');

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -33,7 +33,7 @@ sortedList.each { buildFile ->
 	String rules = props.getFileProperty('assembler_resolutionRules', buildFile)
 	String assembler_srcPDS = props.getFileProperty('assembler_srcPDS', buildFile)
 	DependencyResolver dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
-	buildUtils.copySourceFiles(buildFile, assembler_srcPDS, props.assembler_macroPDS, dependencyResolver)
+	buildUtils.copySourceFiles(buildFile, assembler_srcPDS, 'assembler_dependeciesDatasetMapping', dependencyResolver)
 
 	// create mvs commands
 	LogicalFile logicalFile = dependencyResolver.getLogicalFile()

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -27,7 +27,7 @@ sortedList.each { buildFile ->
 	println "*** Building file $buildFile"
 	
 	// copy build file to input data set
-	buildUtils.copySourceFiles(buildFile, props.bms_srcPDS, null, null)
+	buildUtils.copySourceFiles(buildFile, props.bms_srcPDS, null, null, null)
 	
 	// create mvs commands
 	String member = CopyToPDS.createMemberName(buildFile)

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -232,7 +232,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		alternateLibraryNameAllocations = evaluate(props.cobol_alternativeLibraryNamesMapping)
 		alternateLibraryNameAllocations.each { libraryName, datasetDSN ->
 			datasetDSN = props.getProperty(datasetDSN)
-			if (datasetDSN) compile.dd(new DDStatement().name(libraryName).dsn(props.cobol_BMS_PDS).options("shr"))
+			if (datasetDSN) compile.dd(new DDStatement().name(libraryName).dsn(datasetDSN).options("shr"))
 		}
 	}
 	

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -210,7 +210,6 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.cobol_BMS_PDS).options("shr"))
-		
 	// add custom concatenation
 	def compileSyslibConcatenation = props.getFileProperty('cobol_compileSyslibConcatenation', buildFile) ?: ""
 	if (compileSyslibConcatenation) {
@@ -228,6 +227,15 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	if (isZUnitTestCase)
 	compile.dd(new DDStatement().dsn(props.SBZUSAMP).options("shr"))
 
+	// adding alternate library definitions
+	if (props.cobol_alternativeLibraryNamesMapping) {
+		alternateLibraryNameAllocations = evaluate(props.cobol_alternativeLibraryNamesMapping)
+		alternateLibraryNameAllocations.each { libraryName, datasetDSN ->
+			datasetDSN = props.getProperty(datasetDSN)
+			if (datasetDSN) compile.dd(new DDStatement().name(libraryName).dsn(props.cobol_BMS_PDS).options("shr"))
+		}
+	}
+	
 	// add a tasklib to the compile command with optional CICS, DB2, and IDz concatenations
 	String compilerVer = props.getFileProperty('cobol_compilerVersion', buildFile)
 	compile.dd(new DDStatement().name("TASKLIB").dsn(props."SIGYCOMP_$compilerVer").options("shr"))

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -210,6 +210,15 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.cobol_BMS_PDS).options("shr"))
+	
+	// add additional datasets with dependencies based on the dependenciesDatasetMapping
+	PropertyMappings dsMapping = new PropertyMappings('cobol_dependenciesDatasetMapping')
+	dsMapping.getValues().each { targetDataset ->
+		// exclude the defaults cobol_cpyPDS and any overwrite in the alternativeLibraryNameMap
+		if (targetDataset != 'cobol_cpyPDS')
+			compile.dd(new DDStatement().dsn(props.getProperty(targetDataset)).options("shr"))
+	}
+
 	// add custom concatenation
 	def compileSyslibConcatenation = props.getFileProperty('cobol_compileSyslibConcatenation', buildFile) ?: ""
 	if (compileSyslibConcatenation) {

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -45,7 +45,7 @@ sortedList.each { buildFile ->
 	if(isZUnitTestCase){
 		buildUtils.copySourceFiles(buildFile, props.cobol_testcase_srcPDS, null, null)
 	}else{
-		buildUtils.copySourceFiles(buildFile, props.cobol_srcPDS, props.cobol_cpyPDS, dependencyResolver)
+		buildUtils.copySourceFiles(buildFile, props.cobol_srcPDS, 'cobol_dependeciesDatasetMapping', dependencyResolver)
 	}
 	// create mvs commands
 	LogicalFile logicalFile = dependencyResolver.getLogicalFile()

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -45,7 +45,7 @@ sortedList.each { buildFile ->
 	if(isZUnitTestCase){
 		buildUtils.copySourceFiles(buildFile, props.cobol_testcase_srcPDS, null, null)
 	}else{
-		buildUtils.copySourceFiles(buildFile, props.cobol_srcPDS, 'cobol_dependeciesDatasetMapping', dependencyResolver)
+		buildUtils.copySourceFiles(buildFile, props.cobol_srcPDS, 'cobol_dependenciesDatasetMapping', props.cobol_dependenciesAlternativeLibraryNameMapping, dependencyResolver)
 	}
 	// create mvs commands
 	LogicalFile logicalFile = dependencyResolver.getLogicalFile()
@@ -228,8 +228,8 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	compile.dd(new DDStatement().dsn(props.SBZUSAMP).options("shr"))
 
 	// adding alternate library definitions
-	if (props.cobol_alternativeLibraryNamesMapping) {
-		alternateLibraryNameAllocations = evaluate(props.cobol_alternativeLibraryNamesMapping)
+	if (props.cobol_dependenciesAlternativeLibraryNameMapping) {
+		alternateLibraryNameAllocations = evaluate(props.cobol_dependenciesAlternativeLibraryNameMapping)
 		alternateLibraryNameAllocations.each { libraryName, datasetDSN ->
 			datasetDSN = props.getProperty(datasetDSN)
 			if (datasetDSN) compile.dd(new DDStatement().name(libraryName).dsn(datasetDSN).options("shr"))

--- a/languages/DBDgen.groovy
+++ b/languages/DBDgen.groovy
@@ -26,7 +26,7 @@ sortedList.each { buildFile ->
 	println "*** Building file $buildFile"
 
 	// copy build file to input data set
-	buildUtils.copySourceFiles(buildFile, props.dbdgen_srcPDS, null, null)
+	buildUtils.copySourceFiles(buildFile, props.dbdgen_srcPDS, null, null, null)
 
 	// create mvs commands
 	String member = CopyToPDS.createMemberName(buildFile)

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -27,7 +27,7 @@ sortedList.each { buildFile ->
 	println "*** Building file $buildFile"
 
 	// copy build file to input data set
-	buildUtils.copySourceFiles(buildFile, props.linkedit_srcPDS, null, null)
+	buildUtils.copySourceFiles(buildFile, props.linkedit_srcPDS, null, null, null)
 
 	// create mvs commands
 	String rules = props.getFileProperty('linkedit_resolutionRules', buildFile)

--- a/languages/MFS.groovy
+++ b/languages/MFS.groovy
@@ -28,7 +28,7 @@ sortedList.each { buildFile ->
 	println "*** Building file $buildFile"
 
 	// copy build file to input data set
-	buildUtils.copySourceFiles(buildFile, props.mfs_srcPDS, null, null)
+	buildUtils.copySourceFiles(buildFile, props.mfs_srcPDS, null, null, null)
 
 	// create mvs commands
 	String member = CopyToPDS.createMemberName(buildFile)

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -33,7 +33,7 @@ sortedList.each { buildFile ->
 	// copy build file and dependency files to data sets
 	String rules = props.getFileProperty('pli_resolutionRules', buildFile)
 	DependencyResolver dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
-	buildUtils.copySourceFiles(buildFile, props.pli_srcPDS, props.pli_incPDS, dependencyResolver)
+	buildUtils.copySourceFiles(buildFile, props.pli_srcPDS, 'pli_dependeciesDatasetMapping', dependencyResolver)
 
 	// create mvs commands
 	LogicalFile logicalFile = dependencyResolver.getLogicalFile()

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -159,7 +159,15 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 		compile.dd(new DDStatement().dsn(props.bms_cpyPDS).options("shr"))
 	if(props.team)
 		compile.dd(new DDStatement().dsn(props.pli_BMS_PDS).options("shr"))
-		
+	
+	// add additional datasets with dependencies based on the dependenciesDatasetMapping
+	PropertyMappings dsMapping = new PropertyMappings('pli_dependenciesDatasetMapping')
+	dsMapping.getValues().each { targetDataset ->
+		// exclude the defaults cobol_cpyPDS and any overwrite in the alternativeLibraryNameMap
+		if (targetDataset != 'pli_incPDS')
+			compile.dd(new DDStatement().dsn(props.getProperty(targetDataset)).options("shr"))
+	}
+
 	// add custom concatenation
 	def compileSyslibConcatenation = props.getFileProperty('pli_compileSyslibConcatenation', buildFile) ?: ""
 	if (compileSyslibConcatenation) {

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -33,7 +33,7 @@ sortedList.each { buildFile ->
 	// copy build file and dependency files to data sets
 	String rules = props.getFileProperty('pli_resolutionRules', buildFile)
 	DependencyResolver dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
-	buildUtils.copySourceFiles(buildFile, props.pli_srcPDS, 'pli_dependeciesDatasetMapping', dependencyResolver)
+	buildUtils.copySourceFiles(buildFile, props.pli_srcPDS, 'pli_dependenciesDatasetMapping', props.pli_dependenciesAlternativeLibraryNameMapping, dependencyResolver)
 
 	// create mvs commands
 	LogicalFile logicalFile = dependencyResolver.getLogicalFile()
@@ -185,6 +185,15 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	if (buildUtils.isSQL(logicalFile))
 		compile.dd(new DDStatement().name("DBRMLIB").dsn("$props.pli_dbrmPDS($member)").options('shr').output(true).deployType('DBRM'))
 
+	// adding alternate library definitions
+	if (props.cobol_dependenciesAlternativeLibraryNameMapping) {
+		alternateLibraryNameAllocations = evaluate(props.pli_dependenciesAlternativeLibraryNameMapping)
+		alternateLibraryNameAllocations.each { libraryName, datasetDSN ->
+			datasetDSN = props.getProperty(datasetDSN)
+			if (datasetDSN) compile.dd(new DDStatement().name(libraryName).dsn(datasetDSN).options("shr"))
+		}
+	}
+		
 	// add IDz User Build Error Feedback DDs
 	if (props.errPrefix) {
 		compile.dd(new DDStatement().name("SYSADATA").options("DUMMY"))

--- a/languages/PSBgen.groovy
+++ b/languages/PSBgen.groovy
@@ -29,7 +29,7 @@ sortedList.each { buildFile ->
 	println "*** Building file $buildFile"
 
 	// copy build file to input data set
-	buildUtils.copySourceFiles(buildFile, props.psbgen_srcPDS, null, null)
+	buildUtils.copySourceFiles(buildFile, props.psbgen_srcPDS, null, null, null)
 
 	// create mvs commands
 	String member = CopyToPDS.createMemberName(buildFile)

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -121,7 +121,13 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	
 	// add a syslib to the compile command with optional bms output copybook and CICS concatenation
 	compile.dd(new DDStatement().name("SYSLIB").dsn(props.rexx_srcPDS).options("shr"))
-		
+
+	// add additional datasets with dependencies based on the dependenciesDatasetMapping
+	PropertyMapping dsMapping = new PropertyMappings('rexx_dependenciesDatasetMapping')
+	dsMapping.getProperties().values().each { targetDatasets ->
+		if (targetDatasets != 'rexx_srcPDS') rexx.dd(new DDStatement().dsn(props.getProperty(targetDatasets)).options("shr"))
+	}
+			
 	// add custom concatenation
 	def compileSyslibConcatenation = props.getFileProperty('rexx_compileSyslibConcatenation', buildFile) ?: ""
 	if (compileSyslibConcatenation) {

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -28,7 +28,7 @@ sortedList.each { buildFile ->
 	// copy build file and dependency files to data sets
 	String rules = props.getFileProperty('rexx_resolutionRules', buildFile)
 	DependencyResolver dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
-	buildUtils.copySourceFiles(buildFile, props.rexx_srcPDS, props.rexx_srcPDS, dependencyResolver)
+	buildUtils.copySourceFiles(buildFile, props.rexx_srcPDS, 'rexx_dependeciesDatasetMapping', dependencyResolver)
 	// create mvs commands
 	LogicalFile logicalFile = dependencyResolver.getLogicalFile()
 	String member = CopyToPDS.createMemberName(buildFile)

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -28,7 +28,7 @@ sortedList.each { buildFile ->
 	// copy build file and dependency files to data sets
 	String rules = props.getFileProperty('rexx_resolutionRules', buildFile)
 	DependencyResolver dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
-	buildUtils.copySourceFiles(buildFile, props.rexx_srcPDS, 'rexx_dependeciesDatasetMapping', dependencyResolver)
+	buildUtils.copySourceFiles(buildFile, props.rexx_srcPDS, 'rexx_dependenciesDatasetMapping', null, dependencyResolver)
 	// create mvs commands
 	LogicalFile logicalFile = dependencyResolver.getLogicalFile()
 	String member = CopyToPDS.createMemberName(buildFile)

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -42,7 +42,7 @@ buildUtils.createLanguageDatasets(langQualifier)
 	(hasPlayback, playback) = getPlaybackFile(buildFile);
 
 	// Upload BZUCFG file to a BZUCFG Dataset
-	buildUtils.copySourceFiles(buildUtils.getAbsolutePath(buildFile), props.zunit_bzucfgPDS, props.zunit_bzuplayPDS, dependencyResolver)
+	buildUtils.copySourceFiles(buildUtils.getAbsolutePath(buildFile), props.zunit_bzucfgPDS, 'zunit_dependeciesDatasetMapping', dependencyResolver)
 
 	// Create JCLExec String
 	String jobcard = props.jobCard.replace("\\n", "\n")

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -42,7 +42,7 @@ buildUtils.createLanguageDatasets(langQualifier)
 	(hasPlayback, playback) = getPlaybackFile(buildFile);
 
 	// Upload BZUCFG file to a BZUCFG Dataset
-	buildUtils.copySourceFiles(buildUtils.getAbsolutePath(buildFile), props.zunit_bzucfgPDS, 'zunit_dependeciesDatasetMapping', dependencyResolver)
+	buildUtils.copySourceFiles(buildUtils.getAbsolutePath(buildFile), props.zunit_bzucfgPDS, 'zunit_dependenciesDatasetMapping', null, dependencyResolver)
 
 	// Create JCLExec String
 	String jobcard = props.jobCard.replace("\\n", "\n")

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -70,7 +70,7 @@ def getFileSet(String dir, boolean relativePaths, String includeFileList, String
  * dependencies from USS directories to data sets
  */
 
-def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, DependencyResolver dependencyResolver) {
+def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMapping, DependencyResolver dependencyResolver) {
 	// only copy the build file once
 	if (!copiedFileCache.contains(buildFile)) {
 		copiedFileCache.add(buildFile)
@@ -79,14 +79,17 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 				.member(CopyToPDS.createMemberName(buildFile))
 				.execute()
 	}
-
-	if (dependencyPDS && props.userBuildDependencyFile && props.userBuild) {
+	
+	if (dependencyDatasetMapping && props.userBuildDependencyFile && props.userBuild) {
 		if (props.verbose) println "*** User Build Dependency File Detected. Skipping DBB Dependency Resolution."
 		// userBuildDependencyFile present (passed from the IDE)
 		// skip dependency resolution, extract dependencies from userBuildDependencyFile, and copy directly to dependencyPDS
 
 		// parse JSON and validate fields of userBuildDependencyFile
 		def depFileData = validateDependencyFile(buildFile, props.userBuildDependencyFile)
+		
+		// Load property mapping containing the map of targetPDS and dependencyfile
+		PropertyMappings dsMapping = new PropertyMappings(dependencyDatasetMapping)
 
 		// Manually create logical file for the user build program
 		String lname = CopyToPDS.createMemberName(buildFile)
@@ -96,9 +99,9 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		if (dependencyResolver)
 			dependencyResolver.setLogicalFile(lfile)
 
- 		// get list of dependencies from userBuildDependencyFile
+		// get list of dependencies from userBuildDependencyFile
 		List<String> dependencyPaths = depFileData.dependencies
-		
+
 		// copy each dependency from USS to member of depedencyPDS
 		dependencyPaths.each { dependencyPath ->
 			// if dependency is relative, convert to absolute path
@@ -119,18 +122,18 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 							.dataset(dependencyPDS)
 							.member(memberName)
 							.execute()
-				} 
+				}
 				else
 				{
 					new CopyToPDS().file(new File(dependencyLoc))
 							.dataset(dependencyPDS)
 							.member(memberName)
 							.execute()
-				}			
+				}
 			}
-		} 
+		}
 	}
-	else if (dependencyPDS && dependencyResolver) {
+	else if (dependencyDatasetMapping && dependencyResolver) {
 		// resolve the logical dependencies to physical files to copy to data sets
 		List<PhysicalDependency> physicalDependencies = dependencyResolver.resolve()
 		if (props.verbose) {
@@ -139,32 +142,47 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyPDS, Depen
 		}
 		if (props.verbose) println "*** Physical dependencies for $buildFile:"
 
+		// Load property mapping containing the map of targetPDS and dependencyfile
+		PropertyMappings dsMapping = new PropertyMappings(dependencyDatasetMapping)
+		
 		physicalDependencies.each { physicalDependency ->
 			if (props.verbose) println physicalDependency
+
 			if (physicalDependency.isResolved()) {
+
+				// optain target dataset based on PropertyMapping dsMapping
+				String dependencyPDS = props.getProperty(dsMapping.getValue(physicalDependency.getFile()))
 				String physicalDependencyLoc = "${physicalDependency.getSourceDir()}/${physicalDependency.getFile()}"
 
-				// only copy the dependency file once per script invocation
-				if (!copiedFileCache.contains(physicalDependencyLoc)) {
-					copiedFileCache.add(physicalDependencyLoc)
-					// create member name
-					String memberName = CopyToPDS.createMemberName(physicalDependency.getFile())
-					//retrieve zUnitFileExtension plbck
-					zunitFileExtension = (props.zunit_playbackFileExtension) ? props.zunit_playbackFileExtension : null
+				if (dependencyPDS != null) {
 
-					if( zunitFileExtension && !zunitFileExtension.isEmpty() && ((physicalDependency.getFile().substring(physicalDependency.getFile().indexOf("."))).contains(zunitFileExtension))){
-						new CopyToPDS().file(new File(physicalDependencyLoc))
-								.copyMode(CopyMode.BINARY)
-								.dataset(dependencyPDS)
-								.member(memberName)
-								.execute()
-					} else
-					{
-						new CopyToPDS().file(new File(physicalDependencyLoc))
-								.dataset(dependencyPDS)
-								.member(memberName)
-								.execute()
+					// only copy the dependency file once per script invocation
+					if (!copiedFileCache.contains(physicalDependencyLoc)) {
+						copiedFileCache.add(physicalDependencyLoc)
+						// create member name
+						String memberName = CopyToPDS.createMemberName(physicalDependency.getFile())
+						//retrieve zUnitFileExtension plbck
+						zunitFileExtension = (props.zunit_playbackFileExtension) ? props.zunit_playbackFileExtension : null
+
+						if( zunitFileExtension && !zunitFileExtension.isEmpty() && ((physicalDependency.getFile().substring(physicalDependency.getFile().indexOf("."))).contains(zunitFileExtension))){
+							new CopyToPDS().file(new File(physicalDependencyLoc))
+									.copyMode(CopyMode.BINARY)
+									.dataset(dependencyPDS)
+									.member(memberName)
+									.execute()
+						} else
+						{
+							new CopyToPDS().file(new File(physicalDependencyLoc))
+									.dataset(dependencyPDS)
+									.member(memberName)
+									.execute()
+						}
 					}
+				} else {
+					String errorMsg = "*! Target dataset mapping for dependency ${physicalDependency.getFile()} could not be found in PropertyMapping $dependencyDatasetMapping"
+					println(errorMsg)
+					props.error = "true"
+					buildUtils.updateBuildResult(errorMsg:errorMsg)
 				}
 			}
 		}


### PR DESCRIPTION
Both Cobol and PLI have the ability to pull in dependencies from specific libraries. Additionally, users might wish to manage dependencies in different libraries.

This PR implements:

* Ability to upload dependencies to specific libraries - for example be able to direct DCLGEN or generated copybooks to a separated library and add the new dataset to the SYSLIB concatenation. 
* Support dependencies in COBOL and PLI which define the Library Name in the source (like `COPY EPSNBRPM OF MYFILE.`). Files are copied to mapped libraries and allocations are added to the compile steps.