### PR TITLE
Conditionally load BuildReportUtilities

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -17,7 +17,6 @@ import groovy.cli.commons.*
 @Field def gitUtils= loadScript(new File("utilities/GitUtilities.groovy"))
 @Field def buildUtils= loadScript(new File("utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("utilities/ImpactUtilities.groovy"))
-@Field def buildReportUtils= loadScript(new File("utilities/BuildReportUtilities.groovy"))
 @Field String hashPrefix = ':githash:'
 @Field String giturlPrefix = ':giturl:'
 @Field String gitchangedfilesPrefix = ':gitchangedfiles:'
@@ -74,6 +73,7 @@ else {
 if (deletedFiles.size() != 0 && props.documentDeleteRecords && props.documentDeleteRecords.toBoolean()) {
 	println("** Document deleted files in Build Report.")
 	if (buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.3")) {
+		buildReportUtils = loadScript(new File("utilities/BuildReportUtilities.groovy"))
 		buildReportUtils.processDeletedFilesList(deletedFiles)
 	}
 }


### PR DESCRIPTION
To preserve backward compatibility with older toolkit versions, the utility script BuildReportUtilities needs to be loaded after it passed the compatibility check.

Fixes this issue with older toolkit versions

```
utilities/BuildReportUtilities.groovy: 43: unable to resolve class AnyTypeRecord 
 @ line 43, column 35.
   					AnyTypeRecord deleteRecord = new AnyTypeRecord("DELETE_RECORD")
```