### PR TITLE
Correction PSBgen script

### DIFF
--- a/languages/PSBgen.groovy
+++ b/languages/PSBgen.groovy
@@ -221,7 +221,7 @@ def createACBgenCommand(String buildFile, String member, File logFile) {
 
 	// retrieve target pds and deploytype
 	String acbgen_loadPDS = props.getFileProperty('acbgen_loadPDS', buildFile)
-	String deployType = buildUtils.getDeployType("acbgen", buildFile, logicalFile)
+	String deployType = buildUtils.getDeployType("acbgen", buildFile, null)
 	acbgen.dd(new DDStatement().name("IMSACB").dsn("${acbgen_loadPDS}").options('shr').output(true).deployType(deployType))
 
 	// addional allocations


### PR DESCRIPTION
Minor cosmetics on obtaining the deployType for acbgen. Rather than passing an undefined variable `logicalFile`, be more specific and pass `null`. 

closes #222