### PR TITLE
fix logging for physicalDependencies in verbose mode

### DIFF
--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -182,7 +182,8 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMap
 		}
 		
 		physicalDependencies.each { physicalDependency ->
-			if (props.verbose && !props.formatConsoleOutput && !props.formatConsoleOutput.toBoolean()) 	println physicalDependency
+			// Write Physical Dependency details to log on verbose, not on formatConsoleOutput
+			if (props.verbose && !(props.formatConsoleOutput && props.formatConsoleOutput.toBoolean())) 	println physicalDependency
 			
 			if (physicalDependency.isResolved()) {
 


### PR DESCRIPTION
The condition is not well formed and causes that the physicalDependencies are not correctly logged to the console atm. This fixes #191 