### PR TITLE
Correction of additional dependency datasets in SYSLIB for language scripts ASM and REXX

### DIFF
--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -272,7 +272,7 @@ def createAssemblerCommand(String buildFile, LogicalFile logicalFile, String mem
 	assembler.dd(new DDStatement().name("SYSLIB").dsn(props.assembler_macroPDS).options("shr"))
 	
 	// add additional datasets with dependencies based on the dependenciesDatasetMapping
-	PropertyMapping dsMapping = new PropertyMappings('assembler_dependenciesDatasetMapping')
+	PropertyMappings dsMapping = new PropertyMappings('assembler_dependenciesDatasetMapping')
 	dsMapping.getProperties().values().each { targetDatasets ->
 		if (targetDatasets != 'assembler_macroPDS')	assembler.dd(new DDStatement().dsn(props.getProperty(targetDatasets)).options("shr"))
 	}

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -273,8 +273,10 @@ def createAssemblerCommand(String buildFile, LogicalFile logicalFile, String mem
 	
 	// add additional datasets with dependencies based on the dependenciesDatasetMapping
 	PropertyMappings dsMapping = new PropertyMappings('assembler_dependenciesDatasetMapping')
-	dsMapping.getProperties().values().each { targetDatasets ->
-		if (targetDatasets != 'assembler_macroPDS')	assembler.dd(new DDStatement().dsn(props.getProperty(targetDatasets)).options("shr"))
+	dsMapping.getValues().each { targetDataset ->
+		// exclude the defaults assembler_macroPDS
+		if (targetDataset != 'assembler_macroPDS')
+			assembler.dd(new DDStatement().dsn(props.getProperty(targetDataset)).options("shr"))
 	}
 	
 	// add custom external concatenations

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -123,7 +123,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	compile.dd(new DDStatement().name("SYSLIB").dsn(props.rexx_srcPDS).options("shr"))
 
 	// add additional datasets with dependencies based on the dependenciesDatasetMapping
-	PropertyMapping dsMapping = new PropertyMappings('rexx_dependenciesDatasetMapping')
+	PropertyMappings dsMapping = new PropertyMappings('rexx_dependenciesDatasetMapping')
 	dsMapping.getProperties().values().each { targetDatasets ->
 		if (targetDatasets != 'rexx_srcPDS') rexx.dd(new DDStatement().dsn(props.getProperty(targetDatasets)).options("shr"))
 	}

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -124,8 +124,10 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 
 	// add additional datasets with dependencies based on the dependenciesDatasetMapping
 	PropertyMappings dsMapping = new PropertyMappings('rexx_dependenciesDatasetMapping')
-	dsMapping.getProperties().values().each { targetDatasets ->
-		if (targetDatasets != 'rexx_srcPDS') rexx.dd(new DDStatement().dsn(props.getProperty(targetDatasets)).options("shr"))
+	dsMapping.getValues().each { targetDataset ->
+		// exclude the defaults rexx_srcPDS
+		if (targetDataset != 'rexx_srcPDS')
+			rexx.dd(new DDStatement().dsn(props.getProperty(targetDataset)).options("shr"))
 	}
 			
 	// add custom concatenation


### PR DESCRIPTION
A syntax error has been identified for the new capability to direct dependencies to different datasets in the `Assembler.groovy` as well as `REXX.groovy`.

