### PR TITLE
Removal of hard coded library name in Assembler.groovy

### DIFF
--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -308,8 +308,7 @@ def createAssemblerCommand(String buildFile, LogicalFile logicalFile, String mem
 		assembler.dd(new DDStatement().dsn(props.MODGEN).options("shr"))
 	if (buildUtils.isCICS(logicalFile))
 		assembler.dd(new DDStatement().dsn(props.SDFHMAC).options("shr"))
-	if (buildUtils.isSQL(logicalFile))
-		assembler.dd(new DDStatement().dsn("DBC0CFG.DB2.V12.SDSNSAMP").options("shr"))
+	//if (buildUtils.isSQL(logicalFile))
 	if (props.SDFSMAC)
 		assembler.dd(new DDStatement().dsn(props.SDFSMAC).options("shr"))
 


### PR DESCRIPTION
The `assembler.groovy` language script contained a hard coded library name, which was used to pull in a macro from a sample library for one of our Assembler test programs. 

The section was removed + commented out. Users should rather use the `assembler_assemblySyslibConcatenation` to provide a custom syslib concatenation.

I am not aware (and have not found) that a specific library needs to be passed to the assembler compiler for asm/db2 programs.