### PR TITLE
Updated zAppBuild test framework

### DIFF
--- a/test/applications/MortgageApplication/application-conf/Cobol.properties
+++ b/test/applications/MortgageApplication/application-conf/Cobol.properties
@@ -11,6 +11,11 @@ cobol_fileBuildRank=
 cobol_resolutionRules=[${copybookRule}]
 
 #
+# COBOL dependencySearch configuration
+# searchPath defined in application.properties
+cobol_dependencySearch=${copybookSearch}
+
+#
 # default COBOL compiler version
 # can be overridden by file properties
 cobol_compilerVersion=V6
@@ -58,6 +63,12 @@ cobol_linkDebugExit=    INCLUDE OBJECT(@{member})  \n    INCLUDE SYSLIB(EQAD3CXT
 # execute link edit step
 # can be overridden by file properties
 cobol_linkEdit=true
+
+#
+# store abbrev git hash in ssi field
+# available for buildTypes impactBuild, mergeBuild and fullBuild 
+# can be overridden by file properties
+cobol_storeSSI=true 
 
 #
 # default deployType

--- a/test/applications/MortgageApplication/build-conf/impactBuildDeletion.properties
+++ b/test/applications/MortgageApplication/build-conf/impactBuildDeletion.properties
@@ -1,0 +1,1 @@
+documentDeleteRecords=true

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -4,7 +4,7 @@
 #
 # list of test scripts to run for this application
 #  the order of the list matters
-test_testOrder=resetBuild.groovy,mergeBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_properties.groovy,impactBuild_renaming.groovy,resetBuild.groovy
+test_testOrder=resetBuild.groovy,mergeBuild.groovy,fullBuild.groovy,impactBuild.groovy,impactBuild_properties.groovy,impactBuild_renaming.groovy,impactBuild_deletion.groovy,resetBuild.groovy
 
 
 ###############################

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -76,3 +76,16 @@ impactBuild_properties_buildPropSetting = build-conf/impactPropertyChanges.prope
 impactBuild_properties_expectedFilesBuilt = epscmort.cbl,epscsmrd.cbl,epscsmrt.cbl,epsmlist.cbl,epsmpmt.cbl,epsnbrvl.cbl :: application-conf/Cobol.properties
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_properties_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
+
+
+###############################
+# impactBuild_deletion.groovy properties
+###############################
+# build properties to overwrite a set of options to enable test scenario in test framework
+impactBuild_deletion_buildPropSetting = build-conf/impactBuildDeletion.properties
+# deleted source files to test impact builds
+impactBuild_deletion_deleteFiles = cobol/epscmort.cbl
+# expected files deleted
+impactBuild_deletion_deletedOutputs = LOAD(EPSCMORT),DBRM(EPSCMORT) :: cobol/epscmort.cbl
+# list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
+impactBuild_deletion_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -86,6 +86,6 @@ impactBuild_deletion_buildPropSetting = build-conf/impactBuildDeletion.propertie
 # deleted source files to test impact builds
 impactBuild_deletion_deleteFiles = cobol/epscmort.cbl
 # expected files deleted
-impactBuild_deletion_deletedOutputs = LOAD(EPSCMORT),DBRM(EPSCMORT) :: cobol/epscmort.cbl
+impactBuild_deletion_deletedOutputs = LOAD(EPSCMORT) :: cobol/epscmort.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_deletion_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT

--- a/test/test.groovy
+++ b/test/test.groovy
@@ -11,6 +11,9 @@ BuildProperties props = loadBuildProperties(args)
 // create a test branch to run under
 createTestBranch(props)
 
+// flag to control test process
+props.testsSucceeded = 'true'
+
 // run the test scripts
 try {
 	if (props.test_testOrder) {
@@ -30,6 +33,15 @@ try {
 finally {
 	// delete test branch
 	deleteTestBranch(props)
+	
+	// if error occurred signal process error
+	if (props.testsSucceeded.toBoolean() == false) {
+		println("*! Not all test scripts completed successfully. Please check console outputs. Send exit signal.")
+		System.exit(1)
+	} else {
+		println("* ZAPPBUILD TESTFRAMEWORK COMPLETED. All tests (${props.test_testOrder}) completed successfully.")
+	}
+	
 }
 // end script
 

--- a/test/testScripts/fullBuild.groovy
+++ b/test/testScripts/fullBuild.groovy
@@ -37,6 +37,8 @@ process.waitForProcessOutput(outputStream, System.err)
 println "** Validating full build results"
 def expectedFilesBuiltList = props.fullBuild_expectedFilesBuilt.split(',')
 
+@Field def assertionList = []
+
 try {
 	// Validate clean build
 	assert outputStream.contains("Build State : CLEAN") : "*! FULL BUILD FAILED\nOUTPUT STREAM:\n$outputStream\n"
@@ -52,8 +54,21 @@ try {
 	println "** FULL BUILD TEST : PASSED **"
 	println "**"
 }
+catch(AssertionError e) {
+	def result = e.getMessage()
+	assertionList << result;
+	props.testsSucceeded = false
+}
 finally {
 	cleanUpDatasets()
+	if (assertionList.size()>0) {
+		println "\n***"
+	println "**START OF FAILED FULL BUILD TEST RESULTS**\n"
+	println "*FAILED FULL BUILD RESULTS*\n" + assertionList
+	println "\n**END OF FAILED FULL BUILD **"
+	println "***"
+  }
+	
 }
 
 // script end

--- a/test/testScripts/impactBuild.groovy
+++ b/test/testScripts/impactBuild.groovy
@@ -102,6 +102,7 @@ def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings,
     catch(AssertionError e) {
         def result = e.getMessage()
         assertionList << result;
+		props.testsSucceeded = false
  }
 }
 def cleanUpDatasets() {

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -85,7 +85,7 @@ def deleteAndCommit(String deleteFile) {
 	task.waitForProcessOutput(outputStream, System.err)
 }
 
-def validateImpactBuild(String deleteFile, PropertyMappings outputsDeletedMappings. StringBuffer outputStream) {
+def validateImpactBuild(String deleteFile, PropertyMappings outputsDeletedMappings, StringBuffer outputStream) {
 
 	println "** Validating impact build results"
 	def expectedDeletedFilesList = filesBuiltMappings.getValue(deleteFile).split(',')
@@ -104,12 +104,12 @@ def validateImpactBuild(String deleteFile, PropertyMappings outputsDeletedMappin
 		assert outputStream.contains("** Create deletion record for file") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND CREATION OF DELETE RECORD\nOUTPUT STREAM:\n$outputStream\n"
 		
 		expectedDeletedFilesList.each { deletedOutput ->
-		
-		assert outputStream.contains("** Document deletion ${props.hlq}.${deletedOutput} for file") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND CREATION OF DELETE RECORD\nOUTPUT STREAM:\n$outputStream\n"
-		
-		// Validate deletion of output
-		assert outputStream.contains("** Deleting ${props.hlq}.${deletedOutput}" : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND DELETION OF LOAD MODULE\nOUTPUT STREAM:\n$outputStream\n"
-		
+
+			assert outputStream.contains("** Document deletion ${props.hlq}.${deletedOutput} for file") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND CREATION OF DELETE RECORD\nOUTPUT STREAM:\n$outputStream\n"
+
+			// Validate deletion of output
+			assert outputStream.contains("** Deleting ${props.hlq}.${deletedOutput}" : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND DELETION OF LOAD MODULE\nOUTPUT STREAM:\n$outputStream\n"
+
 		}
 		println "**"
 		println "** IMPACT BUILD TEST - FILE DELETE : PASSED FOR DELETING $deleteFile **"

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -74,8 +74,8 @@ try {
 				
 		// run impact build
 		println "** Executing ${impactBuildCommand.join(" ")}"
-		def outputStream = new StringBuffer()
-		def process = [
+		outputStream = new StringBuffer()
+		process = [
 			'bash',
 			'-c',
 			impactBuildCommand.join(" ")

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -1,0 +1,134 @@
+
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+import com.ibm.dbb.*
+import com.ibm.dbb.build.*
+import com.ibm.jzos.ZFile
+
+@Field BuildProperties props = BuildProperties.getInstance()
+println "\n** Executing test script impactBuild_deletion.groovy"
+
+// Get the DBB_HOME location
+def dbbHome = EnvVars.getHome()
+if (props.verbose) println "** DBB_HOME = ${dbbHome}"
+
+// create impact build command
+def impactBuildCommand = []
+impactBuildCommand << "${dbbHome}/bin/groovyz"
+impactBuildCommand << "${props.zAppBuildDir}/build.groovy"
+impactBuildCommand << "--workspace ${props.workspace}"
+impactBuildCommand << "--application ${props.app}"
+impactBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+impactBuildCommand << "--hlq ${props.hlq}"
+impactBuildCommand << "--logEncoding UTF-8"
+impactBuildCommand << "--url ${props.url}"
+impactBuildCommand << "--id ${props.id}"
+impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+impactBuildCommand << "--verbose"
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_deletion_buildPropSetting}" : "")
+impactBuildCommand << "--impactBuild"
+
+// iterate through change files to test impact build
+@Field def assertionList = []
+
+PropertyMappings outputsDeletedMappings = new PropertyMappings('impactBuild_deletion_deletedOutputs')
+
+
+def deleteFiles = props.impactBuild_deletion_deleteFiles.split(',')
+try {
+	deleteFiles.each{ deleteFile ->
+		
+		// delete file in Git repo test branch
+		deleteAndCommit(deleteFile)
+
+		println "\n** Running impact after deleting file $deleteFile"
+				
+		// run impact build
+		println "** Executing ${impactBuildCommand.join(" ")}"
+		def outputStream = new StringBuffer()
+		def process = [
+			'bash',
+			'-c',
+			impactBuildCommand.join(" ")
+		].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+
+		// validate build results
+		validateImpactBuild(deleteFile, outputsDeletedMappings, outputStream)
+	}
+}
+finally {
+	cleanUpDatasets()
+	if (assertionList.size()>0) {
+		println "\n***"
+		println "**START OF FAILED IMPACT BUILD TEST RESULTS**\n"
+		println "*FAILED IMPACT BUILD TEST RESULTS*\n" + assertionList
+		println "\n**END OF FAILED IMPACT BUILD TEST RESULTS**"
+		println "***"
+	}
+}
+// script end
+
+//*************************************************************
+// Method Definitions
+//*************************************************************
+
+def deleteAndCommit(String deleteFile) {
+	println "** Delete $deleteFile"
+	def commands = """
+	rm ${props.appLocation}/${deleteFile}
+	git -C ${props.appLocation} add .
+	git -C ${props.appLocation} commit . -m "delete file"
+"""
+	def task = ['bash', '-c', commands].execute()
+	def outputStream = new StringBuffer();
+	task.waitForProcessOutput(outputStream, System.err)
+}
+
+def validateImpactBuild(String deleteFile, PropertyMappings outputsDeletedMappings. StringBuffer outputStream) {
+
+	println "** Validating impact build results"
+	def expectedDeletedFilesList = filesBuiltMappings.getValue(deleteFile).split(',')
+	
+	try{
+		def memberName = CopyToPDS.createMemberName(deleteFile)
+		
+		
+		// Validate clean build
+		assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $deleteFile\nOUTPUT STREAM:\n$outputStream\n"
+
+		// Validate message that deleted file was deleted from collections
+		assert outputStream.contains("*** Deleting renamed logical file for ${props.app}/${deleteFile}") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
+		
+		// Validate creation of the Delete Record 
+		assert outputStream.contains("** Create deletion record for file") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND CREATION OF DELETE RECORD\nOUTPUT STREAM:\n$outputStream\n"
+		
+		expectedDeletedFilesList.each { deletedOutput ->
+		
+		assert outputStream.contains("** Document deletion ${props.hlq}.${deletedOutput} for file") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND CREATION OF DELETE RECORD\nOUTPUT STREAM:\n$outputStream\n"
+		
+		// Validate deletion of output
+		assert outputStream.contains("** Deleting ${props.hlq}.${deletedOutput}" : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND DELETION OF LOAD MODULE\nOUTPUT STREAM:\n$outputStream\n"
+		
+		}
+		println "**"
+		println "** IMPACT BUILD TEST - FILE DELETE : PASSED FOR DELETING $deleteFile **"
+		println "**"
+	}
+	catch(AssertionError e) {
+		def result = e.getMessage()
+		assertionList << result;
+	}
+}
+def cleanUpDatasets() {
+	def segments = props.impactBuild_deletion_datasetsToCleanUp.split(',')
+
+	println "Deleting impact build PDSEs ${segments}"
+	segments.each { segment ->
+		def pds = "'${props.hlq}.${segment}'"
+		if (ZFile.dsExists(pds)) {
+			if (props.verbose) println "** Deleting ${pds}"
+			ZFile.remove("//$pds")
+		}
+	}
+}

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -12,6 +12,22 @@ println "\n** Executing test script impactBuild_deletion.groovy"
 def dbbHome = EnvVars.getHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
+// Create full build command to set baseline and populate output libraries
+def fullBuildCommand = []
+fullBuildCommand << "${dbbHome}/bin/groovyz"
+fullBuildCommand << "${props.zAppBuildDir}/build.groovy"
+fullBuildCommand << "--workspace ${props.workspace}"
+fullBuildCommand << "--application ${props.app}"
+fullBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+fullBuildCommand << "--hlq ${props.hlq}"
+fullBuildCommand << "--logEncoding UTF-8"
+fullBuildCommand << "--url ${props.url}"
+fullBuildCommand << "--id ${props.id}"
+fullBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+fullBuildCommand << (props.verbose ? "--verbose" : "")
+fullBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_deletion_buildPropSetting}" : "")
+fullBuildCommand << "--fullBuild"
+
 // create impact build command
 def impactBuildCommand = []
 impactBuildCommand << "${dbbHome}/bin/groovyz"
@@ -36,6 +52,19 @@ PropertyMappings outputsDeletedMappings = new PropertyMappings('impactBuild_dele
 
 def deleteFiles = props.impactBuild_deletion_deleteFiles.split(',')
 try {
+	
+	println "\n** Running full build to set baseline"
+
+	// run impact build
+	println "** Executing ${fullBuildCommand.join(" ")}"
+	def outputStream = new StringBuffer()
+	def process = [
+		'bash',
+		'-c',
+		fullBuildCommand.join(" ")
+	].execute()
+	process.waitForProcessOutput(outputStream, System.err)
+	
 	deleteFiles.each{ deleteFile ->
 		
 		// delete file in Git repo test branch

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -61,9 +61,9 @@ finally {
 	cleanUpDatasets()
 	if (assertionList.size()>0) {
 		println "\n***"
-		println "**START OF FAILED IMPACT BUILD TEST RESULTS**\n"
+		println "**START OF FAILED IMPACT BUILD TEST RESULTS FOR FILE DELETION**\n"
 		println "*FAILED IMPACT BUILD TEST RESULTS*\n" + assertionList
-		println "\n**END OF FAILED IMPACT BUILD TEST RESULTS**"
+		println "\n**END OF FAILED IMPACT BUILD TEST RESULTS FOR FILE DELETION**"
 		println "***"
 	}
 }
@@ -98,17 +98,17 @@ def validateImpactBuild(String deleteFile, PropertyMappings outputsDeletedMappin
 		assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $deleteFile\nOUTPUT STREAM:\n$outputStream\n"
 
 		// Validate message that deleted file was deleted from collections
-		assert outputStream.contains("*** Deleting renamed logical file for ${props.app}/${deleteFile}") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
+		assert outputStream.contains("*** Deleting logical file for ${props.app}/${deleteFile}") : "*! IMPACT BUILD FOR DELETION OF $deleteFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
 		
 		// Validate creation of the Delete Record 
 		assert outputStream.contains("** Create deletion record for file") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND CREATION OF DELETE RECORD\nOUTPUT STREAM:\n$outputStream\n"
 		
 		expectedDeletedFilesList.each { deletedOutput ->
 
-			assert outputStream.contains("** Document deletion ${props.hlq}.${deletedOutput} for file") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND CREATION OF DELETE RECORD\nOUTPUT STREAM:\n$outputStream\n"
+			assert outputStream.contains("** Document deletion ${props.hlq}.${deletedOutput} for file") : "*! IMPACT BUILD FOR DELETION OF $deleteFile DO NOT FIND CREATION OF DELETE RECORD\nOUTPUT STREAM:\n$outputStream\n"
 
 			// Validate deletion of output
-			assert outputStream.contains("** Deleting ${props.hlq}.${deletedOutput}") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND DELETION OF LOAD MODULE\nOUTPUT STREAM:\n$outputStream\n"
+			assert outputStream.contains("** Deleting ${props.hlq}.${deletedOutput}") : "*! IMPACT BUILD FOR DELETION OF $deleteFile DO NOT FIND DELETION OF LOAD MODULE\nOUTPUT STREAM:\n$outputStream\n"
 
 		}
 		println "**"

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -108,7 +108,7 @@ def validateImpactBuild(String deleteFile, PropertyMappings outputsDeletedMappin
 			assert outputStream.contains("** Document deletion ${props.hlq}.${deletedOutput} for file") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND CREATION OF DELETE RECORD\nOUTPUT STREAM:\n$outputStream\n"
 
 			// Validate deletion of output
-			assert outputStream.contains("** Deleting ${props.hlq}.${deletedOutput}" : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND DELETION OF LOAD MODULE\nOUTPUT STREAM:\n$outputStream\n"
+			assert outputStream.contains("** Deleting ${props.hlq}.${deletedOutput}") : "*! IMPACT BUILD FOR $deleteFile DO NOT FIND DELETION OF LOAD MODULE\nOUTPUT STREAM:\n$outputStream\n"
 
 		}
 		println "**"

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -88,7 +88,7 @@ def deleteAndCommit(String deleteFile) {
 def validateImpactBuild(String deleteFile, PropertyMappings outputsDeletedMappings, StringBuffer outputStream) {
 
 	println "** Validating impact build results"
-	def expectedDeletedFilesList = filesBuiltMappings.getValue(deleteFile).split(',')
+	def expectedDeletedFilesList = outputsDeletedMappings.getValue(deleteFile).split(',')
 	
 	try{
 		def memberName = CopyToPDS.createMemberName(deleteFile)

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -126,6 +126,7 @@ def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings,
 	catch(AssertionError e) {
 		def result = e.getMessage()
 		assertionList << result;
+		props.testsSucceeded = false
  }
 }
 def cleanUpDatasets() {

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -41,7 +41,7 @@ impactBuildCommand << "--url ${props.url}"
 impactBuildCommand << "--id ${props.id}"
 impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 impactBuildCommand << (props.verbose ? "--verbose" : "")
-impactBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}" : "")
 impactBuildCommand << "--impactBuild"
 
 // iterate through change files to test impact build

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -25,7 +25,7 @@ fullBuildCommand << "--url ${props.url}"
 fullBuildCommand << "--id ${props.id}"
 fullBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 fullBuildCommand << (props.verbose ? "--verbose" : "")
-fullBuildCommand << (props.propFiles ? "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting},${props.propFiles}" : "")
+fullBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}" : "")
 fullBuildCommand << "--fullBuild"
 
 // create impact build command

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -113,6 +113,7 @@ def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, 
 	catch(AssertionError e) {
 		def result = e.getMessage()
 		assertionList << result;
+		props.testsSucceeded = false
 	}
 }
 def cleanUpDatasets() {

--- a/test/testScripts/mergeBuild.groovy
+++ b/test/testScripts/mergeBuild.groovy
@@ -117,6 +117,7 @@ def validateMergeBuild(String changedFile, PropertyMappings filesBuiltMappings, 
     catch(AssertionError e) {
         def result = e.getMessage()
         assertionList << result;
+		props.testsSucceeded = false
  }
 }
 def cleanUpDatasets() {


### PR DESCRIPTION
This is an enhancement of the test framework to test zAppBuild.

The contributions are:
* New `impactBuild_delete.groovy` test script to validate the ability to document and perform deletions when files are deleted. Requires DBB 1.1.3
* Capture an overall test state across the different test scripts, and prints a Success or Failure message at the end. Process send an exit signal when one test failed.
* Update to `impactBuild_properties` to load property settings in the correct order.