### PR TITLE
Enable SSI Info for load modules in fullBuild scenario

### DIFF
--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -320,7 +320,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// obtain githash for buildfile
 	String assembler_storeSSI = props.getFileProperty('assembler_storeSSI', buildFile)
-	if (assembler_storeSSI && assembler_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
+	if (assembler_storeSSI && assembler_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild || props.fullBuild)) {
 		String ssi = buildUtils.getShortGitHash(buildFile)
 		if (ssi != null) parameters = parameters + ",SSI=$ssi"
 	}

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -123,7 +123,7 @@ def createLinkEditCommand(String buildFile, String member, File logFile) {
 	
 	// obtain githash for buildfile
 	String bms_storeSSI = props.getFileProperty('bms_storeSSI', buildFile)
-	if (bms_storeSSI && bms_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
+	if (bms_storeSSI && bms_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild || props.fullBuild)) {
 		String ssi = buildUtils.getShortGitHash(buildFile)
 		if (ssi != null) parameters = parameters + ",SSI=$ssi"
 	}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -285,7 +285,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// obtain githash for buildfile
 	String cobol_storeSSI = props.getFileProperty('cobol_storeSSI', buildFile)
-	if (cobol_storeSSI && cobol_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
+	if (cobol_storeSSI && cobol_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild || props.fullBuild)) {
 		String ssi = buildUtils.getShortGitHash(buildFile)
 		if (ssi != null) parms = parms + ",SSI=$ssi"
 	}

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -80,7 +80,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// obtain githash for buildfile
 	String linkedit_storeSSI = props.getFileProperty('linkedit_storeSSI', buildFile) 
-	if (linkedit_storeSSI && linkedit_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
+	if (linkedit_storeSSI && linkedit_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild || props.fullBuild)) {
 		String ssi = buildUtils.getShortGitHash(buildFile)
 		if (ssi != null) parms = parms + ",SSI=$ssi"
 	}

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -256,7 +256,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 
 	// obtain githash for buildfile
 	String pli_storeSSI = props.getFileProperty('pli_storeSSI', buildFile)
-	if (pli_storeSSI && pli_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild)) {
+	if (pli_storeSSI && pli_storeSSI.toBoolean() && (props.mergeBuild || props.impactBuild || props.fullBuild)) {
 		String ssi = buildUtils.getShortGitHash(buildFile)
 		if (ssi != null) parms = parms + ",SSI=$ssi"
 	}


### PR DESCRIPTION
This implements #186 to write the SSI Info also in fullBuild scenarios.