### PR TITLE
Correction when loading individual file properties 

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -554,8 +554,10 @@ def createBuildList() {
 	}
 	
 	// Loading file/member level properties from member specific properties files
-	println "** Populate file level properties from individual property files."
-	buildUtils.loadFileLevelPropertiesFromFile(buildList)
+	if (props.filePropertyValueKeySet().getAt("loadFileLevelProperties") || props.loadFileLevelProperties) {
+		println "** Populating file level properties from individual property files."
+		buildUtils.loadFileLevelPropertiesFromFile(buildList)
+	}
 
 	return [buildList, deleteList]
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -782,7 +782,8 @@ def loadFileLevelPropertiesFromFile(List<String> buildList) {
 	buildList.each { String buildFile ->
 
 		// check for file level overwrite
-		if (props.getFileProperty('loadFileLevelProperties', buildFile).toBoolean()) {
+		loadFileLevelProperties = props.getFileProperty('loadFileLevelProperties', buildFile)
+		if (loadFileLevelProperties && loadFileLevelProperties.toBoolean()) {
 
 			String member = new File(buildFile).getName()
 			String propertyFilePath = props.getFileProperty('propertyFilePath', buildFile)


### PR DESCRIPTION
During the release preparation, we noticed a problem with applications with an existing application-conf configuration that do not define the `loadFileLevelProperties` build property. This led to a NullPointerException.

The logic was extended to capture this scenario.

Multiple manual tests were performed to validate:
* `loadFileLevelProperties` not defined at all (the above scenario with an NPE).
* `loadFileLevelProperties` only set as a global property
* `loadFileLevelProperties` only defined as a file-level property
* `loadFileLevelProperties` set as a global property and as a file-level property

