### PR TITLE
Capture file deletions and deleted outputs in DBB build report

### DIFF
--- a/build-conf/ACBgen.properties
+++ b/build-conf/ACBgen.properties
@@ -23,6 +23,9 @@ acbgen_loadOptions=cyl space(5,5) dir(40) dsorg(PO) recfm(U) blksize(32760) dsnt
 
 acbgen_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 
+# List of output datasets to document deletions
+acbgen_outputDatasets=${acbgen_loadPDS}
+
 #
 # default acbgen pgm
 acbgen_pgm=DFSRRC00

--- a/build-conf/Assembler.properties
+++ b/build-conf/Assembler.properties
@@ -30,6 +30,9 @@ assembler_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) 
 # Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List
 assembler_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep
 
+# List of output datasets to document deletions
+assembler_outputDatasets=${assembler_loadPDS},${assembler_dbrmPDS}
+
 #
 # default assembler execs
 assembler_db2precompiler=DSNHPC

--- a/build-conf/BMS.properties
+++ b/build-conf/BMS.properties
@@ -25,6 +25,9 @@ bms_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library
 
 bms_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 
+# List of output datasets to document deletions
+bms_outputDatasets=${bms_cpyPDS},${bms_loadPDS}
+
 #
 # default BMS properties
 bms_assembler=ASMA90

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -47,10 +47,6 @@ cobol_printTempOptions=cyl space(5,5) unit(vio) blksize(133) lrecl(133) recfm(f,
 
 
 #
-# List of output datasets to document deletions
-cobol_outputDatasets=${cobol_loadPDS}
-
-#
 # List the data sets for tests that need to be created and their creation options
 cobol_test_srcDatasets=${cobol_testcase_srcPDS}
 cobol_test_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
@@ -60,6 +56,10 @@ cobol_test_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(
 
 # Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List
 cobol_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep
+
+#
+# List of output datasets to document deletions
+cobol_outputDatasets=${cobol_loadPDS}
 
 #
 # COBOL scanner language hint

--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -45,6 +45,11 @@ cobol_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(libra
 cobol_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 cobol_printTempOptions=cyl space(5,5) unit(vio) blksize(133) lrecl(133) recfm(f,b) new
 
+
+#
+# List of output datasets to document deletions
+cobol_outputDatasets=${cobol_loadPDS}
+
 #
 # List the data sets for tests that need to be created and their creation options
 cobol_test_srcDatasets=${cobol_testcase_srcPDS}

--- a/build-conf/DBDgen.properties
+++ b/build-conf/DBDgen.properties
@@ -28,6 +28,8 @@ dbdgen_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 # Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List
 dbdgen_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep
 
+# List of output datasets to document deletions
+dbdgen_outputDatasets=${dbdgen_loadPDS}
 
 #
 # default dbdgen properties

--- a/build-conf/LinkEdit.properties
+++ b/build-conf/LinkEdit.properties
@@ -30,5 +30,9 @@ linkedit_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(li
 linkedit_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 
 #
+# List of output datasets to document deletions
+linkedit_outputDatasets=${linkedit_loadPDS}
+
+#
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # linkedit_linkEditSyslibConcatenation=

--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -51,12 +51,12 @@ pli_test_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(librar
 pli_test_loadDatasets=${pli_testcase_loadPDS}
 pli_test_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library)
 
-#
-# List of output datasets to document deletions
-pli_outputDatasets=${pli_loadPDS}
-
 # Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List
 pli_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep
+
+#
+# List of output datasets to document deletions
+pli_outputDatasets=${pli_loadPDS},${pli_dbrmPDS}
 
 #
 # PL/I scanner language hint

--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -37,6 +37,10 @@ pli_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library
 pli_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 pli_listOptions=cyl space(5,5) unit(vio) blksize(0) lrecl(137) recfm(v,b) new
 
+#
+# List of output datasets to document deletions
+pli_outputDatasets=${pli_loadPDS}
+
 # Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List
 pli_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep
 

--- a/build-conf/PSBgen.properties
+++ b/build-conf/PSBgen.properties
@@ -28,6 +28,8 @@ psbgen_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 # Allocation of SYSMLSD Dataset used for extracting Compile Messages to Remote Error List
 psbgen_compileErrorFeedbackXmlOptions=tracks space(200,40) dsorg(PS) blksize(27998) lrecl(16383) recfm(v,b) new keep
 
+# List of output datasets to document deletions
+psbgen_outputDatasets=${psbgen_loadPDS}
 
 #
 # default psbgen properties

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -80,7 +80,7 @@ assembler_loadDatasets | Comma separated list of 'load module' type data sets
 assembler_loadOptions | BPXWDYN creation options for 'load module' type data sets
 assembler_tempOptions | BPXWDYN creation options for temporary data sets
 assembler_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
-assembler_outputDatasets | List of output datasets to document deletions
+assembler_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property.
 assembler_pgm | MVS program name of the high level assembler
 assembler_linkEditor | MVS program name of the link editor
 dbb.DependencyScanner.languageHint | DBB configuration property used by the dependency scanner to disambiguate a source file's language
@@ -100,7 +100,7 @@ bms_srcOptions | BPXWDYN creation options for creating 'source' type data sets
 bms_loadDatasets | Comma separated list of 'load module' type data sets
 bms_loadOptions | BPXWDYN creation options for 'load module' type data sets
 bms_tempOptions | BPXWDYN creation options for temporary data sets
-bms_outputDatasets | List of output datasets to document deletions
+bms_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property.
 bms_assembler | MVS program name of the high level assembler
 bms_linkEditor | MVS program name of the link editor
 
@@ -127,7 +127,7 @@ cobol_test_srcOptions | BPXWDYN creation options for creating 'source' type data
 cobol_test_loadDatasets | Comma separated list of test 'load module' type data sets
 cobol_test_loadOptions | BPXWDYN creation options for creating 'load module' type data sets
 cobol_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
-cobol_outputDatasets | List of output datasets to document deletions
+cobol_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property.
 cobol_compiler | MVS program name of the COBOL compiler
 cobol_linkEditor | MVS program name of the link editor
 cobol_dependenciesAlternativeLibraryNameMapping | a map to define target dataset definition for alternate include libraries
@@ -150,7 +150,7 @@ linkedit_srcOptions | BPXWDYN creation options for creating 'source' type data s
 linkedit_loadDatasets | Comma separated list of 'load module' type data sets
 linkedit_loadOptions | BPXWDYN creation options for 'load module' type data sets
 linkedit_tempOptions | BPXWDYN creation options for temporary data sets
-linkedit_outputDatasets | List of output datasets to document deletions
+linkedit_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property.
 
 ### PLI.properties
 Build properties used by zAppBuild/language/PLI.groovy
@@ -177,7 +177,7 @@ pli_test_srcOptions | BPXWDYN creation options for creating 'source' type data s
 pli_test_loadDatasets | Comma separated list of test 'load module' type data sets
 pli_test_loadOptions | BPXWDYN creation options for creating 'load module' type data sets
 pli_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
-pli_outputDatasets | List of output datasets to document deletions
+pli_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property.
 pli_listOptions | BPXWDYN creation options for LIST data sets
 pli_dependenciesAlternativeLibraryNameMapping | a map to define target dataset definition for alternate include libraries
 pli_dependenciesDatasetMapping | dbb property mapping to map dependencies to different target datasets
@@ -215,7 +215,7 @@ dbdgen_loadDatasets | Comma separated list of 'load module' type data sets
 dbdgen_loadOptions | BPXWDYN creation options for 'load module' type data sets
 dbdgen_tempOptions | BPXWDYN creation options for temporary data sets
 dbdgen_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
-dbdgen_outputDatasets | List of output datasets to document deletions
+dbdgen_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property.
 dbdgen_pgm | MVS program name of the high level assembler
 dbdgen_linkEditor | MVS program name of the link editor
 dbdgen_deployType | Deploy Type of build outputs
@@ -236,7 +236,7 @@ psbgen_loadDatasets | Comma separated list of 'load module' type data sets
 psbgen_loadOptions | BPXWDYN creation options for 'load module' type data sets
 psbgen_tempOptions | BPXWDYN creation options for temporary data sets
 psbgen_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
-psbgen_outputDatasets | List of output datasets to document deletions
+psbgen_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property.
 psbgen_pgm | MVS program name of the high level assembler
 psbgen_linkEditor | MVS program name of the link editor
 psbgen_deployType | Deploy Type of build outputs
@@ -254,7 +254,7 @@ acbgen_loadPDS | Dataset to create acbgen modules
 acbgen_loadDatasets | Comma separated list of 'load module' type data sets
 acbgen_loadOptions | BPXWDYN creation options for 'load module' type data sets
 acbgen_tempOptions | BPXWDYN creation options for temporary data sets
-acbgen_outputDatasets | List of output datasets to document deletions
+acbgen_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property.
 acbgen_pgm | MVS program name of the acbgen pgm
 acbgen_deployType | Deploy Type of build outputs
 
@@ -284,4 +284,4 @@ transfer_srcPDS | Dataset of any type of source
 transfer_jclPDS | Sample dataset for JCL members
 transfer_xmlPDS | Sample dataset for xml members
 transfer_srcOptions | BPXWDYN creation options for creating 'source' type data sets
-transfer_outputDatasets | List of output datasets to document deletions ** If used for multiple, use a file property to set transfer_outputDatasets 
+transfer_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property. ** If used for multiple, use a file property to set transfer_outputDatasets 

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -44,7 +44,8 @@ formatConsoleOutput | Flag to log output in table views instead of printing raw
 impactBuildOnBuildPropertyChanges | Boolean property to activate impact builds on changes of build properties within the application repository
 impactBuildOnBuildPropertyList | List of build property lists referencing which language properties should cause an impact build when the given property is changed 
 continueOnScanFailure | Determine the behavior when facing a scanner failure. true (default) to continue scanning. false will terminate the process. 
-createBuildOutputSubfolder | Option to create a subfolder with the build label within the build output dir (outDir). Default: true. 
+createBuildOutputSubfolder | Option to create a subfolder with the build label within the build output dir (outDir). Default: true.
+documentDeleteRecords | Option determine if the build framework should document deletions of outputs in DBB Build Report. Default: false. Requires DBB Toolkit 1.1.3 and higher.
 generateDb2BindInfoRecord | Flag to control the generation of a generic DBB build record for a build file to document the configured db2 bind information (application-conf/bind.properties). Default: false ** Can be overridden by a file property. 
 dbb.file.tagging | Controls compile log and build report file tagging. Default: true.
 dbb.LinkEditScanner.excludeFilter | DBB configuration property used by the link edit scanner to exclude load module entries

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -80,6 +80,7 @@ assembler_loadDatasets | Comma separated list of 'load module' type data sets
 assembler_loadOptions | BPXWDYN creation options for 'load module' type data sets
 assembler_tempOptions | BPXWDYN creation options for temporary data sets
 assembler_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
+assembler_outputDatasets | List of output datasets to document deletions
 assembler_pgm | MVS program name of the high level assembler
 assembler_linkEditor | MVS program name of the link editor
 dbb.DependencyScanner.languageHint | DBB configuration property used by the dependency scanner to disambiguate a source file's language
@@ -99,6 +100,7 @@ bms_srcOptions | BPXWDYN creation options for creating 'source' type data sets
 bms_loadDatasets | Comma separated list of 'load module' type data sets
 bms_loadOptions | BPXWDYN creation options for 'load module' type data sets
 bms_tempOptions | BPXWDYN creation options for temporary data sets
+bms_outputDatasets | List of output datasets to document deletions
 bms_assembler | MVS program name of the high level assembler
 bms_linkEditor | MVS program name of the link editor
 
@@ -125,6 +127,7 @@ cobol_test_srcOptions | BPXWDYN creation options for creating 'source' type data
 cobol_test_loadDatasets | Comma separated list of test 'load module' type data sets
 cobol_test_loadOptions | BPXWDYN creation options for creating 'load module' type data sets
 cobol_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
+cobol_outputDatasets | List of output datasets to document deletions
 cobol_compiler | MVS program name of the COBOL compiler
 cobol_linkEditor | MVS program name of the link editor
 cobol_dependenciesAlternativeLibraryNameMapping | a map to define target dataset definition for alternate include libraries
@@ -147,6 +150,7 @@ linkedit_srcOptions | BPXWDYN creation options for creating 'source' type data s
 linkedit_loadDatasets | Comma separated list of 'load module' type data sets
 linkedit_loadOptions | BPXWDYN creation options for 'load module' type data sets
 linkedit_tempOptions | BPXWDYN creation options for temporary data sets
+linkedit_outputDatasets | List of output datasets to document deletions
 
 ### PLI.properties
 Build properties used by zAppBuild/language/PLI.groovy
@@ -173,6 +177,7 @@ pli_test_srcOptions | BPXWDYN creation options for creating 'source' type data s
 pli_test_loadDatasets | Comma separated list of test 'load module' type data sets
 pli_test_loadOptions | BPXWDYN creation options for creating 'load module' type data sets
 pli_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
+pli_outputDatasets | List of output datasets to document deletions
 pli_listOptions | BPXWDYN creation options for LIST data sets
 pli_dependenciesAlternativeLibraryNameMapping | a map to define target dataset definition for alternate include libraries
 pli_dependenciesDatasetMapping | dbb property mapping to map dependencies to different target datasets
@@ -210,6 +215,7 @@ dbdgen_loadDatasets | Comma separated list of 'load module' type data sets
 dbdgen_loadOptions | BPXWDYN creation options for 'load module' type data sets
 dbdgen_tempOptions | BPXWDYN creation options for temporary data sets
 dbdgen_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
+dbdgen_outputDatasets | List of output datasets to document deletions
 dbdgen_pgm | MVS program name of the high level assembler
 dbdgen_linkEditor | MVS program name of the link editor
 dbdgen_deployType | Deploy Type of build outputs
@@ -230,6 +236,7 @@ psbgen_loadDatasets | Comma separated list of 'load module' type data sets
 psbgen_loadOptions | BPXWDYN creation options for 'load module' type data sets
 psbgen_tempOptions | BPXWDYN creation options for temporary data sets
 psbgen_compileErrorFeedbackXmlOptions | BPXWDYN creation options for SYSXMLSD data set
+psbgen_outputDatasets | List of output datasets to document deletions
 psbgen_pgm | MVS program name of the high level assembler
 psbgen_linkEditor | MVS program name of the link editor
 psbgen_deployType | Deploy Type of build outputs
@@ -247,6 +254,7 @@ acbgen_loadPDS | Dataset to create acbgen modules
 acbgen_loadDatasets | Comma separated list of 'load module' type data sets
 acbgen_loadOptions | BPXWDYN creation options for 'load module' type data sets
 acbgen_tempOptions | BPXWDYN creation options for temporary data sets
+acbgen_outputDatasets | List of output datasets to document deletions
 acbgen_pgm | MVS program name of the acbgen pgm
 acbgen_deployType | Deploy Type of build outputs
 
@@ -276,3 +284,4 @@ transfer_srcPDS | Dataset of any type of source
 transfer_jclPDS | Sample dataset for JCL members
 transfer_xmlPDS | Sample dataset for xml members
 transfer_srcOptions | BPXWDYN creation options for creating 'source' type data sets
+transfer_outputDatasets | List of output datasets to document deletions ** If used for multiple, use a file property to set transfer_outputDatasets 

--- a/build-conf/REXX.properties
+++ b/build-conf/REXX.properties
@@ -39,6 +39,9 @@ rexx_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 rexx_rexxPrintTempOptions=cyl space(5,5) unit(vio) blksize(121) lrecl(121) recfm(f,a) new
 rexx_printTempOptions=cyl space(5,5) unit(vio) blksize(133) lrecl(133) recfm(f,b) new
 
+#
+# List of output datasets to document deletions
+rexx_outputDatasets=${rexx_cexecPDS},${rexx_loadPDS}
 
 #
 # rexx scanner language hint

--- a/build-conf/Transfer.properties
+++ b/build-conf/Transfer.properties
@@ -18,3 +18,6 @@ transfer_xmlPDS=${hlq}.XML
 #
 # dataset creation options
 transfer_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
+
+# List of output datasets to document deletions
+transfer_outputDatasets=${transfer_srcPDS}

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -118,8 +118,11 @@ createBuildOutputSubfolder=true
 
 #
 # Flag to determine if the build framework should document deletions of outputs in DBB Build Report
-# for build files being mapped to BMS,Cobol,LinkEdit,PLI, REXX
-# Requires the DBB toolkit 1.1.3 or higher 
+# for build files being mapped to language scripts
+#
+# Requires the DBB toolkit 1.1.3 or higher. Backward compatibility of zAppBuild is preserved, 
+# when feature is turned off
+# 
 # Default : false
 documentDeleteRecords=false 
 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -117,9 +117,10 @@ continueOnScanFailure=true
 createBuildOutputSubfolder=true
 
 #
-# Determine if the build framework should document (potential) deletions of outputs in DBB Build Report for build files being mapped to BMS,Cobol,LinkEdit,PLI, REXX
-# Prereq: Requires the dbb toolkit to contain the necessary extension to support the DELETE Record 
-# Default: false
+# Flag to determine if the build framework should document deletions of outputs in DBB Build Report
+# for build files being mapped to BMS,Cobol,LinkEdit,PLI, REXX
+# Requires the DBB toolkit 1.1.3 or higher 
+# Default : false
 documentDeleteRecords=false 
 
 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -95,6 +95,13 @@ continueOnScanFailure=true
 createBuildOutputSubfolder=true
 
 #
+# Determine if the build framework should document (potential) deletions of outputs in DBB Build Report for build files being mapped to BMS,Cobol,LinkEdit,PLI, REXX
+# Prereq: Requires the dbb toolkit to contain the necessary extension to support the DELETE Record 
+# Default: false
+documentDeleteRecords=false 
+
+
+#
 # default DBB Repository Web Application authentication properties
 # can be overridden by build.groovy script options
 

--- a/build.groovy
+++ b/build.groovy
@@ -71,9 +71,11 @@ else {
 }
 
 // document deletions in build report
-if (deletedFiles.size() != 0) {
+if (deletedFiles.size() != 0 && props.documentDeleteRecords && props.documentDeleteRecords.toBoolean()) {
 	println("** Document deleted files in Build Report.")
-	buildReportUtils.processDeletedFilesList(deletedFiles)
+	if (buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.3")) {
+		buildReportUtils.processDeletedFilesList(deletedFiles)
+	}
 }
 
 // finalize build process
@@ -99,13 +101,14 @@ def initializeBuildProcess(String[] args) {
 	// build properties initial set
 	populateBuildProperties(args)
 	
-	// print dbb toolkit version in use
+	// print and store property dbb toolkit version in use
 	def dbbToolkitVersion = VersionInfo.getInstance().getVersion()
+	props.dbbToolkitVersion = dbbToolkitVersion
 	def dbbToolkitBuildDate = VersionInfo.getInstance().getDate()
 	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion} ${dbbToolkitBuildDate} "
 	
 	// verify required dbb toolkit
-	buildUtils.assertDbbBuildToolkitVersion(dbbToolkitVersion)
+	buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, props.requiredDBBToolkitVersion)
 
 	// verify required build properties
 	buildUtils.assertBuildProperties(props.requiredBuildProperties)

--- a/build.groovy
+++ b/build.groovy
@@ -17,6 +17,7 @@ import groovy.cli.commons.*
 @Field def gitUtils= loadScript(new File("utilities/GitUtilities.groovy"))
 @Field def buildUtils= loadScript(new File("utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("utilities/ImpactUtilities.groovy"))
+@Field def buildReportUtils= loadScript(new File("utilities/BuildReportUtilities.groovy"))
 @Field String hashPrefix = ':githash:'
 @Field String giturlPrefix = ':giturl:'
 @Field String gitchangedfilesPrefix = ':gitchangedfiles:'
@@ -73,7 +74,6 @@ else {
 if (deletedFiles.size() != 0 && props.documentDeleteRecords && props.documentDeleteRecords.toBoolean()) {
 	println("** Document deleted files in Build Report.")
 	if (buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.3")) {
-		def buildReportUtils= loadScript(new File("utilities/BuildReportUtilities.groovy"))
 		buildReportUtils.processDeletedFilesList(deletedFiles)
 	}
 }

--- a/build.groovy
+++ b/build.groovy
@@ -17,7 +17,6 @@ import groovy.cli.commons.*
 @Field def gitUtils= loadScript(new File("utilities/GitUtilities.groovy"))
 @Field def buildUtils= loadScript(new File("utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("utilities/ImpactUtilities.groovy"))
-@Field def buildReportUtils= loadScript(new File("utilities/BuildReportUtilities.groovy"))
 @Field String hashPrefix = ':githash:'
 @Field String giturlPrefix = ':giturl:'
 @Field String gitchangedfilesPrefix = ':gitchangedfiles:'
@@ -74,6 +73,7 @@ else {
 if (deletedFiles.size() != 0 && props.documentDeleteRecords && props.documentDeleteRecords.toBoolean()) {
 	println("** Document deleted files in Build Report.")
 	if (buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.3")) {
+		def buildReportUtils= loadScript(new File("utilities/BuildReportUtilities.groovy"))
 		buildReportUtils.processDeletedFilesList(deletedFiles)
 	}
 }

--- a/build.groovy
+++ b/build.groovy
@@ -72,7 +72,7 @@ else {
 // document deletions in build report
 if (deletedFiles.size() != 0) {
 	println("** Document deleted files in Build Report.")
-	buildReportUtilities.processDeletedFilesList(deletedFiles)
+	buildReportUtils.processDeletedFilesList(deletedFiles)
 }
 
 // finalize build process

--- a/utilities/BuildReportUtilities.groovy
+++ b/utilities/BuildReportUtilities.groovy
@@ -7,6 +7,9 @@ import com.ibm.dbb.build.report.records.*
 import com.ibm.dbb.extensions.*
 import com.ibm.jzos.ZFile
 
+@Field def buildUtils= loadScript(new File("BuildUtilities.groovy"))
+
+
 /*
  * Method to iterate over deleted files list to generate Delete Records in BuildReport.
  */

--- a/utilities/BuildReportUtilities.groovy
+++ b/utilities/BuildReportUtilities.groovy
@@ -7,8 +7,9 @@ import com.ibm.dbb.build.report.records.*
 import com.ibm.dbb.extensions.*
 import com.ibm.jzos.ZFile
 
+// define script properties
+@Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("BuildUtilities.groovy"))
-
 
 /*
  * Method to iterate over deleted files list to generate Delete Records in BuildReport.

--- a/utilities/BuildReportUtilities.groovy
+++ b/utilities/BuildReportUtilities.groovy
@@ -1,0 +1,51 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import com.ibm.dbb.dependency.*
+import com.ibm.dbb.build.*
+import groovy.transform.*
+import com.ibm.dbb.build.report.*
+import com.ibm.dbb.build.report.records.*
+import com.ibm.dbb.extensions.*
+import com.ibm.jzos.ZFile
+
+/*
+ * Method to iterate over deleted files list to generate Delete Records in BuildReport.
+ */
+def processDeletedFilesList(List deletedList){
+
+	deletedList.each { deletedFile ->
+		def scriptMapping = ScriptMappings.getScriptName(deletedFile)
+		if(scriptMapping != null){
+			langPrefix = buildUtils.getLangPrefix(scriptMapping)
+			if(langPrefix != null){
+
+				String member = CopyToPDS.createMemberName(deletedFile)
+
+				props."${langPrefix}_outputDatasets".split(',').each{ outputDS ->
+
+					// outputRecord
+					String outputRecord = "$outputDS"+"($member)"
+
+					String isLinkEdited = props.getFileProperty("${langPrefix}_linkEdit", deletedFile)
+					if ((isLinkEdited && isLinkEdited.toBoolean()) || scriptMapping == "LinkEdit.groovy" || isLinkEdited == null){
+
+						DeleteRecord deleteRecord = new DeleteRecord()
+						deleteRecord.setFile(deletedFile)
+						deleteRecord.addOutput(outputRecord)
+						BuildReportFactory.getBuildReport().addRecord(deleteRecord)
+
+						if (ZFile.dsExists("//'$outputRecord'")) {
+						   if (props.verbose) println "** Deleting ${outputRecord}"
+						   ZFile.remove("//'$outputRecord'")
+						}
+						
+					}
+					else {
+						if (props.verbose) println ("*** Skipped $deletedFile.")
+					}
+				}
+			} else {
+				if (props.verbose) println ("*** No Delete Record generated for $deletedFile. No language prefix found.")
+			}
+		}
+	}
+}

--- a/utilities/BuildReportUtilities.groovy
+++ b/utilities/BuildReportUtilities.groovy
@@ -43,7 +43,7 @@ def processDeletedFilesList(List deletedList){
 					AnyTypeRecord deleteRecord = new AnyTypeRecord("DELETE_RECORD")
 					deleteRecord.setAttribute("file", deletedFile)
 
-					Set<String> deletedOutputsList = new HashSet<String>()
+					List<String> deletedOutputsList = new ArrayList<String>() 
 
 					props."${langPrefix}_outputDatasets".split(',').each{ outputDS ->
 						// record for deleted dataset(member)

--- a/utilities/BuildReportUtilities.groovy
+++ b/utilities/BuildReportUtilities.groovy
@@ -19,7 +19,7 @@ import com.ibm.jzos.ZFile
  *  While the logicalFile no longer exists, it has to validate if a potential output exists.
  *  This is based on the languagePrefix, which is used to obtain the property
  *  <langprefix>_outputDatasets, which contains a comma-separated list of libraries
- *  containing build outputs.
+ *  containing build outputs. Supports file overwrites
  *  
  *  A decision was taken not to validate if the file exists on the dataset before 
  *  capturing the record, while on featureBranches build libraries, the outputs most likely
@@ -45,7 +45,8 @@ def processDeletedFilesList(List deletedList){
 
 					List<String> deletedOutputsList = new ArrayList<String>() 
 
-					props."${langPrefix}_outputDatasets".split(',').each{ outputDS ->
+					String outputLibs = props.getFileProperty("${langPrefix}_outputDatasets", deletedFile)
+					outputLibs.split(',').each{ outputDS ->
 						// record for deleted dataset(member)
 						String outputRecord = "$outputDS"+"($member)"
 						if (props.verbose) println "** Document deletion ${outputRecord} for file ${deletedFile}"

--- a/utilities/BuildReportUtilities.groovy
+++ b/utilities/BuildReportUtilities.groovy
@@ -43,8 +43,8 @@ def processDeletedFilesList(List deletedList){
 					AnyTypeRecord deleteRecord = new AnyTypeRecord("DELETE_RECORD")
 					deleteRecord.setAttribute("file", deletedFile)
 
-					Set<String> deletedOutputsList = new HashSet<String>() 
-					
+					Set<String> deletedOutputsList = new HashSet<String>()
+
 					props."${langPrefix}_outputDatasets".split(',').each{ outputDS ->
 						// record for deleted dataset(member)
 						String outputRecord = "$outputDS"+"($member)"
@@ -59,8 +59,10 @@ def processDeletedFilesList(List deletedList){
 
 					}
 
-					if(deletedOutputsList.size() > 0 ) 
+					if(deletedOutputsList.size() > 0 ) { 
+						deleteRecord.setAttribute("deletedBuildOutputs",deletedOutputsList)
 						BuildReportFactory.getBuildReport().addRecord(deleteRecord)
+					}
 
 				}
 				else {

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -644,12 +644,12 @@ def validateDependencyFile(String buildFile, String depFilePath) {
  * exits the process, if it does not meet the minimum required version of zAppBuild.
  * 
  */
-def assertDbbBuildToolkitVersion(String currentVersion){
+def assertDbbBuildToolkitVersion(String currentVersion, String requiredVersion){
 
 	try {
 		// Tokenize current version
 		List currentVersionList = currentVersion.tokenize(".")
-		List requiredVersionList = props.requiredDBBToolkitVersion.tokenize(".")
+		List requiredVersionList = requiredVersion.tokenize(".")
 
 		// validate the version formats, current version is allowed have more labels.
 		assert currentVersionList.size() >= requiredVersionList.size() : "Version syntax does not match."


### PR DESCRIPTION
This enhancement enables a **decommissioning process** through the pipeline. Until now, zAppBuild had just documented the deleted files on the source code level.

This contribution adds a new step after the build list is processed to loop through the list of deleted source code files to
* Create a new DBB Build Report Record type `DELETE_RECORD` for the deleted build file and documents  the assumed deleted build outputs such as LOAD, DBRMs and others.  The implementation leverages the new AnyTypedRecord, which got introduced in DBB 1.1.3. 
* Deletes the build outputs from the build libraries, if they exist

To configure the feature, please see the new set of build properties `<langPrefix_outputDatasets` and `documentDeleteRecords`. By default the functionality is turned off to preserve backward compatibility.

FYI #153 
