### PR TITLE
Support UTF-8 for user build dependency file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,4 @@
 *.asm zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.jcl zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.mac zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
+*.json zos-working-tree-encoding=utf-8 git-encoding=utf-8

--- a/samples/userBuildDependencyFile/README.md
+++ b/samples/userBuildDependencyFile/README.md
@@ -2,7 +2,7 @@
 
 In order to increase performance of User Build running on ZD&T, the IDEs can **optionally** pass dependency information about the program being built to zAppBuild allowing it to skip running dependency resolution which depending on the size and number of build dependencies the program references can be time consuming on ZD&T platforms.
 
-### Dependency File Option
+### Option
 Providing the following option when calling *build.groovy* will skip scanning and dependency resolution within zAppBuild.
 
     --dependencyFile <pathToFile>
@@ -10,9 +10,16 @@ Providing the following option when calling *build.groovy* will skip scanning an
 If not provided, zAppBuild will run the traditional scan and dependency resolution on the build file.
 If it is provided, zAppBuild will skip scanning and resolution and refer to the dependencies and information from the file. 
   
-### Dependency File Location
+### Location
 
 The location of the user build dependency file on USS is unimportant, as long as that path is correctly specified when passing the **-\-dependencyFile \<path>** option to zAppBuild. 
+
+### Encoding and Tagging
+
+The user build dependency file functionality supports three encoding scenarios when uploaded:
+ 1. Encoded as UTF-8 and tagged as UTF-8. 
+ 2. Encoded as IBM-1047 and tagged as IBM-1047.
+ 3. Encoded as IBM-1047 and untagged.  
 
 ### Additional Resources
 View the user build dependency file schema and a sample file using the links below. 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -665,7 +665,11 @@ def assertDbbBuildToolkitVersion(String currentVersion){
 	}
 }
 
-def retrieveHFSEncoding(File file) {
+/*
+ * Returns a string representation of a file's encoding calculated from its tag.
+ * 
+ */
+def retrieveHFSFileEncoding(File file) {
 	FileAttribute.Stat stat = FileAttribute.getStat(file.getAbsolutePath())
     FileAttribute.Tag tag = stat.getTag()
 	int i = 0

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -91,16 +91,12 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMap
 	if (dependencyDatasetMapping && props.userBuildDependencyFile && props.userBuild) {
 		if (props.verbose) println "*** User Build Dependency File Detected. Skipping DBB Dependency Resolution."
 		// userBuildDependencyFile present (passed from the IDE)
+		// Skip dependency resolution, extract dependencies from userBuildDependencyFile, and copy directly dataset
 		// Load property mapping containing the map of targetPDS and dependencyfile
 		PropertyMappings dependenciesDatasetMapping = new PropertyMappings(dependencyDatasetMapping)
 		
-		// skip dependency resolution, extract dependencies from userBuildDependencyFile, and copy directly to dependencyPDS
-
 		// parse JSON and validate fields of userBuildDependencyFile
 		def depFileData = validateDependencyFile(buildFile, props.userBuildDependencyFile)
-		
-		// Load property mapping containing the map of targetPDS and dependencyfile
-		PropertyMappings dsMapping = new PropertyMappings(dependencyDatasetMapping)
 
 		// Manually create logical file for the user build program
 		String lname = CopyToPDS.createMemberName(buildFile)
@@ -118,17 +114,8 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMap
 			// if dependency is relative, convert to absolute path
 			String dependencyLoc = getAbsolutePath(dependencyPath)
 
-			// obtain target dataset based on Mappings
-			// Order :
-			//    1. langprefix_dependenciesAlternativeLibraryNameMapping based on the library setting recognized by DBB (COBOL and PLI)
-			//    2. langprefix_dependenciesDatasetMapping as a manual overwrite to determine an alternative library used in the default dd concatentation 
-			String dependencyPDS 
-			// if (!physicalDependency.getLibrary().equals("SYSLIB") && dependenciesAlternativeLibraryNameMapping) {
-			// 	dependencyPDS = props.getProperty(evaluate(dependenciesAlternativeLibraryNameMapping).get(physicalDependency.getLibrary()))
-			// }
-			if (dependencyPDS == null && dependenciesDatasetMapping){
-				dependencyPDS = props.getProperty(dependenciesDatasetMapping.getValue(dependencyPath))
-			}
+			// Assume library is SYSLIB for all dependencies
+			String dependencyPDS = props.getProperty(dependenciesDatasetMapping.getValue(dependencyPath))
 
 			// only copy the dependency file once per script invocation
 			if (!copiedFileCache.contains(dependencyLoc)) {

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -3,7 +3,9 @@ import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
-import groovy.json.*
+import groovy.json.JsonParserType
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
 import com.ibm.dbb.build.DBBConstants.CopyMode
 import com.ibm.dbb.build.report.records.*
 import com.ibm.jzos.FileAttribute

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -91,6 +91,9 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMap
 	if (dependencyDatasetMapping && props.userBuildDependencyFile && props.userBuild) {
 		if (props.verbose) println "*** User Build Dependency File Detected. Skipping DBB Dependency Resolution."
 		// userBuildDependencyFile present (passed from the IDE)
+		// Load property mapping containing the map of targetPDS and dependencyfile
+		PropertyMappings dependenciesDatasetMapping = new PropertyMappings(dependencyDatasetMapping)
+		
 		// skip dependency resolution, extract dependencies from userBuildDependencyFile, and copy directly to dependencyPDS
 
 		// parse JSON and validate fields of userBuildDependencyFile
@@ -114,6 +117,18 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMap
 		dependencyPaths.each { dependencyPath ->
 			// if dependency is relative, convert to absolute path
 			String dependencyLoc = getAbsolutePath(dependencyPath)
+
+			// obtain target dataset based on Mappings
+			// Order :
+			//    1. langprefix_dependenciesAlternativeLibraryNameMapping based on the library setting recognized by DBB (COBOL and PLI)
+			//    2. langprefix_dependenciesDatasetMapping as a manual overwrite to determine an alternative library used in the default dd concatentation 
+			String dependencyPDS 
+			// if (!physicalDependency.getLibrary().equals("SYSLIB") && dependenciesAlternativeLibraryNameMapping) {
+			// 	dependencyPDS = props.getProperty(evaluate(dependenciesAlternativeLibraryNameMapping).get(physicalDependency.getLibrary()))
+			// }
+			if (dependencyPDS == null && dependenciesDatasetMapping){
+				dependencyPDS = props.getProperty(dependenciesDatasetMapping.getValue(dependencyPath))
+			}
 
 			// only copy the dependency file once per script invocation
 			if (!copiedFileCache.contains(dependencyLoc)) {

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -4,8 +4,10 @@ import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
 import groovy.json.JsonSlurper
+import groovy.json.JsonBuilder
 import com.ibm.dbb.build.DBBConstants.CopyMode
 import com.ibm.dbb.build.report.records.*
+import com.ibm.jzos.FileAttribute
 
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -615,7 +615,7 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 	assert depFile.exists() : "*! Dependency file not found: ${depFile.getAbsolutePath()}"
 	
 	// Parse the JSON file
-	String encoding = retrieveHFSEncoding(depFile) // Determine the encoding from filetag
+	String encoding = retrieveHFSFileEncoding(depFile) // Determine the encoding from filetag
 	JsonSlurper slurper = new JsonSlurper().setType(JsonParserType.INDEX_OVERLAY) // Use INDEX_OVERLAY, fastest parser
 	def depFileData
 	if (encoding) {

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -3,8 +3,7 @@ import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
-import groovy.json.JsonSlurper
-import groovy.json.JsonBuilder
+import groovy.json.*
 import com.ibm.dbb.build.DBBConstants.CopyMode
 import com.ibm.dbb.build.report.records.*
 import com.ibm.jzos.FileAttribute


### PR DESCRIPTION
According to [JSON Standards](https://datatracker.ietf.org/doc/html/rfc7159#section-8.1) JSON files should be encoded UTF-8. 
This PR includes support for the user build dependency file being uploaded, tagged, and parsed as UTF-8.
Note: Backwards compatibility is maintained. Previously the dependency file was being uploaded as text (converted to IBM-1047) and left untagged, and this will still be supported as described below. 

Changes Made:
- Refactored BuildUtilities.validateDependencyFile() to support and parse under three encoding/tagging scenarios:
   1. Encoded as UTF-8 and tagged as UTF-8. (JSON Standard)
   2. Encoded as IBM-1047 and tagged as IBM-1047.
   3. Encoded as IBM-1047 and untagged.  (Provides backwards compatibility)
 - Added BuildUtilities.retreiveHFSTag() which reads the file tag attribute and returns a text representation of the codepage represented by that tag. 
 - Added *.json to gitattributes to conform to JSON standards. 