### PR TITLE
Mark build as failed on git errors

### DIFF
--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -144,7 +144,7 @@ def getCurrentGitHash(String gitDir, boolean abbrev) {
 		String errorMsg = "*! Error executing Git command: $cmd error: $gitError"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+		updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
 	}
 	return gitHash.toString().trim()
 }
@@ -259,7 +259,7 @@ def getChangedFiles(String cmd) {
 		String errorMsg = "*! Error executing Git command: $cmd error: $git_error \n *! Attempting to parse unstable git command for changed files..."
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+		updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
 	}
 
 	for (line in git_diff.toString().split("\n")) {

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -4,6 +4,9 @@ import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
 
+@Field BuildProperties props = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("BuildUtilities.groovy"))
+
 /*
  * Tests if directory is in a local git repository
  *
@@ -20,7 +23,9 @@ def isGitDir(String dir) {
 	Process process = cmd.execute()
 	process.waitForProcessOutput(gitResponse, gitError)
 	if (gitError) {
-		println("*? Warning executing isGitDir($dir). Git command: $cmd error: $gitError")
+		String warningMsg = "*? Warning executing isGitDir($dir). Git command: $cmd error: $gitError"
+		println(warningMsg)
+		buildUtils.updateBuildResult(warningMsg:warningMsg,client:getRepositoryClient())
 	}
 	else if (gitResponse) {
 		isGit = gitResponse.toString().trim().toBoolean()
@@ -137,7 +142,10 @@ def getCurrentGitHash(String gitDir, boolean abbrev) {
 	Process process = cmd.execute()
 	process.waitForProcessOutput(gitHash, gitError)
 	if (gitError) {
-		print("*! Error executing Git command: $cmd error: $gitError")
+		String errorMsg = "*! Error executing Git command: $cmd error: $gitError"
+		println(errorMsg)
+		props.error = "true"
+		buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
 	}
 	return gitHash.toString().trim()
 }
@@ -249,8 +257,10 @@ def getChangedFiles(String cmd) {
 
 	// handle command error
 	if (git_error.size() > 0) {
-		println("*! Error executing Git command: $cmd error: $git_error")
-		println ("*! Attempting to parse unstable git command for changed files...")
+		String errorMsg = "*! Error executing Git command: $cmd error: $git_error \n *! Attempting to parse unstable git command for changed files..."
+		println(errorMsg)
+		props.error = "true"
+		buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
 	}
 
 	for (line in git_diff.toString().split("\n")) {
@@ -369,4 +379,10 @@ def getChangedProperties(String gitDir, String baseline, String currentHash, Str
 	}
 
 	return changedProperties.propertyNames()
+}
+
+def getRepositoryClient() {
+	if (!repositoryClient && props."dbb.RepositoryClient.url")
+		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
+	return repositoryClient
 }

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -5,7 +5,6 @@ import com.ibm.dbb.build.*
 import groovy.transform.*
 
 @Field BuildProperties props = BuildProperties.getInstance()
-@Field def buildUtils= loadScript(new File("BuildUtilities.groovy"))
 
 /*
  * Tests if directory is in a local git repository
@@ -25,7 +24,7 @@ def isGitDir(String dir) {
 	if (gitError) {
 		String warningMsg = "*? Warning executing isGitDir($dir). Git command: $cmd error: $gitError"
 		println(warningMsg)
-		buildUtils.updateBuildResult(warningMsg:warningMsg,client:getRepositoryClient())
+		updateBuildResult(warningMsg:warningMsg,client:getRepositoryClient())
 	}
 	else if (gitResponse) {
 		isGit = gitResponse.toString().trim().toBoolean()
@@ -381,8 +380,38 @@ def getChangedProperties(String gitDir, String baseline, String currentHash, Str
 	return changedProperties.propertyNames()
 }
 
+/** helper methods **/
+
 def getRepositoryClient() {
 	if (!repositoryClient && props."dbb.RepositoryClient.url")
 		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
 	return repositoryClient
+}
+
+/*
+ * updateBuildResult - for git cmd related issues
+ */
+def updateBuildResult(Map args) {
+	// args : errorMsg / warningMsg, client:repoClient
+
+	// update build results only in non-userbuild scenarios
+	if (args.client && !props.userBuild) {
+		def buildResult = args.client.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
+		if (!buildResult) {
+			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
+			return
+		}
+		// add error message
+		if (args.errorMsg) {
+			buildResult.setStatus(buildResult.ERROR)
+			buildResult.addProperty("error", args.errorMsg)
+		}
+		// add warning message, but keep result status
+		if (args.warningMsg) {
+			// buildResult.setStatus(buildResult.WARNING)
+			buildResult.addProperty("warning", args.warningMsg)
+		}
+		// save result
+		buildResult.save()
+	}
 }

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -5,6 +5,7 @@ import com.ibm.dbb.build.*
 import groovy.transform.*
 
 @Field BuildProperties props = BuildProperties.getInstance()
+@Field RepositoryClient repositoryClient
 
 /*
  * Tests if directory is in a local git repository


### PR DESCRIPTION
This implements #202 to mark the DBB build as failed, when a conflict is detected on the calculation of changed files  - the git diff. Build report is updated accordingly.

Sample output:

```
*** Baseline hash for directory MortgageApplication retrieved from overwrite.
** Storing MortgageApplication : abc
** Calculating changed files for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication
** Diffing baseline abc -> current bf9207b11f3b3c7152946ae79484210710f84657
*! Error executing Git command: git -C /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication --no-pager diff --name-status abc bf9207b11f3b3c7152946ae79484210710f84657 error: fatal: ambiguous argument 'abc': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
 
 *! Attempting to parse unstable git command for changed files...
*** Changed files for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication :
*** Deleted files for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication :
*** Renamed files for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication :
** Updating collections MortgageApplication-202-fail-build-on-git-error and MortgageApplication-202-fail-build-on-git-error-outputs
** Storing 0 logical files in repository collection 'MortgageApplication-202-fail-build-on-git-error'
HTTP/1.1 200 OK
*** Perform impacted analysis for changed files.
** Calculation of impacted files by changed properties has been skipped due to configuration. 
*** Calculate and document concurrent changes.
***  Analysing and validating changes for branch main .
** Getting current hash for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication
** Storing MortgageApplication : bf9207b11f3b3c7152946ae79484210710f84657
** Calculating changed files for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication
*** Changed files for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication in configuration main:
**** MortgageApplication/cobol/epscmort.cbl
*** Deleted files for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication in configuration main:
*** Renamed files for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication in configuration main:
** Writing report of concurrent changes to /u/ibmuser/test-zapp-app-out/mortgageout/build.20220331.011733.017/report_concurrentChanges.txt for configuration main
 Changed: MortgageApplication/cobol/epscmort.cbl
** Writing build list file to /u/ibmuser/test-zapp-app-out/mortgageout/build.20220331.011733.017/buildList.txt
*! No files in build list.  Nothing to do.
*** Obtaining hash for directory /u/ibmuser/test-zapp/dbb-zappbuild/samples/MortgageApplication
** Setting property :githash:MortgageApplication : bf9207b11f3b3c7152946ae79484210710f84657
** Setting property :giturl:MortgageApplication : https://github.com/dennis-behm/dbb-zappbuild.git
** Setting property :gitchangedfiles:MortgageApplication : https://github.com/ibm/dbb-zappbuild/compare/5bc138f66214165e8fe69f214f403287d83aab44..bf9207b11f3b3c7152946ae79484210710f84657
** Writing build report data to /u/ibmuser/test-zapp-app-out/mortgageout/build.20220331.011733.017/BuildReport.json
** Writing build report to /u/ibmuser/test-zapp-app-out/mortgageout/build.20220331.011733.017/BuildReport.html
** Updating build result BuildGroup:MortgageApplication-202-fail-build-on-git-error BuildLabel:build.20220331.011733.017 at https://10.3.20.96:10443/dbb/rest/buildResult/92363
** Build ended at Thu Mar 31 13:17:38 GMT+01:00 2022
** Build State : ERROR
** Total files processed : 0
** Total build time  : 4.130 seconds

```


Couple of comments:
* I had to duplicate the update build result method, while it caused a recursion when pulling in the build utilities.

