### PR TITLE
Replace usage of evaluate with string parsing

### DIFF
--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -83,13 +83,13 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # cobol_linkEditSyslibConcatenation=
 
-# cobol_dependenciesAlternativeLibraryNameMapping - an *optional* map to define target dataset definition for alternate include libraries
+# cobol_dependenciesAlternativeLibraryNameMapping - an *optional* JSON String of a map defining the target dataset definition for alternate include libraries
 #  this property is used to 
 #   * copy files the to mapped dataset definition (PLEASE NOTE! This setting takes precendence over cobol_dependenciesDatasetMapping)
 #   * defining additional allocations in the compile step
 #
 #  note that the SYSLIB is defaulted to the dataset definition 'cobol_cpyPDS' and is not required to be set here
-#  sample: cobol_dependenciesAlternativeLibraryNameMapping = [MYFILE: 'cobol_myfilePDS', DCLGEN : 'cobol_dclgenPDS']
+#  sample: cobol_dependenciesAlternativeLibraryNameMapping = {"MYFILE": "cobol_myfilePDS", "DCLGEN" : "cobol_dclgenPDS"}
 cobol_dependenciesAlternativeLibraryNameMapping=
 
 # cobol_dependenciesDatasetMapping - an optional dbb property mapping to map dependencies to different target datasets

--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -70,12 +70,12 @@ dbb.DependencyScanner.languageHint=PLI :: **/*.pli, **/*.inc, **/*.cpy
 # additional libraries for linkEdit SYSLIB concatenation, comma-separated, see definitions in application-conf
 # pli_linkEditSyslibConcatenation=
 
-# pli_dependenciesAlternativeLibraryNameMapping - an *optional* map to define target dataset definition for alternate include libraries
+# pli_dependenciesAlternativeLibraryNameMapping -  an *optional* JSON String of a map defining the target dataset definition for alternate include libraries
 #  this property is used to 
 #   * copy files the to mapped dataset definition (this setting takes precendence over pli_dependenciesDatasetMapping)
 #   * defining additional allocations in the compile step
 #  note that the SYSLIB is defaulted to the dataset definition 'pli_cpyPDS' and is not required to be set here
-#  sample: pli_dependenciesAlternativeLibraryNameMapping = [MYFILE: 'pli_myfilePDS', DCLGEN : 'pli_dclgenPDS']
+#  sample: pli_dependenciesAlternativeLibraryNameMapping = {"MYFILE": "pli_myfilePDS", "DCLGEN" : "pli_dclgenPDS"}
 pli_dependenciesAlternativeLibraryNameMapping=
 
 # pli_dependenciesDatasetMapping - an optional dbb property mapping to map dependencies to different target datasets

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -255,7 +255,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 
 	// adding alternate library definitions
 	if (props.cobol_dependenciesAlternativeLibraryNameMapping) {
-		alternateLibraryNameAllocations = evaluate(props.cobol_dependenciesAlternativeLibraryNameMapping)
+		alternateLibraryNameAllocations = buildUtils.parseStringToMap(props.cobol_dependenciesAlternativeLibraryNameMapping)
 		alternateLibraryNameAllocations.each { libraryName, datasetDSN ->
 			datasetDSN = props.getProperty(datasetDSN)
 			if (datasetDSN) compile.dd(new DDStatement().name(libraryName).dsn(datasetDSN).options("shr"))

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -255,7 +255,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 
 	// adding alternate library definitions
 	if (props.cobol_dependenciesAlternativeLibraryNameMapping) {
-		alternateLibraryNameAllocations = buildUtils.parseStringToMap(props.cobol_dependenciesAlternativeLibraryNameMapping)
+		alternateLibraryNameAllocations = buildUtils.parseJSONStringToMap(props.cobol_dependenciesAlternativeLibraryNameMapping)
 		alternateLibraryNameAllocations.each { libraryName, datasetDefinition ->
 			datasetName = props.getProperty(datasetDefinition)
 			if (datasetName) {

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -256,9 +256,17 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	// adding alternate library definitions
 	if (props.cobol_dependenciesAlternativeLibraryNameMapping) {
 		alternateLibraryNameAllocations = buildUtils.parseStringToMap(props.cobol_dependenciesAlternativeLibraryNameMapping)
-		alternateLibraryNameAllocations.each { libraryName, datasetDSN ->
-			datasetDSN = props.getProperty(datasetDSN)
-			if (datasetDSN) compile.dd(new DDStatement().name(libraryName).dsn(datasetDSN).options("shr"))
+		alternateLibraryNameAllocations.each { libraryName, datasetDefinition ->
+			datasetName = props.getProperty(datasetDefinition)
+			if (datasetName) {
+				compile.dd(new DDStatement().name(libraryName).dsn(datasetName).options("shr"))
+			}
+			else {
+				String errorMsg = "*! Cobol.groovy. The dataset definition $datasetDefinition could not be resolved from the DBB Build properties."
+				println(errorMsg)
+				props.error = "true"
+				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+			}
 		}
 	}
 	

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -240,9 +240,17 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	// adding alternate library definitions
 	if (props.cobol_dependenciesAlternativeLibraryNameMapping) {
 		alternateLibraryNameAllocations = buildUtils.parseStringToMap(props.pli_dependenciesAlternativeLibraryNameMapping)
-		alternateLibraryNameAllocations.each { libraryName, datasetDSN ->
-			datasetDSN = props.getProperty(datasetDSN)
-			if (datasetDSN) compile.dd(new DDStatement().name(libraryName).dsn(datasetDSN).options("shr"))
+		alternateLibraryNameAllocations.each { libraryName, datasetDefinition ->
+			datasetName = props.getProperty(datasetDefinition)
+			if (datasetName) {
+				compile.dd(new DDStatement().name(libraryName).dsn(datasetName).options("shr"))
+			}
+			else {
+				String errorMsg = "*! PLI.groovy. The dataset definition $datasetDefinition could not be resolved from the DBB Build properties."
+				println(errorMsg)
+				props.error = "true"
+				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+			}
 		}
 	}
 		

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -239,7 +239,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 
 	// adding alternate library definitions
 	if (props.cobol_dependenciesAlternativeLibraryNameMapping) {
-		alternateLibraryNameAllocations = buildUtils.parseStringToMap(props.pli_dependenciesAlternativeLibraryNameMapping)
+		alternateLibraryNameAllocations = buildUtils.parseJSONStringToMap(props.pli_dependenciesAlternativeLibraryNameMapping)
 		alternateLibraryNameAllocations.each { libraryName, datasetDefinition ->
 			datasetName = props.getProperty(datasetDefinition)
 			if (datasetName) {

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -239,7 +239,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 
 	// adding alternate library definitions
 	if (props.cobol_dependenciesAlternativeLibraryNameMapping) {
-		alternateLibraryNameAllocations = evaluate(props.pli_dependenciesAlternativeLibraryNameMapping)
+		alternateLibraryNameAllocations = buildUtils.parseStringToMap(props.pli_dependenciesAlternativeLibraryNameMapping)
 		alternateLibraryNameAllocations.each { libraryName, datasetDSN ->
 			datasetDSN = props.getProperty(datasetDSN)
 			if (datasetDSN) compile.dd(new DDStatement().name(libraryName).dsn(datasetDSN).options("shr"))

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -756,9 +756,11 @@ def parseStringToMap(String buildProperty) {
 		// remove trailing brackets
 		if (props.cobol_dependenciesAlternativeLibraryNameMapping.take(1) == "[")  tempMappingString = tempMappingString.substring(1)
 		if (props.cobol_dependenciesAlternativeLibraryNameMapping.takeRight(1) == "]")  tempMappingString = tempMappingString.substring(0, tempMappingString.length() - 1)
-		// remove whitespaces
+		// remove whitespaces, single and double quotes
 		tempMappingString = tempMappingString.replaceAll(" ","")
-
+		tempMappingString = tempMappingString.replaceAll("\'","")
+		tempMappingString = tempMappingString.replaceAll("\"","")
+		
 		// split by comma
 		tempMappingString.split(",").each{ keyValuePair ->
 			// split by :

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -754,8 +754,8 @@ def parseStringToMap(String buildProperty) {
 	tempMappingString = buildProperty
 	try {
 		// remove trailing brackets
-		if (props.cobol_dependenciesAlternativeLibraryNameMapping.take(1) == "[")  tempMappingString = tempMappingString.substring(1)
-		if (props.cobol_dependenciesAlternativeLibraryNameMapping.takeRight(1) == "]")  tempMappingString = tempMappingString.substring(0, tempMappingString.length() - 1)
+		if (tempMappingString.take(1) == "[")  tempMappingString = tempMappingString.substring(1)
+		if (tempMappingString.takeRight(1) == "]")  tempMappingString = tempMappingString.substring(0, tempMappingString.length() - 1)
 		// remove whitespaces, single and double quotes
 		tempMappingString = tempMappingString.replaceAll(" ","")
 		tempMappingString = tempMappingString.replaceAll("\'","")


### PR DESCRIPTION
For the transforming the dependenciesAlternativeLibraryNameMapping to proper maps, the evaluate method was used, which is a security concern. This is replaced with some simple string parsing.