### PR TITLE
Add hidden files in subdirectories to excludeFileList

### DIFF
--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -28,7 +28,7 @@ gitRepositoryURL=https://github.com/ibm/dbb-zappbuild/
 
 #
 # exclude list used when scanning or running full build
-excludeFileList=.*,**/*.properties,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/application-conf/*.*
+excludeFileList=.*,**/.*,**/*.properties,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/application-conf/*.*
 
 #
 # comma-separated list of file patterns for which impact calculation should be skipped. Uses glob file patterns

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -43,7 +43,7 @@ gitRepositoryURL=
 
 #
 # exclude list used when scanning or running full build
-excludeFileList=.*,**/*.properties,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/application-conf/*.*
+excludeFileList=.*,**/.*,**/*.properties,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/application-conf/*.*
 
 #
 # comma-separated list of file patterns for which impact calculation should be skipped. Uses glob file patterns


### PR DESCRIPTION
Hidden files, also called .-files, are not supposed to be a valid build files for the build framework.

This PR adds hidden files in subdirectories to the excludeFileList samples in `sample/application-conf` and `sample/MortgageApplication/application-conf`

Implements #184 