### PR TITLE
SSI info conditional via a build property for Assembler and BMS language scripts

### DIFF
--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -319,8 +319,11 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	String parameters = props.getFileProperty('assembler_linkEditParms', buildFile)
 
 	// obtain githash for buildfile
-	String ssi = buildUtils.getShortGitHash(buildFile)
-	if (ssi != null) parameters = parameters + ",SSI=$ssi"
+	String assembler_storeSSI = props.getFileProperty('assembler_storeSSI', buildFile)
+	if (assembler_storeSSI && assembler_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
+		String ssi = buildUtils.getShortGitHash(buildFile)
+		if (ssi != null) parameters = parameters + ",SSI=$ssi"
+	}
 	
 	// define the MVSExec command to link edit the program
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(props.assembler_linkEditor).parm(parameters)

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -122,8 +122,11 @@ def createLinkEditCommand(String buildFile, String member, File logFile) {
 	String parameters = props.getFileProperty('bms_linkEditParms', buildFile)
 	
 	// obtain githash for buildfile
-	String ssi = buildUtils.getShortGitHash(buildFile)
-	if (ssi != null) parameters = parameters + ",SSI=$ssi"
+	String bms_storeSSI = props.getFileProperty('bms_storeSSI', buildFile)
+	if (bms_storeSSI && bms_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
+		String ssi = buildUtils.getShortGitHash(buildFile)
+		if (ssi != null) parameters = parameters + ",SSI=$ssi"
+	}
 	
 	// define the MVSExec command to link edit the program
 	MVSExec linkedit = new MVSExec().file(buildFile).pgm(props.bms_linkEditor).parm(parameters)

--- a/samples/MortgageApplication/application-conf/Assembler.properties
+++ b/samples/MortgageApplication/application-conf/Assembler.properties
@@ -37,6 +37,12 @@ assembler_impactPropertyListSQL=assembler_cicsprecompilerParms
 assembler_resolutionRules=[${maclibRule},${asmCopyRule}]
 
 #
+# store abbrev git hash in ssi field
+# available for impactBuild and mergeBuild scenario
+# can be overridden by file properties 
+assembler_storeSSI=true 
+
+#
 # default deployType
 assembler_deployType=LOAD
 

--- a/samples/MortgageApplication/application-conf/BMS.properties
+++ b/samples/MortgageApplication/application-conf/BMS.properties
@@ -22,6 +22,12 @@ bms_linkEditParms=MAP,RENT,COMPAT(PM5)
 bms_impactPropertyList=bms_copyGenParms,bms_compileParms,bms_linkEditParms
 
 #
+# store abbrev git hash in ssi field
+# available for impactBuild and mergeBuild scenario
+# can be overridden by file properties 
+bms_storeSSI=true 
+
+#
 # default deployType
 bms_deployType=MAPLOAD
 

--- a/samples/MortgageApplication/application-conf/LinkEdit.properties
+++ b/samples/MortgageApplication/application-conf/LinkEdit.properties
@@ -11,6 +11,10 @@ linkedit_fileBuildRank=
 linkedit_maxRC=0
 
 #
+# lists of properties which should cause a rebuild after being changed
+linkedit_impactPropertyList=linkEdit_parms
+
+#
 # default LinkEdit parameters
 # can be overridden by file properties
 linkEdit_parms=MAP,RENT,COMPAT(PM5)
@@ -26,11 +30,17 @@ linkedit_storeSSI=true
 linkedit_deployType=LOAD
 
 #
-# deployType for build files with isCICS=true
+# deployType for build files with isCICS=true set in file properties
+#  DBB scanners cannot determine the file tags for linkcards automatically,
+#  requires the flag to be set via a file property
+#  e.q isCICS = true :: **/link/epsmlist.lnk
 linkedit_deployTypeCICS=CICSLOAD
 
 #
-# deployType for build files with isDLI=true
+# deployType for build files with isDLI=true set in file properties
+#  DBB scanners cannot determine the file tags for linkcards automatically,
+#  requires the flag to be set via a file property
+#  e.q isDLI = true :: **/link/epsmlist.lnk
 linkedit_deployTypeDLI=IMSLOAD
 
 #

--- a/samples/MortgageApplication/application-conf/PLI.properties
+++ b/samples/MortgageApplication/application-conf/PLI.properties
@@ -34,6 +34,7 @@ pli_compileParms=PP(INCLUDE('ID(++INCLUDE)'))
 pli_compileCICSParms=SYSTEM(CICS),PP(MACRO,CICS)
 pli_compileSQLParms=PP(SQL)
 pli_compileErrorPrefixParms=XINFO(XML)
+pli_compileDebugParms=TEST
 
 #
 # default LinkEdit parameters

--- a/samples/application-conf/Assembler.properties
+++ b/samples/application-conf/Assembler.properties
@@ -37,6 +37,12 @@ assembler_impactPropertyListSQL=assembler_cicsprecompilerParms
 assembler_resolutionRules=[${maclibRule},${asmCopyRule}]
 
 #
+# store abbrev git hash in ssi field
+# available for impactBuild and mergeBuild scenario
+# can be overridden by file properties 
+assembler_storeSSI=true 
+
+#
 # default deployType
 assembler_deployType=LOAD
 

--- a/samples/application-conf/BMS.properties
+++ b/samples/application-conf/BMS.properties
@@ -22,6 +22,12 @@ bms_linkEditParms=MAP,RENT,COMPAT(PM5)
 bms_impactPropertyList=bms_copyGenParms,bms_compileParms,bms_linkEditParms
 
 #
+# store abbrev git hash in ssi field
+# available for impactBuild and mergeBuild scenario
+# can be overridden by file properties 
+bms_storeSSI=true 
+
+#
 # default deployType
 bms_deployType=MAPLOAD
 

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -64,6 +64,7 @@ assembler_impactPropertyList | List of build properties causing programs to rebu
 assembler_impactPropertyListCICS | List of CICS build properties causing programs to rebuild when changed | false
 assembler_impactPropertyListSQL | List of SQL build properties causing programs to rebuild when changed | false
 assembler_resolutionRules | Assembler dependency resolution rules used to create a Assmebler dependency resolver.  Format is a JSON array of resolution rule property keys.  Resolution rule properties are defined in `application-conf/application.properties`. | true
+assembler_storeSSI | Flag to store abbrev git hash in ssi field in link step | true
 assembler_deployType | default deployType for build output | true
 assembler_deployTypeCICS | deployType for build output for build files where isCICS=true | true
 assembler_deployTypeDLI | deployType for build output for build files with isDLI=true | true
@@ -82,6 +83,7 @@ bms_copyGenParms | Default parameters for the copybook generation step. | true
 bms_compileParms | Default parameters for the compilation step. | true
 bms_linkEditParms | Default parameters for the link edit step. | true
 bms_impactPropertyList | List of build properties causing programs to rebuild when changed | false
+bms_storeSSI | Flag to store abbrev git hash in ssi field in link step | true
 bms_deployType | deployType for build output | true
 bms_copy_deployType | deployType for generated copybooks | true
 


### PR DESCRIPTION
This PR adds the conditional logic for storing the abbreviated hash via the Linker in the SSI Info field for the language scripts Assembler.groovy and BMS.groovy, where the conditional implementation was missed, when the feature was first contributed. This fixes #181.