### PR TITLE
Formatted console output for impactResolver config only on verbose logging

### DIFF
--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -70,7 +70,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 			List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
 
 			// Print impactResolverConfiguration
-			if (props.formatConsoleOutput && props.formatConsoleOutput.toBoolean()) {
+			if (props.verbose && props.formatConsoleOutput && props.formatConsoleOutput.toBoolean()) {
 				// print collection information
 				println("    " + "Collection".padRight(20) )
 				println("    " + " ".padLeft(20,"-"))


### PR DESCRIPTION
The output of the impactResolver configuration for collections and searchPath should only be written to console log in case of the `--verbose` tracing option.