### PR TITLE
Format Console Output

### DIFF
--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -40,7 +40,7 @@ languagePropertyQualifiers | List of language script property qualifiers. Each l
 applicationConfRootDir | Alternate root directory for application-conf location.  Allows for the deployment of the application-conf directories to a static location.  Defaults to ${workspace}/${application}
 requiredDBBToolkitVersion | Minimum required DBB ToolkitVersion to run this version of zAppBuild.
 requiredBuildProperties | Comma separated list of required build properties for zAppBuild/build.groovy. Build and language scripts will validate that *required* build properties have been set before the script runs.  If any are missing or empty, then a validation error will be thrown.
-cleanConsoleOutput | Flag to log output in table views instead of printing raw JSON data
+formatConsoleOutput | Flag to log output in table views instead of printing raw JSON data
 impactBuildOnBuildPropertyChanges | Boolean property to activate impact builds on changes of build properties within the application repository
 impactBuildOnBuildPropertyList | List of build property lists referencing which language properties should cause an impact build when the given property is changed 
 continueOnScanFailure | Determine the behavior when facing a scanner failure. true (default) to continue scanning. false will terminate the process. 

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -40,6 +40,7 @@ languagePropertyQualifiers | List of language script property qualifiers. Each l
 applicationConfRootDir | Alternate root directory for application-conf location.  Allows for the deployment of the application-conf directories to a static location.  Defaults to ${workspace}/${application}
 requiredDBBToolkitVersion | Minimum required DBB ToolkitVersion to run this version of zAppBuild.
 requiredBuildProperties | Comma separated list of required build properties for zAppBuild/build.groovy. Build and language scripts will validate that *required* build properties have been set before the script runs.  If any are missing or empty, then a validation error will be thrown.
+cleanConsoleOutput | Flag to log output in table views instead of printing raw JSON data
 impactBuildOnBuildPropertyChanges | Boolean property to activate impact builds on changes of build properties within the application repository
 impactBuildOnBuildPropertyList | List of build property lists referencing which language properties should cause an impact build when the given property is changed 
 continueOnScanFailure | Determine the behavior when facing a scanner failure. true (default) to continue scanning. false will terminate the process. 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -54,7 +54,7 @@ requiredBuildProperties=buildOrder,buildListFileExt
 #
 # Flag to log output in table views instead of printing raw JSON data
 # default = false
-cleanConsoleOutput=false
+formatConsoleOutput=false
 
 #
 # impactBuildOnBuildPropertyChanges controls if impact calculation should analyze

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -52,6 +52,11 @@ requiredDBBToolkitVersion=1.0.0
 requiredBuildProperties=buildOrder,buildListFileExt
 
 #
+# Flag to log output in table views instead of printing raw JSON data
+# default = false
+cleanConsoleOutput=false
+
+#
 # impactBuildOnBuildPropertyChanges controls if impact calculation should analyze
 # build property changes for COBOL, PLI, ASM.
 # default = false

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -17,6 +17,7 @@ runzTests | Boolean value to specify if zUnit tests should be run.  Defaults to 
 applicationPropFiles | Comma separated list of additional application property files to load. Supports both absolute and relative file paths.  Relative paths assumed to be relative to ${workspace}/${application}/application-conf/. | false
 applicationSrcDirs | Comma separated list of all source directories included in application build. Each directory is assumed to be a local Git repository clone. Supports both absolute and relative paths though for maximum reuse of collected dependency data relative paths should be used.  Relative paths assumed to be relative to ${workspace}. | false
 buildOrder | Comma separated list of the build script processing order. | false
+cleanConsoleOutput | Flag to log output in table views instead of printing raw JSON data | false
 mainBuildBranch | The main build branch of the main application repository.  Used for cloning collections for topic branch builds instead of rescanning the entire application. | false
 gitRepositoryURL | git repository URL of the application repository to establish links to the changed files in the build result properties | false
 excludeFileList | Files to exclude when scanning or running full build. | false

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -17,7 +17,7 @@ runzTests | Boolean value to specify if zUnit tests should be run.  Defaults to 
 applicationPropFiles | Comma separated list of additional application property files to load. Supports both absolute and relative file paths.  Relative paths assumed to be relative to ${workspace}/${application}/application-conf/. | false
 applicationSrcDirs | Comma separated list of all source directories included in application build. Each directory is assumed to be a local Git repository clone. Supports both absolute and relative paths though for maximum reuse of collected dependency data relative paths should be used.  Relative paths assumed to be relative to ${workspace}. | false
 buildOrder | Comma separated list of the build script processing order. | false
-cleanConsoleOutput | Flag to log output in table views instead of printing raw JSON data | false
+formatConsoleOutput | Flag to log output in table views instead of printing raw JSON data | false
 mainBuildBranch | The main build branch of the main application repository.  Used for cloning collections for topic branch builds instead of rescanning the entire application. | false
 gitRepositoryURL | git repository URL of the application repository to establish links to the changed files in the build result properties | false
 excludeFileList | Files to exclude when scanning or running full build. | false

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -25,6 +25,12 @@ buildOrder=BMS.groovy,MFS.groovy,Cobol.groovy,Assembler.groovy,PLI.groovy,LinkEd
 testOrder=ZunitConfig.groovy
 
 #
+# Flag to log output in table views instead of printing raw JSON data
+# See also build-conf/build.properties
+# default = false
+# cleanConsoleOutput=false
+
+#
 # The main build branch.  Used for cloning collections for topic branch builds instead
 # of rescanning the entire application.
 mainBuildBranch=master

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -28,7 +28,7 @@ testOrder=ZunitConfig.groovy
 # Flag to log output in table views instead of printing raw JSON data
 # See also build-conf/build.properties
 # default = false
-# cleanConsoleOutput=false
+# formatConsoleOutput=false
 
 #
 # The main build branch.  Used for cloning collections for topic branch builds instead

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -643,8 +643,8 @@ def assertDbbBuildToolkitVersion(String currentVersion){
 def printResolutionRules(List<ResolutionRule> rules) {
 
 	// Print header of table
-	println("    " + "Library".padRight(10) + "Category".padRight(12) + "SourceDir/File".padRight(40) + "Directory".padRight(36) + "Collection".padRight(24) + "Archive".padRight(20))
-	println("    " + " ".padLeft(10,"-") + " ".padLeft(12,"-") + " ".padLeft(40,"-") + " ".padLeft(36,"-") + " ".padLeft(24,"-") + " ".padLeft(20,"-"))
+	println("    " + "Library".padRight(10) + "Category".padRight(12) + "SourceDir/File".padRight(50) + "Directory".padRight(36) + "Collection".padRight(24) + "Archive".padRight(20))
+	println("    " + " ".padLeft(10,"-") + " ".padLeft(12,"-") + " ".padLeft(50,"-") + " ".padLeft(36,"-") + " ".padLeft(24,"-") + " ".padLeft(20,"-"))
 
 	// iterate over rules configured for the dependencyResolver
 	rules.each{ rule ->
@@ -652,7 +652,7 @@ def printResolutionRules(List<ResolutionRule> rules) {
 		searchPaths.each { DependencyPath searchPath ->
 			def libraryName = (rule.getLibrary() != null) ? rule.getLibrary().padRight(10) : "N/A".padRight(10)
 			def categoryName = (rule.getCategory() != null) ? rule.getCategory().padRight(12) : "N/A".padRight(12)
-			def srcDir = (searchPath.getSourceDir() != null) ? searchPath.getSourceDir().padRight(40) : "N/A".padRight(40)
+			def srcDir = (searchPath.getSourceDir() != null) ? searchPath.getSourceDir().padRight(50) : "N/A".padRight(50)
 			def directory = (searchPath.getDirectory() != null) ? searchPath.getDirectory().padRight(36) : "N/A".padRight(36)
 			def collection = (searchPath.getCollection() != null) ? searchPath.getCollection().padRight(24) : "N/A".padRight(24)
 			def archiveFile = (searchPath.getArchive() != null) ? searchPath.getArchive().padRight(20) : "N/A".padRight(20)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -642,6 +642,8 @@ def assertDbbBuildToolkitVersion(String currentVersion){
  */
 def printResolutionRules(List<ResolutionRule> rules) {
 
+	println("*** Configured resulution rules:")
+	
 	// Print header of table
 	println("    " + "Library".padRight(10) + "Category".padRight(12) + "SourceDir/File".padRight(50) + "Directory".padRight(36) + "Collection".padRight(24) + "Archive".padRight(20))
 	println("    " + " ".padLeft(10,"-") + " ".padLeft(12,"-") + " ".padLeft(50,"-") + " ".padLeft(36,"-") + " ".padLeft(24,"-") + " ".padLeft(20,"-"))

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -643,8 +643,8 @@ def assertDbbBuildToolkitVersion(String currentVersion){
 def printResolutionRules(List<ResolutionRule> rules) {
 
 	// Print header of table
-	println("    " + "Library".padRight(10) + "Category".padRight(12) + "SourceDir/File".padRight(28) + "Directory".padRight(36) + "Collection".padRight(24) + "Archive".padRight(20))
-	println("    " + " ".padLeft(10,"-") + " ".padLeft(12,"-") + " ".padLeft(28,"-") + " ".padLeft(36,"-") + " ".padLeft(24,"-") + " ".padLeft(20,"-"))
+	println("    " + "Library".padRight(10) + "Category".padRight(12) + "SourceDir/File".padRight(40) + "Directory".padRight(36) + "Collection".padRight(24) + "Archive".padRight(20))
+	println("    " + " ".padLeft(10,"-") + " ".padLeft(12,"-") + " ".padLeft(40,"-") + " ".padLeft(36,"-") + " ".padLeft(24,"-") + " ".padLeft(20,"-"))
 
 	// iterate over rules configured for the dependencyResolver
 	rules.each{ rule ->
@@ -652,7 +652,7 @@ def printResolutionRules(List<ResolutionRule> rules) {
 		searchPaths.each { DependencyPath searchPath ->
 			def libraryName = (rule.getLibrary() != null) ? rule.getLibrary().padRight(10) : "N/A".padRight(10)
 			def categoryName = (rule.getCategory() != null) ? rule.getCategory().padRight(12) : "N/A".padRight(12)
-			def srcDir = (searchPath.getSourceDir() != null) ? searchPath.getSourceDir().padRight(28) : "N/A".padRight(28)
+			def srcDir = (searchPath.getSourceDir() != null) ? searchPath.getSourceDir().padRight(40) : "N/A".padRight(40)
 			def directory = (searchPath.getDirectory() != null) ? searchPath.getDirectory().padRight(36) : "N/A".padRight(36)
 			def collection = (searchPath.getCollection() != null) ? searchPath.getCollection().padRight(24) : "N/A".padRight(24)
 			def archiveFile = (searchPath.getArchive() != null) ? searchPath.getArchive().padRight(20) : "N/A".padRight(20)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -691,15 +691,17 @@ def printPhysicalDependencies(List<PhysicalDependency> physicalDependencies) {
 		def depFile = (physicalDependency.getFile()) ? physicalDependency.getFile() : "N/A"
 		println(resolvedFlag.padLeft(4) + physicalDependency.getLibrary().padRight(10) + physicalDependency.getCategory().padRight(16) + physicalDependency.getLname().padRight(10) + resolvedStatus.padRight(14) + depFile.padRight(36))
 	}
+}
 
 /*
  * Obtain the abbreviated git hash from the PropertyMappings table
+ *  returns null if no hash was found
  */
 def getShortGitHash(String buildFile) {
 	def abbrevGitHash
 	PropertyMappings githashChangedFilesMap = new PropertyMappings("githashBuildableFilesMap")
 	abbrevGitHash = githashChangedFilesMap.getValue(buildFile)
 	if (abbrevGitHash != null ) return abbrevGitHash
-	println "*! Could not obtain abbreviated githash for buildFile $buildFile"	
-	return null	
+	println "*! Could not obtain abbreviated githash for buildFile $buildFile"
+	return null
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -146,8 +146,8 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMap
 		if (props.verbose) {
 			println "*** Resolution rules for $buildFile:"
 			
-			if (props.cleanConsoleOutput && props.cleanConsoleOutput.toBoolean()) {
-				printResolutionRules(dependencyResolver)
+			if (props.formatConsoleOutput && props.formatConsoleOutput.toBoolean()) {
+				printResolutionRules(dependencyResolver.getResolutionRules())
 			} else {
 				dependencyResolver.getResolutionRules().each{ rule -> println rule }
 			}
@@ -158,13 +158,13 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMap
 		PropertyMappings dependenciesDatasetMapping = new PropertyMappings(dependencyDatasetMapping)
 		
 		if (physicalDependencies.size() != 0) {
-			if (props.verbose && props.cleanConsoleOutput && props.cleanConsoleOutput.toBoolean()) {
+			if (props.verbose && props.formatConsoleOutput && props.formatConsoleOutput.toBoolean()) {
 				printPhysicalDependencies(physicalDependencies)
 				}
 		}
 		
 		physicalDependencies.each { physicalDependency ->
-			if (props.verbose && !props.cleanConsoleOutput && !props.cleanConsoleOutput.toBoolean()) 	println physicalDependency
+			if (props.verbose && !props.formatConsoleOutput && !props.formatConsoleOutput.toBoolean()) 	println physicalDependency
 			
 			if (physicalDependency.isResolved()) {
 
@@ -640,20 +640,20 @@ def assertDbbBuildToolkitVersion(String currentVersion){
  * Logs the resolution rules of the DependencyResolver in a table format
  * 
  */
-def printResolutionRules(DependencyResolver dependencyResolver) {
+def printResolutionRules(List<ResolutionRule> rules) {
 
 	// Print header of table
 	println("    " + "Library".padRight(10) + "Category".padRight(12) + "SourceDir/File".padRight(28) + "Directory".padRight(36) + "Collection".padRight(24) + "Archive".padRight(20))
 	println("    " + " ".padLeft(10,"-") + " ".padLeft(12,"-") + " ".padLeft(28,"-") + " ".padLeft(36,"-") + " ".padLeft(24,"-") + " ".padLeft(20,"-"))
 
 	// iterate over rules configured for the dependencyResolver
-	dependencyResolver.getResolutionRules().each{ rule ->
+	rules.each{ rule ->
 		searchPaths = rule.getSearchPath()
 		searchPaths.each { DependencyPath searchPath ->
 			def libraryName = (rule.getLibrary() != null) ? rule.getLibrary().padRight(10) : "N/A".padRight(10)
 			def categoryName = (rule.getCategory() != null) ? rule.getCategory().padRight(12) : "N/A".padRight(12)
 			def srcDir = (searchPath.getSourceDir() != null) ? searchPath.getSourceDir().padRight(28) : "N/A".padRight(28)
-			def directory = (searchPath.getDirectory() != null) ? searchPath.getDirectory().padRight(28) : "N/A".padRight(28)
+			def directory = (searchPath.getDirectory() != null) ? searchPath.getDirectory().padRight(36) : "N/A".padRight(36)
 			def collection = (searchPath.getCollection() != null) ? searchPath.getCollection().padRight(24) : "N/A".padRight(24)
 			def archiveFile = (searchPath.getArchive() != null) ? searchPath.getArchive().padRight(20) : "N/A".padRight(20)
 			println("    " + libraryName + categoryName + srcDir + directory + collection + archiveFile)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -65,6 +65,19 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			// get excludeListe
 			List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
 
+			// Print impactResolverConfiguration
+			if (props.cleanConsoleOutput && props.cleanConsoleOutput.toBoolean()) {
+				// print collection information
+				println("    " + "Collection".padRight(20) )
+				println("    " + " ".padLeft(20,"-"))
+				impactResolver.getCollections().each{ collectionName ->
+					println("    " + collectionName)
+				}
+				// print impact resolution rule in table format
+				buildUtils.printResolutionRules(impactResolver.getResolutionRules())
+			}
+			
+			// resolving impacts
 			def impacts = impactResolver.resolve()
 			impacts.each { impact ->
 				def impactFile = impact.getFile()

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -66,7 +66,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
 
 			// Print impactResolverConfiguration
-			if (props.cleanConsoleOutput && props.cleanConsoleOutput.toBoolean()) {
+			if (props.formatConsoleOutput && props.formatConsoleOutput.toBoolean()) {
 				// print collection information
 				println("    " + "Collection".padRight(20) )
 				println("    " + " ".padLeft(20,"-"))


### PR DESCRIPTION
This PR introduces a flag to configure a more human readable console output about the dependency resolution process of zAppBuild. 

Having `formatConsoleOutput` turned on in `build-conf/build.properties` or `application-conf/application.properties` as an individual setting, it will print in `--verbose` logging mode table views, rather than raw JSON .  

```
*** Building file MortgageApplication/cobol/epsnbrvl.cbl
*** Creating dependency resolver for MortgageApplication/cobol/epsnbrvl.cbl with [{"library": "SYSLIB", "searchPath": [ {"sourceDir": "/u/dbehm/userBuild", "directory": "MortgageApplication/copybook"} ]                }] rules
*** Scanning file with the default scanner
*** Resolution rules for MortgageApplication/cobol/epsnbrvl.cbl:
    Library   Category    SourceDir/File              Directory                           Collection              Archive
    --------- ----------- --------------------------- ----------------------------------- ----------------------- -------------------
    SYSLIB    N/A         /u/dbehm/userBuild          MortgageApplication/copybookN/A                     N/A
*** Physical dependencies for MortgageApplication/cobol/epsnbrvl.cbl:
    Library   Category        Name      Status        SourceDir/File
    --------- --------------- --------- ------------- -----------------------------------
    SYSLIB    COPY            EPSNBRPM  RESOLVED      MortgageApplication/copybook/epsnbrpm.cpy
   *SYSLIB    COPY            XYZ       NOT RESOLVED  N/A
Cobol compiler parms for MortgageApplication/cobol/epsnbrvl.cbl = LIB,ADATA,EX(ADX(ELAXMGUX))
```