### PR TITLE
Correction about supported build types for SSI info

### DIFF
--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -284,8 +284,8 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	String linkDebugExit = props.getFileProperty('cobol_linkDebugExit', buildFile)
 
 	// obtain githash for buildfile
-	String cobol_storeSSI = props.getFileProperty('cobol_storeSSI', buildFile) 
-	if (cobol_storeSSI && cobol_storeSSI.toBoolean()) {
+	String cobol_storeSSI = props.getFileProperty('cobol_storeSSI', buildFile)
+	if (cobol_storeSSI && cobol_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
 		String ssi = buildUtils.getShortGitHash(buildFile)
 		if (ssi != null) parms = parms + ",SSI=$ssi"
 	}

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -80,7 +80,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// obtain githash for buildfile
 	String linkedit_storeSSI = props.getFileProperty('linkedit_storeSSI', buildFile) 
-	if (linkedit_storeSSI && linkedit_storeSSI.toBoolean()) {
+	if (linkedit_storeSSI && linkedit_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
 		String ssi = buildUtils.getShortGitHash(buildFile)
 		if (ssi != null) parms = parms + ",SSI=$ssi"
 	}

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -256,7 +256,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// obtain githash for buildfile
 	String pli_storeSSI = props.getFileProperty('pli_storeSSI', buildFile)
-	if (pli_storeSSI && pli_storeSSI.toBoolean()) {
+	if (pli_storeSSI && pli_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
 		String ssi = buildUtils.getShortGitHash(buildFile)
 		if (ssi != null) parms = parms + ",SSI=$ssi"
 	}

--- a/samples/MortgageApplication/application-conf/Cobol.properties
+++ b/samples/MortgageApplication/application-conf/Cobol.properties
@@ -61,6 +61,7 @@ cobol_linkEdit=true
 
 #
 # store abbrev git hash in ssi field
+# available for impactBuild and mergeBuild scenario 
 # can be overridden by file properties
 cobol_storeSSI=true 
 

--- a/samples/MortgageApplication/application-conf/LinkEdit.properties
+++ b/samples/MortgageApplication/application-conf/LinkEdit.properties
@@ -17,6 +17,7 @@ linkEdit_parms=MAP,RENT,COMPAT(PM5)
 
 #
 # store abbrev git hash in ssi field
+# available for impactBuild and mergeBuild scenario 
 # can be overridden by file properties
 linkedit_storeSSI=true
 

--- a/samples/MortgageApplication/application-conf/PLI.properties
+++ b/samples/MortgageApplication/application-conf/PLI.properties
@@ -47,6 +47,7 @@ pli_linkEdit=true
 
 #
 # store abbrev git hash in ssi field
+# available for impactBuild and mergeBuild scenario  
 # can be overridden by file properties
 pli_storeSSI=true 
 

--- a/samples/application-conf/Cobol.properties
+++ b/samples/application-conf/Cobol.properties
@@ -61,7 +61,8 @@ cobol_linkEdit=true
 
 #
 # store abbrev git hash in ssi field
-# can be overridden by file properties
+# available for impactBuild and mergeBuild scenario
+# can be overridden by file properties 
 cobol_storeSSI=true 
 
 #

--- a/samples/application-conf/LinkEdit.properties
+++ b/samples/application-conf/LinkEdit.properties
@@ -21,6 +21,7 @@ linkEdit_parms=MAP,RENT,COMPAT(PM5)
 
 #
 # store abbrev git hash in ssi field
+# available for impactBuild and mergeBuild scenario 
 # can be overridden by file properties
 linkedit_storeSSI=true 
 

--- a/samples/application-conf/PLI.properties
+++ b/samples/application-conf/PLI.properties
@@ -48,6 +48,7 @@ pli_linkEdit=true
 
 #
 # store abbrev git hash in ssi field
+# available for impactBuild and mergeBuild scenario 
 # can be overridden by file properties
 pli_storeSSI=true 
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -702,6 +702,6 @@ def getShortGitHash(String buildFile) {
 	PropertyMappings githashChangedFilesMap = new PropertyMappings("githashBuildableFilesMap")
 	abbrevGitHash = githashChangedFilesMap.getValue(buildFile)
 	if (abbrevGitHash != null ) return abbrevGitHash
-	println "*! Could not obtain abbreviated githash for buildFile $buildFile"
+	if (props.verbose) println "*! Could not obtain abbreviated githash for buildFile $buildFile"
 	return null
 }


### PR DESCRIPTION
Correction for avoid any noice in the log. Storing the SSI Info is captured on `--impactBuild` and `--mergeBuild` with this implementation. 