### PR TITLE
DBB 2.0 Support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -136,8 +136,8 @@ build options:
  -re,--reportExternalImpacts  Flag to activate analysis and report of external impacted files within DBB collections
  
 
-web application credentials
- -url,--url <arg>             DBB repository URL
+Db2 MetadataStore configuration options
+ -url,--url <arg>             Db2 URL for the MetadataStore
  -id,--id <arg>               DBB repository id
  -pw,--pw <arg>               DBB repository password
  -pf,--pwFile <arg>           Absolute or relative (from workspace) path to

--- a/BUILD.md
+++ b/BUILD.md
@@ -173,7 +173,7 @@ utility options
 
 Build a single program in the application. 
 
-By leveraging `--userBuild` zAppBuild does not connect to the repositoryClient to the DBB WebApp and also does not store a build result.  
+By leveraging `--userBuild` zAppBuild does not intialize the MetadataStore and also does not store a build result.  
 
 ```
 groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --hlq USER.ZAPP.CLEAN.MASTER --workDir /var/dbb/out/MortgageApplication --application MortgageApplication --logEncoding UTF-8 --userBuild --verbose MortgageApplication/cobol/epsnbrvl.cbl

--- a/BUILD.md
+++ b/BUILD.md
@@ -55,7 +55,7 @@ $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1
 ## Common User Build Invocation Examples
 **Build one program**
 
-Build a single program in a user build context. Does not require a repository client connection to the DBB WebApp.
+Build a single program in a user build context. Does not require use of the MetadataStore (filesystem or Db2)
 ```
 $DBB_HOME/bin/groovyz build.groovy --workspace /u/build/repos --application app1 --outDir /u/build/out --hlq BUILD.APP1 --userBuild app1/cobol/epsmpmt.cbl
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -137,11 +137,11 @@ build options:
  
 
 Db2 MetadataStore configuration options
- -url,--url <arg>             Db2 URL for the MetadataStore
- -id,--id <arg>               DBB repository id
- -pw,--pw <arg>               DBB repository password
- -pf,--pwFile <arg>           Absolute or relative (from workspace) path to
-                              file containing DBB password
+ -url,--url <arg>             Db2 JDBC URL for the MetadataStore.
+                              Example: jdbc:db2:<Db2 server location>
+ -id,--id <arg>               Db2 user id for the MetadataStore
+ -pw,--pw <arg>               Db2 password (encrypted with DBB Password Utility) for the MetadataStore
+ -pf,--pwFile <arg>           Absolute or relative (from workspace) path to file containing Db2 password
 
 IDz/ZOD User Build options
  -u,--userBuild               Flag indicating running a user build

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -50,6 +50,7 @@ generateDb2BindInfoRecord | Flag to control the generation of a generic DBB buil
 dbb.file.tagging | Controls compile log and build report file tagging. Default: true.
 dbb.LinkEditScanner.excludeFilter | DBB configuration property used by the link edit scanner to exclude load module entries
 metadataStoreType | DBB MetadataStore Type configuration property. Valid options are 'file' or 'db2'. Default: file
+metadataStoreFileLocation | DBB File MetadataStore location. Default: $USER
 metadataStoreDb2Url | DBB configuration property for Db2 URL.  ***Can be overridden by build.groovy option -url, --url***
 metadataStoreDb2ConnectionConf | DBB configuration property for Db2 configuration properties file. 
 

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -49,10 +49,10 @@ documentDeleteRecords | Option determine if the build framework should document 
 generateDb2BindInfoRecord | Flag to control the generation of a generic DBB build record for a build file to document the configured db2 bind information (application-conf/bind.properties). Default: false ** Can be overridden by a file property. 
 dbb.file.tagging | Controls compile log and build report file tagging. Default: true.
 dbb.LinkEditScanner.excludeFilter | DBB configuration property used by the link edit scanner to exclude load module entries
-dbb.RepositoryClient.url | DBB configuration property for web application URL.  ***Can be overridden by build.groovy option -url, --url***
-dbb.RepositoryClient.userId | DBB configuration property for web application logon id.  ***Can be overridden by build.groovy option -id, --id***
-dbb.RepositoryClient.password | DBB configuration property for web application logon password.  ***Can be overridden by build.groovy option -pw, --pw***
-dbb.RepositoryClient.passwordFile | DBB configuration property for web application logon password file.  ***Can be overridden by build.groovy option -pf, --pf***
+dbb.metadatastore.db2.url | DBB configuration property for Db2 URL.  ***Can be overridden by build.groovy option -url, --url***
+dbb.metadatastore.db2.userId | DBB configuration property for Db2 user id.  ***Can be overridden by build.groovy option -id, --id***
+dbb.metadatastore.db2.password | DBB configuration property for Db2 logon password (encrypted).  ***Can be overridden by build.groovy option -pw, --pw***
+dbb.metadatastore.db2.passwordFile | DBB configuration property for Db2 logon password file.  ***Can be overridden by build.groovy option -pf, --pf***
 
 ### dependencyReport.properties
 Properties used by the impact utilities to generate a report of external impacted files

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -49,10 +49,9 @@ documentDeleteRecords | Option determine if the build framework should document 
 generateDb2BindInfoRecord | Flag to control the generation of a generic DBB build record for a build file to document the configured db2 bind information (application-conf/bind.properties). Default: false ** Can be overridden by a file property. 
 dbb.file.tagging | Controls compile log and build report file tagging. Default: true.
 dbb.LinkEditScanner.excludeFilter | DBB configuration property used by the link edit scanner to exclude load module entries
-dbb.metadatastore.db2.url | DBB configuration property for Db2 URL.  ***Can be overridden by build.groovy option -url, --url***
-dbb.metadatastore.db2.userId | DBB configuration property for Db2 user id.  ***Can be overridden by build.groovy option -id, --id***
-dbb.metadatastore.db2.password | DBB configuration property for Db2 logon password (encrypted).  ***Can be overridden by build.groovy option -pw, --pw***
-dbb.metadatastore.db2.passwordFile | DBB configuration property for Db2 logon password file.  ***Can be overridden by build.groovy option -pf, --pf***
+metadataStoreType | DBB MetadataStore Type configuration property. Valid options are 'file' or 'db2'. Default: file
+metadataStoreDb2Url | DBB configuration property for Db2 URL.  ***Can be overridden by build.groovy option -url, --url***
+metadataStoreDb2ConnectionConf | DBB configuration property for Db2 configuration properties file. 
 
 ### dependencyReport.properties
 Properties used by the impact utilities to generate a report of external impacted files

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -135,6 +135,7 @@ documentDeleteRecords=false
 # select MetadataStore configuration (either 'file' or 'db2')
 metadataStoreType=file 
 
+# filesystem metadatastore location (if undefined, defaults to user home directory)
 metadataStoreLocation=
 
 # build.groovy option -url, --url

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -133,7 +133,7 @@ documentDeleteRecords=false
 # can be overridden by build.groovy script options
 
 # select MetadataStore configuration (either 'file' or 'db2')
-metadataStoreType=db2
+metadataStoreType=file
 
 # location of file metadata store.  Default is $USER
 #metadataStoreFileLocation=

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -126,11 +126,7 @@ createBuildOutputSubfolder=true
 # Default : false
 documentDeleteRecords=false 
 
-
-
-#
-# default DB2 authentication properties
-# can be overridden by build.groovy script options
+# MetadataStore configuration properties:
 
 # select MetadataStore configuration (either 'file' or 'db2')
 metadataStoreType=file

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -146,20 +146,6 @@ metadataStoreType=file
 # Sample is povided at $DBB_HOME/conf/db2Connection.conf 
 #metadataStoreDb2ConnectionConf=
 
-#### WOULD NOT BE IN THE BUILD PROPERTIES
-# TODO Remove:
-# 
-# build.groovy option -id, --id
-#metadataStoreUserId=
-
-# build.groovy option -pw, --pw
-#dbb.metadatastore.db2.password=
-
-# build.groovy option -pf, --pf
-#dbb.metadatastore.db2.passwordFile=${zAppBuildDir}/utilities/ADMIN.pw
-
-
-# URL, type goes in build.properties
 
 # Use dbb.metadatastore.db2.sslProtocols to specify one or more SSL protocols used
 # to communication between DBB toolkit and server. Use a comma as separator for more

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -135,12 +135,19 @@ documentDeleteRecords=false
 # select MetadataStore configuration (either 'file' or 'db2')
 metadataStoreType=file 
 
-# filesystem metadatastore location (if undefined, defaults to user home directory)
-metadataStoreLocation=
+# location of file metadata store.  Default is $USER
+#metadataStoreFileLocation=
 
+# Db2 metadata server url
 # build.groovy option -url, --url
-metadataStoreUrl=
+#metadataStoreDb2Url=jdbc:db2:<Db2 server location>
+
+# Db2 connection configuration property file
+# Sample is povided at $DBB_HOME/conf/db2Connection.conf 
+#metadataStoreDb2ConnectionConf=
+
 #### WOULD NOT BE IN THE BUILD PROPERTIES
+# TODO Remove:
 # 
 # build.groovy option -id, --id
 #metadataStoreUserId=

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -127,28 +127,38 @@ createBuildOutputSubfolder=true
 documentDeleteRecords=false 
 
 
+
 #
-# default DBB Repository Web Application authentication properties
+# default DB2 authentication properties
 # can be overridden by build.groovy script options
 
-# build.groovy option -url, --url
-dbb.RepositoryClient.url=
+# select MetadataStore configuration (either 'file' or 'db2')
+metadataStoreType=file 
 
+metadataStoreLocation=
+
+# build.groovy option -url, --url
+metadataStoreUrl=
+#### WOULD NOT BE IN THE BUILD PROPERTIES
+# 
 # build.groovy option -id, --id
-dbb.RepositoryClient.userId=ADMIN
+#metadataStoreUserId=
 
 # build.groovy option -pw, --pw
-dbb.RepositoryClient.password=
+#dbb.metadatastore.db2.password=
 
 # build.groovy option -pf, --pf
-dbb.RepositoryClient.passwordFile=${zAppBuildDir}/utilities/ADMIN.pw
+#dbb.metadatastore.db2.passwordFile=${zAppBuildDir}/utilities/ADMIN.pw
 
-# Use dbb.RepositoryClient.sslProtocols to specify one or more SSL protocols used
+
+# URL, type goes in build.properties
+
+# Use dbb.metadatastore.db2.sslProtocols to specify one or more SSL protocols used
 # to communication between DBB toolkit and server. Use a comma as separator for more
 # than one protocol. Requires toolkit PTF UI72423 or version 1.1.0 or higher
 # examples
-# dbb.RepositoryClient.sslProtocols=TLSv1.2
-# dbb.RepositoryClient.sslProtocols=TLS,TLSv1.2
+# dbb.metadatastore.db2.sslProtocols=TLSv1.2
+# dbb.metadatastore.db2.sslProtocols=TLS,TLSv1.2
 
 # The dbb.gateway.type property determines which gateway type is used for the entire build process
 # Possible values are 'legacy' and 'interactive.  Default if not indicated is 'legacy'

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -133,7 +133,7 @@ documentDeleteRecords=false
 # can be overridden by build.groovy script options
 
 # select MetadataStore configuration (either 'file' or 'db2')
-metadataStoreType=file 
+metadataStoreType=db2
 
 # location of file metadata store.  Default is $USER
 #metadataStoreFileLocation=

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -147,13 +147,6 @@ metadataStoreType=file
 #metadataStoreDb2ConnectionConf=
 
 
-# Use dbb.metadatastore.db2.sslProtocols to specify one or more SSL protocols used
-# to communication between DBB toolkit and server. Use a comma as separator for more
-# than one protocol. Requires toolkit PTF UI72423 or version 1.1.0 or higher
-# examples
-# dbb.metadatastore.db2.sslProtocols=TLSv1.2
-# dbb.metadatastore.db2.sslProtocols=TLS,TLSv1.2
-
 # The dbb.gateway.type property determines which gateway type is used for the entire build process
 # Possible values are 'legacy' and 'interactive.  Default if not indicated is 'legacy'
 dbb.gateway.type=legacy

--- a/build.groovy
+++ b/build.groovy
@@ -131,10 +131,13 @@ def initializeBuildProcess(String[] args) {
 				println("For Db2 MetadataStore, '-pw <password>' or '-pf' <path to password file>' must be passed on the command line. ")
 				System.exit(1)
 			}
-			// Initialize db2 metadatastore
+			// Get password  file or encrypted password
 			def password
 			if (args.pf) 
 				password = new File(pf)
+			else
+				passwrod = args.pw
+			// Initialize Db2 metadatastore
 			metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.url, args.id, password)
 		}
 		else {

--- a/build.groovy
+++ b/build.groovy
@@ -149,7 +149,7 @@ def initializeBuildProcess(String[] args) {
 				
 				// Assert URL property is defined
 				if (!props.metadataStoreDb2Url) {
-					println("For Db2 MetadataStore, '-url jdbc:db2:<Db2 server location>' must be passed on the command line." )
+					println("For Db2 MetadataStore, please define the metadataStoreDb2Url build property or pass '-url jdbc:db2:<Db2 server location>' on the command line." )
 					System.exit(1)
 				}
 				

--- a/build.groovy
+++ b/build.groovy
@@ -688,8 +688,7 @@ def finalizeBuildProcess(Map args) {
 		buildResult.setProperty("filesProcessed", String.valueOf(args.count))
 		buildResult.setState(buildResult.COMPLETE)
 
-		// save updates
-		//buildResult.save()
+
 
 		// store build result properties in BuildReport.json
 		PropertiesRecord buildReportRecord = new PropertiesRecord("DBB.BuildResultProperties")
@@ -730,11 +729,13 @@ def finalizeBuildProcess(Map args) {
 	// print end build message
 	def endTime = new Date()
 	def duration = TimeCategory.minus(endTime, args.start)
-	def state = (props.error) ? "ERROR" : "CLEAN"
-	println("** Build ended at $endTime")
-	println("** Build State : $state")
-	println("** Total files processed : ${args.count}")
-	println("** Total build time  : $duration\n")
+	buildResult.setProperty("buildDuration", duration.toString())
+	println(buildResult)
+	//def state = (props.error) ? "ERROR" : "CLEAN"
+	// println("** Build ended at $endTime")
+	// println("** Build State : $state")
+	// println("** Total files processed : ${args.count}")
+	// println("** Total build time  : $duration\n")
 }
 
 

--- a/build.groovy
+++ b/build.groovy
@@ -115,8 +115,34 @@ def initializeBuildProcess(String[] args) {
 
 	// create metadata store for this script
 	if (!props.userBuild) {
-		metadataStore = MetadataStoreFactory.createFileMetadataStore();
-		println "** MetadataStore initialized"
+		if (props.metadataStoreType == 'file')
+			metadataStore = MetadataStoreFactory.createFileMetadataStore(props.metadataStoreLocation)
+		else if (props.metadataStoreType == 'db2') {
+			// Assert required properties exist
+			if (!args.url) {
+				println("For Db2 MetadataStore, '-url <url> must be passed on the command line." )
+				System.exit(1)
+			}
+			if (!args.id) {
+				println("For Db2 MetadataStore, '-id <user id>' must be passed on the command line. ")
+				System.exit(1)
+			}
+			if (!args.pw || !args.pf) {
+				println("For Db2 MetadataStore, '-pw <password>' or '-pf' <path to password file>' must be passed on the command line. ")
+				System.exit(1)
+			}
+			// Initialize db2 metadatastore
+			def password
+			if (args.pf) 
+				password = new File(pf)
+			metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.url, args.id, password)
+		}
+		else {
+			println("Invalid MetadataStore Type: ${props.metadataStoreType}.\nOnly valid options for 'metadataStoreType' are 'file' and 'db2'.")
+			System.exit(1)
+		}
+
+		if (props.verbose) println "** MetadataStore initialized"
 	}
 
 	// handle -r,--reset option

--- a/build.groovy
+++ b/build.groovy
@@ -98,9 +98,8 @@ if (props.error)
 def initializeBuildProcess(String[] args) {
 	if (props.verbose) println "** Initializing build process . . ."
 
-	// build properties initial set
-	def opts = parseArgs(args)
-	populateBuildProperties(opts)
+	def opts = parseArgs(args) // parse incoming options and arguments
+	populateBuildProperties(opts) // build properties initial set
 	
 	// print and store property dbb toolkit version in use
 	def dbbToolkitVersion = VersionInfo.getInstance().getVersion()
@@ -123,10 +122,10 @@ def initializeBuildProcess(String[] args) {
 			//Get password file or encrypted password from command line
 			String password = null
 			File passwordFile = null
-			if (args.pf)  
-				passwordFile = new File(args.pf)
-			else if (args.pw)
-				password = args.pw
+			if (opts.pf)  
+				passwordFile = new File(opts.pf)
+			else if (opts.pw)
+				password = opts.pw
 
 			if (props.metadataStoreDb2ConnectionConf) { // Db2 Configuration properties file
 			
@@ -142,9 +141,9 @@ def initializeBuildProcess(String[] args) {
 				
 				// Call correct Db2 MetadataStore constructor
 				if (passwordFile)
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.id, passwordFile, db2ConnectionProps)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.id, passwordFile, db2ConnectionProps)
 				else
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.id, password, db2ConnectionProps)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.id, password, db2ConnectionProps)
 			}
 			else { // Not using Db2 Config Properties file
 				
@@ -156,9 +155,9 @@ def initializeBuildProcess(String[] args) {
 				
 				/// Call correct Db2 MetadataStore constructor
 				if (passwordFile)
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.url, args.id, passwordFile)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, passwordFile)
 				else 
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.url, args.id, password)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, password)
 			}
 			
 		}
@@ -305,8 +304,6 @@ options:
  */
 def populateBuildProperties(def opts) {
 
-	// parse incoming options and arguments
-	//def opts = parseArgs(args)
 	def zAppBuildDir =  getScriptDir()
 	props.zAppBuildDir = zAppBuildDir
 

--- a/build.groovy
+++ b/build.groovy
@@ -592,7 +592,7 @@ def createBuildList() {
 		}
 	}
 
-	return buildList
+	return [buildList, deleteList]
 }
 
 

--- a/build.groovy
+++ b/build.groovy
@@ -157,7 +157,7 @@ def initializeBuildProcess(String[] args) {
 				if (passwordFile)
 					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, passwordFile)
 				else 
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, password as String)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, password)
 			}
 			
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -457,15 +457,10 @@ def createBuildList() {
 
 	// using a set to create build list to eliminate duplicate files
 	Set<String> buildSet = new HashSet<String>()
-<<<<<<< HEAD
 	Set<String> changedFiles = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>() // not yet used for any post-processing
 	Set<String> changedBuildProperties = new HashSet<String>() // not yet used for any post-processing
-=======
-	Set<String> deletedFiles = new HashSet<String>()
-
->>>>>>> zappbuild-internal/develop
 	String action = (props.scanOnly) || (props.scanLoadmodules) ? 'Scanning' : 'Building'
 
 	// check if full build
@@ -476,37 +471,22 @@ def createBuildList() {
 	// check if impact build
 	else if (props.impactBuild) {
 		println "** --impactBuild option selected. $action impacted programs for application ${props.application} "
-<<<<<<< HEAD
 		if (repositoryClient) {
-			(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createImpactBuildList(repositoryClient)		}
-=======
-		if (metadataStore) {
-			(buildSet, deletedFiles) = impactUtils.createImpactBuildList(metadataStore)		}
->>>>>>> zappbuild-internal/develop
+			(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createImpactBuildList(metadataStore)		}
 		else {
 			println "*! Impact build requires a repository client connection to a DBB web application"
 		}
 	}
 	else if (props.mergeBuild){
 		println "** --mergeBuild option selected. $action changed programs for application ${props.application} flowing back to ${props.mainBuildBranch}"
-<<<<<<< HEAD
 		if (repositoryClient) {
 			assert (props.topicBranchBuild) : "*! Build type --mergeBuild can only be run on for topic branch builds."
-				(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createMergeBuildList(repositoryClient)		}
-=======
-		if (metadataStore) {
-			assert (props.topicBranchBuild) : "*! Build type --mergeBuild can only be run on for topic branch builds."
-				(buildSet, deletedFiles) = impactUtils.createMergeBuildList(metadataStore)		}
->>>>>>> zappbuild-internal/develop
+				(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createMergeBuildList(metadataStore)		}
 		else {
 			println "*! Merge build requires a repository client connection to a DBB web application"
 		}
 	}
-<<<<<<< HEAD
 	
-=======
-
->>>>>>> zappbuild-internal/develop
 	// if build file present add additional files to build list (mandatory build list)
 	if (props.buildFile) {
 
@@ -536,14 +516,8 @@ def createBuildList() {
 	// now that we are done adding to the build list convert the set to a list
 	List<String> buildList = new ArrayList<String>()
 	buildList.addAll(buildSet)
-<<<<<<< HEAD
 
 	// convert set of deleted files to a list 
-=======
-	buildSet = null
-
-	// 
->>>>>>> zappbuild-internal/develop
 	List<String> deleteList = new ArrayList<String>()
 	deleteList.addAll(deletedFiles)
 	
@@ -562,11 +536,7 @@ def createBuildList() {
 	// write out list of deleted files (for documentation, not actually used by build scripts)
 	if (deletedFiles.size() > 0){
 		String deletedFilesListLoc = "${props.buildOutDir}/deletedFilesList.${props.buildListFileExt}"
-<<<<<<< HEAD
 		println "** Writing list of deleted files to $deletedFilesListLoc"
-=======
-		println "** Writing lists of deleted files to $deletedFilesListLoc"
->>>>>>> zappbuild-internal/develop
 		File deletedFilesListFile = new File(deletedFilesListLoc)
 		deletedFilesListFile.withWriter(enc) { writer ->
 			deletedFiles.each { file ->
@@ -581,11 +551,7 @@ def createBuildList() {
 	// we do not need to scan them again
 	if (!props.impactBuild && !props.userBuild && !props.mergeBuild) {
 		println "** Scanning source code."
-<<<<<<< HEAD
-		impactUtils.updateCollection(buildList, null, null, repositoryClient)
-=======
 		impactUtils.updateCollection(buildList, null, null, metadataStore)
->>>>>>> zappbuild-internal/develop
 	}
 	
 	// Loading file/member level properties from member specific properties files
@@ -593,19 +559,18 @@ def createBuildList() {
 		println "** Populating file level properties from individual property files."
 		buildUtils.loadFileLevelPropertiesFromFile(buildList)
 	}
-<<<<<<< HEAD
 	
 	// Perform analysis and build report of external impacts
-	if (props.reportExternalImpacts && props.reportExternalImpacts.toBoolean() && repositoryClient){
+	if (props.reportExternalImpacts && props.reportExternalImpacts.toBoolean() && metadataStore){
 
 		if (buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.3")) { // validate minimum dbbToolkitVersion
 			if (buildSet && changedFiles) {
 				println "** Perform analysis and reporting of external impacted files for the build list including changed files."
-				impactUtils.reportExternalImpacts(repositoryClient, buildSet.plus(changedFiles))
+				impactUtils.reportExternalImpacts(metadataStore, buildSet.plus(changedFiles))
 			}
 			else if(buildSet) {
 				println "** Perform analysis and reporting of external impacted files for the build list."
-				impactUtils.reportExternalImpacts(repositoryClient, buildSet)
+				impactUtils.reportExternalImpacts(metadataStore, buildSet)
 			}
 		} else{
 			println "*! Perform analysis and reporting of external impacted files requires at least IBM Dependency Based Build Toolkit version 1.1.3."
@@ -613,9 +578,9 @@ def createBuildList() {
 	}
 	
 	// Document and validate concurrent changes
-	if (repositoryClient && props.reportConcurrentChanges && props.reportConcurrentChanges.toBoolean() && repositoryClient){
+	if (metadataStore && props.reportConcurrentChanges && props.reportConcurrentChanges.toBoolean()){
 		println "** Calculate and document concurrent changes."
-		impactUtils.calculateConcurrentChanges(repositoryClient, buildSet)
+		impactUtils.calculateConcurrentChanges(metadataStore, buildSet)
 	}
 	
 	// document deletions in build report
@@ -628,10 +593,6 @@ def createBuildList() {
 	}
 
 	return buildList
-=======
-
-	return [buildList, deleteList]
->>>>>>> zappbuild-internal/develop
 }
 
 
@@ -642,13 +603,8 @@ def finalizeBuildProcess(Map args) {
 	def buildResult = null
 
 	// update repository artifacts
-<<<<<<< HEAD
-	if (repositoryClient) {
-		buildResult = repositoryClient.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
-=======
 	if (metadataStore) {
 		buildResult = metadataStore.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
->>>>>>> zappbuild-internal/develop
 
 		// add git hashes for each build directory
 		List<String> srcDirs = []
@@ -672,11 +628,7 @@ def finalizeBuildProcess(Map args) {
 				// document changed files - Git compare link
 				if (props.impactBuild && props.gitRepositoryURL && props.gitRepositoryCompareService){
 					String gitchangedfilesKey = "$gitchangedfilesPrefix${buildUtils.relativizePath(dir)}"
-<<<<<<< HEAD
-					def lastBuildResult= buildUtils.retrieveLastBuildResult(repositoryClient)
-=======
 					def lastBuildResult= buildUtils.retrieveLastBuildResult(metadataStore)
->>>>>>> zappbuild-internal/develop
 					if (lastBuildResult){
 						String baselineHash = lastBuildResult.getProperty(key)
 						String gitchangedfilesLink = props.gitRepositoryURL << "/" << props.gitRepositoryCompareService <<"/" << baselineHash << ".." << currenthash
@@ -722,22 +674,6 @@ def finalizeBuildProcess(Map args) {
 	// create build report html file
 	def htmlOutputFile = new File("${props.buildOutDir}/BuildReport.html")
 	println "** Writing build report to ${htmlOutputFile}"
-<<<<<<< HEAD
-	def htmlTemplate = null  // Use default HTML template.
-	def css = null       // Use default theme.
-	def renderScript = null  // Use default rendering.
-	def transformer = HtmlTransformer.getInstance()
-	transformer.transform(jsonOutputFile, htmlTemplate, css, renderScript, htmlOutputFile, buildReportEncoding)
-
-
-	// attach build report & result
-	if (repositoryClient) {
-		buildReport.save(jsonOutputFile, buildReportEncoding)
-		buildResult.setBuildReport(new FileInputStream(htmlOutputFile))
-		buildResult.setBuildReportData(new FileInputStream(jsonOutputFile))
-		println "** Updating build result BuildGroup:${props.applicationBuildGroup} BuildLabel:${props.applicationBuildLabel} at ${props.buildResultUrl}"
-		buildResult.save()
-=======
 	buildReport.generateHTML(htmlOutputFile)
 
 
@@ -748,7 +684,6 @@ def finalizeBuildProcess(Map args) {
 		buildResult.setBuildReport(new FileInputStream(htmlOutputFile))
 		buildResult.setBuildReportData(new FileInputStream(jsonOutputFile))
 		println "** Updating build result BuildGroup:${props.applicationBuildGroup} BuildLabel:${props.applicationBuildLabel}"
->>>>>>> zappbuild-internal/develop
 	}
 
 	// print end build message

--- a/build.groovy
+++ b/build.groovy
@@ -433,19 +433,10 @@ def populateBuildProperties(String[] args) {
 	
 	// set buildframe options
 	if (opts.re) props.reportExternalImpacts = 'true'
-// metadataStoreType=file 
 
-// metadataStoreLocation=
-
-// # build.groovy option -url, --url
-// metadataStoreUrl=
-	// set DBB configuration properties
-	if (opts.url) props.metadataStoreUrl = opts.url
-
-	// SHOULD NOT BE SAVED AS PROPERTIES
-	// if (opts.id) props.'dbb.metadatastore.db2.userId' = opts.id
-	// if (opts.pw) props.'dbb.metadatastore.db2.password' = opts.pw
-	// if (opts.pf) props.'dbb.metadatastore.db2.passwordFile' = opts.pf
+	// set Db2 URL configuration properties
+	if (opts.url) props.metadataStoreDb2Url = opts.url
+	// db2 id, password, and passwordFile are no longer properties
 
 	// set IDz/ZOD user build options
 	if (opts.e) props.errPrefix = opts.e

--- a/build.groovy
+++ b/build.groovy
@@ -118,6 +118,11 @@ def initializeBuildProcess(String[] args) {
 		if (props.metadataStoreType == 'file')
 			metadataStore = MetadataStoreFactory.createFileMetadataStore(props.metadataStoreLocation)
 		else if (props.metadataStoreType == 'db2') {
+			// Get ID
+			String id
+			if (opts.id)
+				id = opts.id
+
 			//Get password file or encrypted password from command line
 			String password
 			File passwordFile
@@ -140,9 +145,9 @@ def initializeBuildProcess(String[] args) {
 				
 				// Call correct Db2 MetadataStore constructor
 				if (passwordFile)
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.id, passwordFile, db2ConnectionProps)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(id, passwordFile, db2ConnectionProps)
 				else
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.id, password as String, db2ConnectionProps)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(id, password as String, db2ConnectionProps)
 			}
 			else { // Not using Db2 Config Properties file
 				
@@ -154,9 +159,9 @@ def initializeBuildProcess(String[] args) {
 				
 				/// Call correct Db2 MetadataStore constructor
 				if (passwordFile)
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(props.metadataStoreDb2Url, opts.id, passwordFile)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(props.metadataStoreDb2Url, id, passwordFile)
 				else 
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(props.metadataStoreDb2Url, opts.id, password as String)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(props.metadataStoreDb2Url, id, password as String)
 			}
 			
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -248,7 +248,7 @@ options:
 	cli.sa(longOpt:'scanAll', 'Flag indicating to scan both source files and load modules for application without building anything')
 
 	// web application credentials (overrides properties in build.properties)
-	cli.url(longOpt:'url', args:1, 'Db2 URL for the MetadataStore')
+	cli.url(longOpt:'url', args:1, 'Db2 JDBC URL for the MetadataStore. Example: jdbc:db2:<Db2 server location>')
 	cli.id(longOpt:'id', args:1, 'Db2 id for the MetadataStore')
 	cli.pw(longOpt:'pw', args:1,  'Db2 password (encrypted with DBB Password Utility) for the MetadataStore')
 	cli.pf(longOpt:'pwFile', args:1, 'Absolute or relative (from workspace) path to file containing Db2 password')

--- a/build.groovy
+++ b/build.groovy
@@ -120,8 +120,8 @@ def initializeBuildProcess(String[] args) {
 		else if (props.metadataStoreType == 'db2') {
 
 			//Get password file or encrypted password from command line
-			String password = null
-			File passwordFile = null
+			String password
+			File passwordFile
 			if (opts.pf)  
 				passwordFile = new File(opts.pf)
 			else if (opts.pw)

--- a/build.groovy
+++ b/build.groovy
@@ -210,7 +210,7 @@ def initializeBuildProcess(String[] args) {
 	}
 
 	// verify/create/clone the collections for this build
-	impactUtils.verifyCollections(metadataStore)
+	impactUtils.verifyCollections()
 }
 
 /*

--- a/build.groovy
+++ b/build.groovy
@@ -671,7 +671,7 @@ def finalizeBuildProcess(Map args) {
 				// document changed files - Git compare link
 				if (props.impactBuild && props.gitRepositoryURL && props.gitRepositoryCompareService){
 					String gitchangedfilesKey = "$gitchangedfilesPrefix${buildUtils.relativizePath(dir)}"
-					def lastBuildResult= buildUtils.retrieveLastBuildResult(metadataStore)
+					def lastBuildResult= buildUtils.retrieveLastBuildResult()
 					if (lastBuildResult){
 						String baselineHash = lastBuildResult.getProperty(key)
 						String gitchangedfilesLink = props.gitRepositoryURL << "/" << props.gitRepositoryCompareService <<"/" << baselineHash << ".." << currenthash

--- a/build.groovy
+++ b/build.groovy
@@ -249,7 +249,7 @@ options:
 
 	// web application credentials (overrides properties in build.properties)
 	cli.url(longOpt:'url', args:1, 'Db2 JDBC URL for the MetadataStore. Example: jdbc:db2:<Db2 server location>')
-	cli.id(longOpt:'id', args:1, 'Db2 id for the MetadataStore')
+	cli.id(longOpt:'id', args:1, 'Db2 user id for the MetadataStore')
 	cli.pw(longOpt:'pw', args:1,  'Db2 password (encrypted with DBB Password Utility) for the MetadataStore')
 	cli.pf(longOpt:'pwFile', args:1, 'Absolute or relative (from workspace) path to file containing Db2 password')
 

--- a/build.groovy
+++ b/build.groovy
@@ -524,7 +524,7 @@ def createBuildList() {
 		println "** --mergeBuild option selected. $action changed programs for application ${props.application} flowing back to ${props.mainBuildBranch}"
 		if (metadataStore) {
 			assert (props.topicBranchBuild) : "*! Build type --mergeBuild can only be run on for topic branch builds."
-				(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createMergeBuildList(metadataStore)		}
+				(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createMergeBuildList()		}
 		else {
 			println "*! Merge build requires a Filesystem or Db2 MetadataStore"
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -196,7 +196,7 @@ def initializeBuildProcess(String[] args) {
 	// initialize build report
 	BuildReportFactory.createDefaultReport()
 
-	// initialize build result (requires repository connection)
+	// initialize build result (requires MetadataStore)
 	if (metadataStore) {
 		def buildResult = metadataStore.createBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 		buildResult.setState(buildResult.PROCESSING)
@@ -238,7 +238,7 @@ options:
 	cli.i(longOpt:'impactBuild', 'Flag indicating to build only programs impacted by changed files since last successful build.')
 	cli.b(longOpt:'baselineRef',args:1,'Comma seperated list of git references to overwrite the baselineHash hash in an impactBuild scenario.')
 	cli.m(longOpt:'mergeBuild', 'Flag indicating to build only changes which will be merged back to the mainBuildBranch.')	
-	cli.r(longOpt:'reset', 'Deletes the dependency collections and build result group from the DBB repository')
+	cli.r(longOpt:'reset', 'Deletes the dependency collections and build result group from the MetadataStore')
 	cli.v(longOpt:'verbose', 'Flag to turn on script trace')
 
 	// scan options
@@ -248,10 +248,10 @@ options:
 	cli.sa(longOpt:'scanAll', 'Flag indicating to scan both source files and load modules for application without building anything')
 
 	// web application credentials (overrides properties in build.properties)
-	cli.url(longOpt:'url', args:1, 'DBB repository URL')
-	cli.id(longOpt:'id', args:1, 'DBB repository id')
-	cli.pw(longOpt:'pw', args:1,  'DBB repository password')
-	cli.pf(longOpt:'pwFile', args:1, 'Absolute or relative (from workspace) path to file containing DBB password')
+	cli.url(longOpt:'url', args:1, 'Db2 URL for MetadataStore')
+	cli.id(longOpt:'id', args:1, 'Db2 id for MetadataStore')
+	cli.pw(longOpt:'pw', args:1,  'Db2 password (encrypted with DBB Password Utility)')
+	cli.pf(longOpt:'pwFile', args:1, 'Absolute or relative (from workspace) path to file containing Db2 password')
 
 	// IDz/ZOD User build options
 	cli.u(longOpt:'userBuild', 'Flag indicating running a user build')
@@ -410,11 +410,6 @@ def populateBuildProperties(def opts) {
 		props.scanOnly = 'true'
 		props.scanLoadmodules = 'true'
 	}
-
-	if (opts.url) props.url = opts.url
-	if (opts.id) props.id = opts.id
-	if (opts.pw) props.pw = opts.pw
-	if (opts.pf) props.pf = opts.pf
 
 	// set debug flag
 	if (opts.d) props.debug = 'true'

--- a/build.groovy
+++ b/build.groovy
@@ -729,13 +729,12 @@ def finalizeBuildProcess(Map args) {
 	// print end build message
 	def endTime = new Date()
 	def duration = TimeCategory.minus(endTime, args.start)
-	buildResult.setProperty("buildDuration", duration.toString())
-	println(buildResult)
-	//def state = (props.error) ? "ERROR" : "CLEAN"
-	// println("** Build ended at $endTime")
-	// println("** Build State : $state")
-	// println("** Total files processed : ${args.count}")
-	// println("** Total build time  : $duration\n")
+	//buildResult.setProperty("buildDuration", duration.toString())
+	def state = (props.error) ? "ERROR" : "CLEAN"
+	println("** Build ended at $endTime")
+	println("** Build State : $state")
+	println("** Total files processed : ${args.count}")
+	println("** Total build time  : $duration\n")
 }
 
 

--- a/build.groovy
+++ b/build.groovy
@@ -170,7 +170,7 @@ def initializeBuildProcess(String[] args) {
 			System.exit(1)
 		}
 
-		if (props.verbose) println "** ${props.metadataStoreType} MetadataStore initialized"
+		if (props.verbose) println "** ${props.metadataStoreType.capitalize()} MetadataStore initialized"
 	}
 
 	// handle -r,--reset option

--- a/build.groovy
+++ b/build.groovy
@@ -248,9 +248,9 @@ options:
 	cli.sa(longOpt:'scanAll', 'Flag indicating to scan both source files and load modules for application without building anything')
 
 	// web application credentials (overrides properties in build.properties)
-	cli.url(longOpt:'url', args:1, 'Db2 URL for MetadataStore')
-	cli.id(longOpt:'id', args:1, 'Db2 id for MetadataStore')
-	cli.pw(longOpt:'pw', args:1,  'Db2 password (encrypted with DBB Password Utility)')
+	cli.url(longOpt:'url', args:1, 'Db2 URL for the MetadataStore')
+	cli.id(longOpt:'id', args:1, 'Db2 id for the MetadataStore')
+	cli.pw(longOpt:'pw', args:1,  'Db2 password (encrypted with DBB Password Utility) for the MetadataStore')
 	cli.pf(longOpt:'pwFile', args:1, 'Absolute or relative (from workspace) path to file containing Db2 password')
 
 	// IDz/ZOD User build options

--- a/build.groovy
+++ b/build.groovy
@@ -471,7 +471,7 @@ def createBuildList() {
 	// check if impact build
 	else if (props.impactBuild) {
 		println "** --impactBuild option selected. $action impacted programs for application ${props.application} "
-		if (repositoryClient) {
+		if (metadataStore) {
 			(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createImpactBuildList(metadataStore)		}
 		else {
 			println "*! Impact build requires a repository client connection to a DBB web application"
@@ -479,7 +479,7 @@ def createBuildList() {
 	}
 	else if (props.mergeBuild){
 		println "** --mergeBuild option selected. $action changed programs for application ${props.application} flowing back to ${props.mainBuildBranch}"
-		if (repositoryClient) {
+		if (metadataStore) {
 			assert (props.topicBranchBuild) : "*! Build type --mergeBuild can only be run on for topic branch builds."
 				(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createMergeBuildList(metadataStore)		}
 		else {

--- a/build.groovy
+++ b/build.groovy
@@ -128,7 +128,7 @@ def initializeBuildProcess(String[] args) {
 				System.exit(1)
 			}
 			if (!args.pw || !args.pf) {
-				println("For Db2 MetadataStore, '-pw <password>' or '-pf' <path to password file>' must be passed on the command line. ")
+				println("For Db2 MetadataStore, '-pw <password>' or '-pf' <path to password file>' must be passed on the command line. This password should be encrypted with the DBB Password Encryption Utility.")
 				System.exit(1)
 			}
 			// Get password  file or encrypted password
@@ -136,7 +136,7 @@ def initializeBuildProcess(String[] args) {
 			if (args.pf) 
 				password = new File(pf)
 			else
-				passwrod = args.pw
+				password = args.pw as String
 			// Initialize Db2 metadatastore
 			metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.url, args.id, password)
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -65,7 +65,7 @@ else {
 		}
 	} else if(props.scanLoadmodules && props.scanLoadmodules.toBoolean()){
 		println ("** Scanning load modules.")
-		impactUtils.scanOnlyStaticDependencies(buildList, metadataStore)
+		impactUtils.scanOnlyStaticDependencies(buildList)
 	}
 }
 

--- a/build.groovy
+++ b/build.groovy
@@ -623,7 +623,7 @@ def createBuildList() {
 	// Document and validate concurrent changes
 	if (metadataStore && props.reportConcurrentChanges && props.reportConcurrentChanges.toBoolean()){
 		println "** Calculate and document concurrent changes."
-		impactUtils.calculateConcurrentChanges(metadataStore, buildSet)
+		impactUtils.calculateConcurrentChanges(buildSet)
 	}
 	
 	// document deletions in build report

--- a/build.groovy
+++ b/build.groovy
@@ -118,27 +118,46 @@ def initializeBuildProcess(String[] args) {
 		if (props.metadataStoreType == 'file')
 			metadataStore = MetadataStoreFactory.createFileMetadataStore(props.metadataStoreLocation)
 		else if (props.metadataStoreType == 'db2') {
-			// Assert required properties exist
-			if (!args.url) {
-				println("For Db2 MetadataStore, '-url <url> must be passed on the command line." )
-				System.exit(1)
-			}
-			if (!args.id) {
-				println("For Db2 MetadataStore, '-id <user id>' must be passed on the command line. ")
-				System.exit(1)
-			}
-			if (!args.pw || !args.pf) {
-				println("For Db2 MetadataStore, '-pw <password>' or '-pf' <path to password file>' must be passed on the command line. This password should be encrypted with the DBB Password Encryption Utility.")
-				System.exit(1)
-			}
-			// Get password  file or encrypted password
+
+			//Get password file or encrypted password from command line
 			def password
 			if (args.pf) 
 				password = new File(pf)
 			else
-				password = args.pw as String
-			// Initialize Db2 metadatastore
-			metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.url, args.id, password)
+				password = args.pw
+
+			if (props.metadataStoreDb2ConnectionConf) { // Db2 Configuration properties file
+			
+				// Load properties 
+				File propertiesFile = new File(props.metadataStoreDb2ConnectionConf)
+				if (!propertiesFile.exists()) {
+					println("Db2 Connection Configuration property file does not exist: ${propertiesFile.getAbsolutePath()}\nPlease verify that the provided path is correct")
+					System.exit(1)
+				}
+				Properties db2ConnectionProps = new Properties()
+				db2ConnectionProps.load(propertiesFile)
+				
+				metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.id, password, db2ConnectionProps)
+			}
+			else { // Not using Db2 Config Properties file
+				
+				// Assert required properties exist
+				if (!args.url) {
+					println("For Db2 MetadataStore, '-url <url> must be passed on the command line." )
+					System.exit(1)
+				}
+				if (!args.id) {
+					println("For Db2 MetadataStore, '-id <user id>' must be passed on the command line. ")
+					System.exit(1)
+				}
+				if (!args.pw || !args.pf) {
+					println("For Db2 MetadataStore, '-pw <password>' or '-pf <path to password file>' must be passed on the command line. This password should be encrypted with the DBB Password Encryption Utility.")
+					System.exit(1)
+				}
+				// Initialize Db2 metadatastore
+				metadataStore = MetadataStoreFactory.createDb2MetadataStore(args.url, args.id, password)
+			}
+			
 		}
 		else {
 			println("Invalid MetadataStore Type: ${props.metadataStoreType}.\nOnly valid options for 'metadataStoreType' are 'file' and 'db2'.")

--- a/build.groovy
+++ b/build.groovy
@@ -157,7 +157,7 @@ def initializeBuildProcess(String[] args) {
 				if (passwordFile)
 					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, passwordFile)
 				else 
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, password)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, password as String)
 			}
 			
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -99,7 +99,8 @@ def initializeBuildProcess(String[] args) {
 	if (props.verbose) println "** Initializing build process . . ."
 
 	// build properties initial set
-	populateBuildProperties(args)
+	def opts = parseArgs(args)
+	populateBuildProperties(opts)
 	
 	// print and store property dbb toolkit version in use
 	def dbbToolkitVersion = VersionInfo.getInstance().getVersion()
@@ -302,10 +303,10 @@ options:
  * populateBuildProperties - loads all build property files, creates properties for command line
  * arguments and sets calculated propertied for he build process
  */
-def populateBuildProperties(String[] args) {
+def populateBuildProperties(def opts) {
 
 	// parse incoming options and arguments
-	def opts = parseArgs(args)
+	//def opts = parseArgs(args)
 	def zAppBuildDir =  getScriptDir()
 	props.zAppBuildDir = zAppBuildDir
 

--- a/build.groovy
+++ b/build.groovy
@@ -609,11 +609,11 @@ def createBuildList() {
 		if (buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.3")) { // validate minimum dbbToolkitVersion
 			if (buildSet && changedFiles) {
 				println "** Perform analysis and reporting of external impacted files for the build list including changed files."
-				impactUtils.reportExternalImpacts(metadataStore, buildSet.plus(changedFiles))
+				impactUtils.reportExternalImpacts(buildSet.plus(changedFiles))
 			}
 			else if(buildSet) {
 				println "** Perform analysis and reporting of external impacted files for the build list."
-				impactUtils.reportExternalImpacts(metadataStore, buildSet)
+				impactUtils.reportExternalImpacts(buildSet)
 			}
 		} else{
 			println "*! Perform analysis and reporting of external impacted files requires at least IBM Dependency Based Build Toolkit version 1.1.3."

--- a/build.groovy
+++ b/build.groovy
@@ -594,7 +594,7 @@ def createBuildList() {
 	// we do not need to scan them again
 	if (!props.impactBuild && !props.userBuild && !props.mergeBuild) {
 		println "** Scanning source code."
-		impactUtils.updateCollection(buildList, null, null, metadataStore)
+		impactUtils.updateCollection(buildList, null, null)
 	}
 	
 	// Loading file/member level properties from member specific properties files

--- a/build.groovy
+++ b/build.groovy
@@ -143,7 +143,7 @@ def initializeBuildProcess(String[] args) {
 				if (passwordFile)
 					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.id, passwordFile, db2ConnectionProps)
 				else
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.id, password, db2ConnectionProps)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.id, password as String, db2ConnectionProps)
 			}
 			else { // Not using Db2 Config Properties file
 				
@@ -157,7 +157,7 @@ def initializeBuildProcess(String[] args) {
 				if (passwordFile)
 					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, passwordFile)
 				else 
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, password)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, password as String)
 			}
 			
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -118,7 +118,6 @@ def initializeBuildProcess(String[] args) {
 		if (props.metadataStoreType == 'file')
 			metadataStore = MetadataStoreFactory.createFileMetadataStore(props.metadataStoreLocation)
 		else if (props.metadataStoreType == 'db2') {
-
 			//Get password file or encrypted password from command line
 			String password
 			File passwordFile
@@ -155,9 +154,9 @@ def initializeBuildProcess(String[] args) {
 				
 				/// Call correct Db2 MetadataStore constructor
 				if (passwordFile)
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, passwordFile)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(props.metadataStoreDb2Url, opts.id, passwordFile)
 				else 
-					metadataStore = MetadataStoreFactory.createDb2MetadataStore(opts.url, opts.id, password as String)
+					metadataStore = MetadataStoreFactory.createDb2MetadataStore(props.metadataStoreDb2Url, opts.id, password as String)
 			}
 			
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -515,9 +515,9 @@ def createBuildList() {
 	else if (props.impactBuild) {
 		println "** --impactBuild option selected. $action impacted programs for application ${props.application} "
 		if (metadataStore) {
-			(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createImpactBuildList(metadataStore)		}
+			(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createImpactBuildList()		}
 		else {
-			println "*! Impact build requires a repository client connection to a DBB web application"
+			println "*! Impact build requires a Filesystem or Db2 MetadataStore"
 		}
 	}
 	else if (props.mergeBuild){
@@ -526,7 +526,7 @@ def createBuildList() {
 			assert (props.topicBranchBuild) : "*! Build type --mergeBuild can only be run on for topic branch builds."
 				(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createMergeBuildList(metadataStore)		}
 		else {
-			println "*! Merge build requires a repository client connection to a DBB web application"
+			println "*! Merge build requires a Filesystem or Db2 MetadataStore"
 		}
 	}
 	

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -117,7 +117,7 @@ sortedList.each { buildFile ->
 						String scanLoadModule = props.getFileProperty('assembler_scanLoadModule', buildFile)
 						if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore()) {
 							String assembler_loadPDS = props.getFileProperty('assembler_loadPDS', buildFile)
-							impactUtils.saveStaticLinkDependencies(buildFile, assembler_loadPDS, logicalFile, metadataStore)
+							impactUtils.saveStaticLinkDependencies(buildFile, assembler_loadPDS, logicalFile)
 						}
 					}
 				}

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -11,9 +11,7 @@ import com.ibm.dbb.build.report.records.*
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
-@Field MetadataStore metadataStore
-
-@Field def resolverUtils = loadScript(new File("${props.zAppBuildDir}/utilities/ResolverUtilities.groovy"))}
+@Field def resolverUtils = loadScript(new File("${props.zAppBuildDir}/utilities/ResolverUtilities.groovy"))
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -115,7 +113,7 @@ sortedList.each { buildFile ->
 					// only scan the load module if load module scanning turned on for file
 					if(!props.userBuild){
 						String scanLoadModule = props.getFileProperty('assembler_scanLoadModule', buildFile)
-						if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore()) {
+						if (scanLoadModule && scanLoadModule.toBoolean()) {
 							String assembler_loadPDS = props.getFileProperty('assembler_loadPDS', buildFile)
 							impactUtils.saveStaticLinkDependencies(buildFile, assembler_loadPDS, logicalFile)
 						}
@@ -359,11 +357,5 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	// add a copy command to the linkedit command to append the SYSPRINT from the temporary dataset to the HFS log file
 	linkedit.copy(new CopyToHFS().ddName("SYSPRINT").file(logFile).hfsEncoding(props.logEncoding).append(true))
 	return linkedit
-}
-
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	return metadataStore
 }
 

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
@@ -11,12 +11,9 @@ import com.ibm.dbb.build.report.records.*
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
-@Field RepositoryClient repositoryClient
+@Field MetadataStore metadataStore
 
-@Field def resolverUtils
-// Conditionally load the ResolverUtilities.groovy which require at least DBB 1.1.2
-if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) {
-	resolverUtils = loadScript(new File("${props.zAppBuildDir}/utilities/ResolverUtilities.groovy"))}
+@Field def resolverUtils = loadScript(new File("${props.zAppBuildDir}/utilities/ResolverUtilities.groovy"))}
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -33,22 +30,15 @@ List<String> sortedList = buildUtils.sortBuildList(argMap.buildList, 'assembler_
 sortedList.each { buildFile ->
 	println "*** Building file $buildFile"
 
-	// configure dependency resolution and create logical file 	
-	def dependencyResolver
-	LogicalFile logicalFile
+	// Configure dependency resolution
+	String dependencySearch = props.getFileProperty('assembler_dependencySearch', buildFile)
+	def dependencyResolver = resolverUtils.createSearchPathDependencyResolver(dependencySearch)
 	
-	if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && props.assembler_dependencySearch && buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) { // use new SearchPathDependencyResolver
-		String dependencySearch = props.getFileProperty('assembler_dependencySearch', buildFile)
-		dependencyResolver = resolverUtils.createSearchPathDependencyResolver(dependencySearch)
-		logicalFile = resolverUtils.createLogicalFile(dependencyResolver, buildFile)
-	} else { // use deprecated DependencyResolver
-		String rules = props.getFileProperty('assembler_resolutionRules', buildFile)
-		dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
-		logicalFile = dependencyResolver.getLogicalFile()
-	}
-	
-	// copy build file and dependency files to data sets
+	// Copy build file and dependency files to data sets
 	buildUtils.copySourceFiles(buildFile, props.assembler_srcPDS, 'assembler_dependenciesDatasetMapping', null ,dependencyResolver)
+
+	// Create logical file
+	LogicalFile logicalFile = resolverUtils.createLogicalFile(dependencyResolver, buildFile)
 
 	// create mvs commands
 	String member = CopyToPDS.createMemberName(buildFile)
@@ -75,7 +65,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The assembler sql translator return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 		} else {
 			// Store db2 bind information as a generic property record in the BuildReport
 			String generateDb2BindInfoRecord = props.getFileProperty('generateDb2BindInfoRecord', buildFile)
@@ -93,7 +83,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The assembler cics translator return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 		}
 	}
 
@@ -106,7 +96,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The assembler return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 		}
 		else {
 			// if this program needs to be link edited . . .
@@ -119,15 +109,15 @@ sortedList.each { buildFile ->
 					String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 					println(errorMsg)
 					props.error = "true"
-					buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+					buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 				}
 				else {
 					// only scan the load module if load module scanning turned on for file
 					if(!props.userBuild){
 						String scanLoadModule = props.getFileProperty('assembler_scanLoadModule', buildFile)
-						if (scanLoadModule && scanLoadModule.toBoolean() && getRepositoryClient()) {
+						if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore()) {
 							String assembler_loadPDS = props.getFileProperty('assembler_loadPDS', buildFile)
-							impactUtils.saveStaticLinkDependencies(buildFile, assembler_loadPDS, logicalFile, repositoryClient)
+							impactUtils.saveStaticLinkDependencies(buildFile, assembler_loadPDS, logicalFile, metadataStore)
 						}
 					}
 				}
@@ -308,7 +298,8 @@ def createAssemblerCommand(String buildFile, LogicalFile logicalFile, String mem
 		assembler.dd(new DDStatement().dsn(props.MODGEN).options("shr"))
 	if (buildUtils.isCICS(logicalFile))
 		assembler.dd(new DDStatement().dsn(props.SDFHMAC).options("shr"))
-	//if (buildUtils.isSQL(logicalFile))
+	if (buildUtils.isSQL(logicalFile))
+		assembler.dd(new DDStatement().dsn("DBC0CFG.DB2.V12.SDSNSAMP").options("shr"))
 	if (props.SDFSMAC)
 		assembler.dd(new DDStatement().dsn(props.SDFSMAC).options("shr"))
 
@@ -370,9 +361,9 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	return linkedit
 }
 
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
-	return repositoryClient
+def getMetadataStore() {
+	if (!metadataStore)
+		metadataStore = MetadataStoreFactory.getMetadataStore()
+	return metadataStore
 }
 

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -65,7 +65,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The assembler sql translator return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 		} else {
 			// Store db2 bind information as a generic property record in the BuildReport
 			String generateDb2BindInfoRecord = props.getFileProperty('generateDb2BindInfoRecord', buildFile)
@@ -83,7 +83,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The assembler cics translator return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 		}
 	}
 
@@ -96,7 +96,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The assembler return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 		}
 		else {
 			// if this program needs to be link edited . . .
@@ -109,7 +109,7 @@ sortedList.each { buildFile ->
 					String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 					println(errorMsg)
 					props.error = "true"
-					buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+					buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 				}
 				else {
 					// only scan the load module if load module scanning turned on for file

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -9,8 +9,6 @@ import groovy.transform.*
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 
-@Field MetadataStore metadataStore
-
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
 // verify required build properties
@@ -148,12 +146,6 @@ def createLinkEditCommand(String buildFile, String member, File logFile) {
 	return linkedit
 }
 
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	
-	return metadataStore
-}
 
 
 

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
@@ -9,7 +9,7 @@ import groovy.transform.*
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 
-@Field RepositoryClient repositoryClient
+@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -50,7 +50,7 @@ sortedList.each { buildFile ->
 	    String errorMsg = "*! The build return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 	 }
 	
 }
@@ -148,11 +148,11 @@ def createLinkEditCommand(String buildFile, String member, File logFile) {
 	return linkedit
 }
 
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
+def getMetadataStore() {
+	if (!metadataStore)
+		metadataStore = MetadataStoreFactory.getMetadataStore()
 	
-	return repositoryClient
+	return metadataStore
 }
 
 

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -50,7 +50,7 @@ sortedList.each { buildFile ->
 	    String errorMsg = "*! The build return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	 }
 	
 }

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -105,7 +105,7 @@ sortedList.each { buildFile ->
 					// only scan the load module if load module scanning turned on for file
 					String scanLoadModule = props.getFileProperty('cobol_scanLoadModule', buildFile)
 					if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
-						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile, getMetadataStore())
+						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile)
 				}
 			}
 		}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -77,7 +77,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The compile return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else { // if this program needs to be link edited . . .
 		
@@ -98,7 +98,7 @@ sortedList.each { buildFile ->
 				String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 			}
 			else {
 				if(!props.userBuild && !isZUnitTestCase){
@@ -124,7 +124,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The bind package return code ($bindRc) for $buildFile exceeded the maximum return code allowed ($props.bind_maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}_bind.log":bindLogFile],client:getMetadataStore())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}_bind.log":bindLogFile])
 		}
 	}
 
@@ -254,7 +254,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 				String errorMsg = "*! Cobol.groovy. The dataset definition $datasetDefinition could not be resolved from the DBB Build properties."
 				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
+				buildUtils.updateBuildResult(errorMsg:errorMsg)
 			}
 		}
 	}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -14,7 +14,6 @@ import com.ibm.dbb.build.report.records.*
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
 @Field def bindUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BindUtilities.groovy"))
 @Field def resolverUtils = loadScript(new File("${props.zAppBuildDir}/utilities/ResolverUtilities.groovy"))
-@Field MetadataStore metadataStore
 	
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -104,7 +103,7 @@ sortedList.each { buildFile ->
 				if(!props.userBuild && !isZUnitTestCase){
 					// only scan the load module if load module scanning turned on for file
 					String scanLoadModule = props.getFileProperty('cobol_scanLoadModule', buildFile)
-					if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
+					if (scanLoadModule && scanLoadModule.toBoolean())
 						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile)
 				}
 			}
@@ -378,14 +377,6 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	linkedit.copy(new CopyToHFS().ddName("SYSPRINT").file(logFile).hfsEncoding(props.logEncoding).append(true))
 
 	return linkedit
-}
-
-
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-
-	return metadataStore
 }
 
 boolean buildListContainsTests(List<String> buildList) {

--- a/languages/DBDgen.groovy
+++ b/languages/DBDgen.groovy
@@ -48,7 +48,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The assembly return code for DBDgen ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else {
 
@@ -59,7 +59,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The link edit return code for DBDgen ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 		}
 
 	}

--- a/languages/DBDgen.groovy
+++ b/languages/DBDgen.groovy
@@ -7,7 +7,6 @@ import groovy.transform.*
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -159,8 +158,3 @@ def createDBDLinkEditCommand(String buildFile, String member, File logFile) {
 }
 
 
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	return metadataStore
-}

--- a/languages/DBDgen.groovy
+++ b/languages/DBDgen.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
@@ -7,8 +7,7 @@ import groovy.transform.*
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-
-@Field RepositoryClient repositoryClient
+@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -49,7 +48,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The assembly return code for DBDgen ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 	}
 	else {
 
@@ -60,7 +59,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The link edit return code for DBDgen ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 		}
 
 	}
@@ -160,12 +159,8 @@ def createDBDLinkEditCommand(String buildFile, String member, File logFile) {
 }
 
 
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
-
-	return repositoryClient
+def getMetadataStore() {
+	if (!metadataStore)
+		metadataStore = MetadataStoreFactory.getMetadataStore()
+	return metadataStore
 }
-
-
-

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -9,7 +9,6 @@ import groovy.transform.*
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
-@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -57,7 +56,7 @@ sortedList.each { buildFile ->
 		if(!props.userBuild){
 			// only scan the load module if load module scanning turned on for file
 			String scanLoadModule = props.getFileProperty('linkedit_scanLoadModule', buildFile)
-			if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
+			if (scanLoadModule && scanLoadModule.toBoolean())
 				impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile)
 		}
 	}
@@ -112,14 +111,6 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	linkedit.copy(new CopyToHFS().ddName("SYSPRINT").file(logFile).hfsEncoding(props.logEncoding))
 
 	return linkedit
-}
-
-
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-
-	return metadataStore
 }
 
 

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -58,7 +58,7 @@ sortedList.each { buildFile ->
 			// only scan the load module if load module scanning turned on for file
 			String scanLoadModule = props.getFileProperty('linkedit_scanLoadModule', buildFile)
 			if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
-				impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile, getMetadataStore())
+				impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile)
 		}
 	}
 

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -51,7 +51,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else {
 		if(!props.userBuild){

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
@@ -9,7 +9,7 @@ import groovy.transform.*
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
-@Field RepositoryClient repositoryClient
+@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -29,16 +29,10 @@ sortedList.each { buildFile ->
 	// copy build file to input data set
 	buildUtils.copySourceFiles(buildFile, props.linkedit_srcPDS, null, null, null)
 
+	// Get logical file
+	LogicalFile logicalFile = SearchPathDependencyResolver.getLogicalFile(buildFile,props.workspace)
+
 	// create mvs commands
-	LogicalFile logicalFile
-	if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean()) { // use new SearchPathDependencyResolver
-		logicalFile = SearchPathDependencyResolver.getLogicalFile(buildFile,props.workspace)
-	}
-	else { // use deprecated DependencyResolver API
-		DependencyResolver dependencyResolver = buildUtils.createDependencyResolver(buildFile, null)
-		logicalFile = dependencyResolver.getLogicalFile()
-	}
-	
 	String member = CopyToPDS.createMemberName(buildFile)
 	
 	File logFile = new File( props.userBuild ? "${props.buildOutDir}/${member}.log" : "${props.buildOutDir}/${member}.linkedit.log")
@@ -57,14 +51,14 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 	}
 	else {
 		if(!props.userBuild){
 			// only scan the load module if load module scanning turned on for file
 			String scanLoadModule = props.getFileProperty('linkedit_scanLoadModule', buildFile)
-			if (scanLoadModule && scanLoadModule.toBoolean() && getRepositoryClient())
-				impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile, repositoryClient)
+			if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
+				impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile, getMetadataStore())
 		}
 	}
 
@@ -121,11 +115,11 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 }
 
 
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
+def getMetadataStore() {
+	if (!metadataStore)
+		metadataStore = MetadataStoreFactory.getMetadataStore()
 
-	return repositoryClient
+	return metadataStore
 }
 
 

--- a/languages/MFS.groovy
+++ b/languages/MFS.groovy
@@ -9,7 +9,6 @@ import groovy.transform.*
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -144,10 +143,4 @@ def createPhase2Command(String buildFile, String member, File logFile) {
 	mfsPhase2.copy(new CopyToHFS().ddName("UTPRINT").file(logFile).hfsEncoding(props.logEncoding).append(true))
 	
 	return mfsPhase2
-}
-
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	return metadataStore
 }

--- a/languages/MFS.groovy
+++ b/languages/MFS.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
@@ -9,8 +9,7 @@ import groovy.transform.*
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-
-@Field RepositoryClient repositoryClient
+@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -51,7 +50,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The phase1 return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 	}
 	else {
 
@@ -62,7 +61,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The phase 2 return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 		}
 	}
 	
@@ -147,12 +146,8 @@ def createPhase2Command(String buildFile, String member, File logFile) {
 	return mfsPhase2
 }
 
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
-
-	return repositoryClient
+def getMetadataStore() {
+	if (!metadataStore)
+		metadataStore = MetadataStoreFactory.getMetadataStore()
+	return metadataStore
 }
-
-
-

--- a/languages/MFS.groovy
+++ b/languages/MFS.groovy
@@ -50,7 +50,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The phase1 return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else {
 
@@ -61,7 +61,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The phase 2 return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 		}
 	}
 	

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -83,7 +83,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The compile return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else {
 		// if this program needs to be link edited . . .
@@ -104,7 +104,7 @@ sortedList.each { buildFile ->
 				String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 			}
 			else {
 				// only scan the load module if load module scanning turned on for file
@@ -249,7 +249,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 				String errorMsg = "*! PLI.groovy. The dataset definition $datasetDefinition could not be resolved from the DBB Build properties."
 				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
+				buildUtils.updateBuildResult(errorMsg:errorMsg)
 			}
 		}
 	}

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -12,7 +12,6 @@ import com.ibm.dbb.build.report.records.*
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
-@Field MetadataStore metadataStore
 
 @Field def resolverUtils
 // Conditionally load the ResolverUtilities.groovy which require at least DBB 1.1.2
@@ -110,7 +109,7 @@ sortedList.each { buildFile ->
 				// only scan the load module if load module scanning turned on for file
 				if(!props.userBuild && !isZUnitTestCase){
 					String scanLoadModule = props.getFileProperty('pli_scanLoadModule', buildFile)
-					if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
+					if (scanLoadModule && scanLoadModule.toBoolean())
 						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile)
 				}
 			}
@@ -344,13 +343,6 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	linkedit.copy(new CopyToHFS().ddName("SYSPRINT").file(logFile).hfsEncoding(props.logEncoding).append(true))
 		
 	return linkedit
-}
-
-
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	return metadataStore
 }
 
 

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -111,7 +111,7 @@ sortedList.each { buildFile ->
 				if(!props.userBuild && !isZUnitTestCase){
 					String scanLoadModule = props.getFileProperty('pli_scanLoadModule', buildFile)
 					if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
-						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile, metadataStore)
+						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile)
 				}
 			}
 		}

--- a/languages/PSBgen.groovy
+++ b/languages/PSBgen.groovy
@@ -52,7 +52,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The assembly return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else {
 
@@ -63,7 +63,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 		}
 
 		else{
@@ -75,7 +75,7 @@ sortedList.each { buildFile ->
 					String errorMsg = "*! The acbgen return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 					println(errorMsg)
 					props.error = "true"
-					buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+					buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 				}
 			}
 		}

--- a/languages/PSBgen.groovy
+++ b/languages/PSBgen.groovy
@@ -7,7 +7,6 @@ import groovy.transform.*
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -232,11 +231,5 @@ def createACBgenCommand(String buildFile, String member, File logFile) {
 	acbgen.copy(new CopyToHFS().ddName("SYSPRINT").file(logFile).hfsEncoding(props.logEncoding).append(true))
 
 	return acbgen
-}
-
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	return metadataStore
 }
 

--- a/languages/PSBgen.groovy
+++ b/languages/PSBgen.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
@@ -7,8 +7,7 @@ import groovy.transform.*
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
-
-@Field RepositoryClient repositoryClient
+@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -53,7 +52,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The assembly return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 	}
 	else {
 
@@ -64,7 +63,7 @@ sortedList.each { buildFile ->
 			String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 		}
 
 		else{
@@ -76,7 +75,7 @@ sortedList.each { buildFile ->
 					String errorMsg = "*! The acbgen return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 					println(errorMsg)
 					props.error = "true"
-					buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+					buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 				}
 			}
 		}
@@ -235,12 +234,9 @@ def createACBgenCommand(String buildFile, String member, File logFile) {
 	return acbgen
 }
 
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
-
-	return repositoryClient
+def getMetadataStore() {
+	if (!metadataStore)
+		metadataStore = MetadataStoreFactory.getMetadataStore()
+	return metadataStore
 }
-
-
 

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 
 
 // define script properties
@@ -7,12 +7,8 @@ import com.ibm.dbb.repository.*
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
 @Field def bindUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BindUtilities.groovy"))
-@Field RepositoryClient repositoryClient
-
-@Field def resolverUtils
-// Conditionally load the ResolverUtilities.groovy which require at least DBB 1.1.2
-if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) {
-	resolverUtils = loadScript(new File("${props.zAppBuildDir}/utilities/ResolverUtilities.groovy"))}
+@Field def resolverUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ResolverUtilities.groovy"))
+@Field MetadataStore metadataStore
 
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
@@ -32,22 +28,15 @@ sortedList.each { buildFile ->
 	println "*** Building file $buildFile"
 
 	
-	// configure dependency resolution and create logical file
-	def dependencyResolver
-	LogicalFile logicalFile
-	
-	if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && props.rexx_dependencySearch  && buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) { // use new SearchPathDependencyResolver
-		String dependencySearch = props.getFileProperty('rexx_dependencySearch', buildFile)
-		dependencyResolver = resolverUtils.createSearchPathDependencyResolver(dependencySearch)
-		logicalFile = resolverUtils.createLogicalFile(dependencyResolver, buildFile)
-	} else { // use deprecated DependencyResolver
-		String rules = props.getFileProperty('rexx_resolutionRules', buildFile)
-		dependencyResolver = buildUtils.createDependencyResolver(buildFile, rules)
-		logicalFile = dependencyResolver.getLogicalFile()
-	}
+	// configure dependency resolution and create logical file	
+	String dependencySearch = props.getFileProperty('rexx_dependencySearch', buildFile)
+	def dependencyResolver = resolverUtils.createSearchPathDependencyResolver(dependencySearch)
 	
 	// copy build file and dependency files to data sets
 	buildUtils.copySourceFiles(buildFile, props.rexx_srcPDS, 'rexx_dependenciesDatasetMapping', null, dependencyResolver)
+
+	// Get logical file
+	LogicalFile logicalFile = resolverUtils.createLogicalFile(dependencyResolver, buildFile)
 
 	// create mvs commands
 	String member = CopyToPDS.createMemberName(buildFile)
@@ -76,7 +65,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The compile return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 	}
 	else {
 		// if this program needs to be link edited . . .
@@ -89,14 +78,14 @@ sortedList.each { buildFile ->
 				String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getRepositoryClient())
+				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
 			}
 			else {
 				if (!props.userBuild){
 					// only scan the load module if load module scanning turned on for file
 					String scanLoadModule = props.getFileProperty('rexx_scanLoadModule', buildFile)
-					if (scanLoadModule && scanLoadModule.toBoolean() && getRepositoryClient())
-						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile, repositoryClient)
+					if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
+						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile, metadataStore)
 				}
 			}
 		}
@@ -242,9 +231,9 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 }
 
 
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
-
-	return repositoryClient
+def getMetadataStore() {
+	if (!metadataStore)
+		metadataStore = MetadataStoreFactory.getMetadataStore()
+	return metadataStore
 }
+

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -85,7 +85,7 @@ sortedList.each { buildFile ->
 					// only scan the load module if load module scanning turned on for file
 					String scanLoadModule = props.getFileProperty('rexx_scanLoadModule', buildFile)
 					if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
-						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile, metadataStore)
+						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile)
 				}
 			}
 		}

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -65,7 +65,7 @@ sortedList.each { buildFile ->
 		String errorMsg = "*! The compile return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else {
 		// if this program needs to be link edited . . .
@@ -78,7 +78,7 @@ sortedList.each { buildFile ->
 				String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile],client:getMetadataStore())
+				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 			}
 			else {
 				if (!props.userBuild){

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -8,7 +8,6 @@ import com.ibm.dbb.metadata.*
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
 @Field def bindUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BindUtilities.groovy"))
 @Field def resolverUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ResolverUtilities.groovy"))
-@Field MetadataStore metadataStore
 
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
@@ -84,7 +83,7 @@ sortedList.each { buildFile ->
 				if (!props.userBuild){
 					// only scan the load module if load module scanning turned on for file
 					String scanLoadModule = props.getFileProperty('rexx_scanLoadModule', buildFile)
-					if (scanLoadModule && scanLoadModule.toBoolean() && getMetadataStore())
+					if (scanLoadModule && scanLoadModule.toBoolean())
 						impactUtils.saveStaticLinkDependencies(buildFile, props.linkedit_loadPDS, logicalFile)
 				}
 			}
@@ -228,12 +227,5 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	linkedit.copy(new CopyToHFS().ddName("SYSPRINT").file(logFile).hfsEncoding(props.logEncoding).append(true))
 
 	return linkedit
-}
-
-
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	return metadataStore
 }
 

--- a/languages/Transfer.groovy
+++ b/languages/Transfer.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import com.ibm.dbb.build.report.records.*
@@ -29,7 +29,7 @@ import groovy.transform.*
 // Set to keep information about which datasets where already checked/created
 @Field HashSet<String> verifiedBuildDatasets = new HashSet<String>()
 
-@Field RepositoryClient repositoryClient
+@Field MetadataStore metadataStore
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -52,7 +52,7 @@ buildList.each { buildFile ->
 		errorMsg = "*! Warning. Member name (${member}) exceeds length of 8 characters. "
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
 	} else {
 
 		// evaluate the datasetmapping, which maps build files to targetDataset defintions
@@ -80,27 +80,27 @@ buildList.each { buildFile ->
 					String errorMsg = "*! The CopyToPDS return code ($rc) for $buildFile exceeded the maximum return code allowed (0)."
 					println(errorMsg)
 					props.error = "true"
-					buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+					buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
 				}
 			} catch (BuildException e) { // Catch potential exceptions like file truncation
 				String errorMsg = "*! The CopyToPDS failed with an exception ${e.getMessage()}."
 				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
 			}
 		} else {
 			String errorMsg =  "*! Target dataset for $buildFile could not be obtained from file properties. "
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
 		}
 	}
 }
 
 // internal methods
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
-
-	return repositoryClient
+def getMetadataStore() {
+	if (!metadataStore)
+		metadataStore = MetadataStoreFactory.getMetadataStore()
+	return metadataStore
 }
+

--- a/languages/Transfer.groovy
+++ b/languages/Transfer.groovy
@@ -52,7 +52,7 @@ buildList.each { buildFile ->
 		errorMsg = "*! Warning. Member name (${member}) exceeds length of 8 characters. "
 		println(errorMsg)
 		props.error = "true"
-		buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg)
 	} else {
 
 		// evaluate the datasetmapping, which maps build files to targetDataset defintions
@@ -80,19 +80,19 @@ buildList.each { buildFile ->
 					String errorMsg = "*! The CopyToPDS return code ($rc) for $buildFile exceeded the maximum return code allowed (0)."
 					println(errorMsg)
 					props.error = "true"
-					buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
+					buildUtils.updateBuildResult(errorMsg:errorMsg)
 				}
 			} catch (BuildException e) { // Catch potential exceptions like file truncation
 				String errorMsg = "*! The CopyToPDS failed with an exception ${e.getMessage()}."
 				println(errorMsg)
 				props.error = "true"
-				buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
+				buildUtils.updateBuildResult(errorMsg:errorMsg)
 			}
 		} else {
 			String errorMsg =  "*! Target dataset for $buildFile could not be obtained from file properties. "
 			println(errorMsg)
 			props.error = "true"
-			buildUtils.updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
+			buildUtils.updateBuildResult(errorMsg:errorMsg)
 		}
 	}
 }

--- a/languages/Transfer.groovy
+++ b/languages/Transfer.groovy
@@ -29,8 +29,6 @@ import groovy.transform.*
 // Set to keep information about which datasets where already checked/created
 @Field HashSet<String> verifiedBuildDatasets = new HashSet<String>()
 
-@Field MetadataStore metadataStore
-
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
 // verify required build properties
@@ -95,12 +93,5 @@ buildList.each { buildFile ->
 			buildUtils.updateBuildResult(errorMsg:errorMsg)
 		}
 	}
-}
-
-// internal methods
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	return metadataStore
 }
 

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -196,12 +196,12 @@ zunitDebugParm = props.getFileProperty('zunit_userDebugSessionTestParm', buildFi
 			// print warning and report
 			println warningMsg
 			printReport(reportLogFile)
-			buildUtils.updateBuildResult(warningMsg:warningMsg,logs:["${member}_zunit.log":logFile],client:getMetadataStore())
+			buildUtils.updateBuildResult(warningMsg:warningMsg,logs:["${member}_zunit.log":logFile])
 		} else { // rc > props.zunit_maxWarnRC.toInteger()
 			props.error = "true"
 			String errorMsg = "*! The zunit test failed with RC=($rc) for $buildFile "
 			println(errorMsg)
-			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}_zunit.log":logFile],client:getMetadataStore())
+			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}_zunit.log":logFile])
 		}
 	}
 	else {
@@ -209,7 +209,7 @@ zunitDebugParm = props.getFileProperty('zunit_userDebugSessionTestParm', buildFi
 		props.error = "true"
 		String errorMsg = "*!  zUnit Test Job ${zUnitRunJCL.submittedJobId} failed with ${zUnitRunJCL.maxRC}"
 		println(errorMsg)
-		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}_zunit.log":logFile],client:getMetadataStore())
+		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}_zunit.log":logFile])
 	}
 
 }

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -11,8 +11,6 @@ import groovy.xml.*
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
 @Field def bindUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BindUtilities.groovy"))
-@Field MetadataStore metadataStore
-
 @Field def resolverUtils = loadScript(new File("${props.zAppBuildDir}/utilities/ResolverUtilities.groovy"))
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
@@ -217,13 +215,6 @@ zunitDebugParm = props.getFileProperty('zunit_userDebugSessionTestParm', buildFi
 /**
  * Methods
  */
-
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	return metadataStore
-}
-
 
 /*
  * returns containsPlayback, 

--- a/samples/MortgageApplication/application-conf/README.md
+++ b/samples/MortgageApplication/application-conf/README.md
@@ -20,7 +20,6 @@ gitRepositoryURL | git repository URL of the application repository to establis
 excludeFileList | Files to exclude when scanning or running full build.
 skipImpactCalculationList | Files for which the impact analysis should be skipped in impact build
 jobCard | JOBCARD for JCL execs
-useSearchConfiguration | Flag to define which DBB API is used for dependency and impact analysis. `false` uses DependencyResolver and ImpactResolver APIs, while `true` leverages the DBB SearchPathDependencyResolver and SearchParthImpactFinder APIs introduced with DBB 1.1.2
 resolveSubsystems | boolean flag to configure the SearchPathDependencyResolver to evaluate if resolved dependencies impact the file flags isCICS, isSQL, isDLI, isMQ when creating the LogicalFile
 impactResolutionRules | Comma separated list of resolution rule properties used for impact builds.  Sample resolution rule properties (in JSON format) are included below. ** deprecated ** Please consider moving to new SearchPathDepedencyAPI leveraging `impactSearch` configuration. 
 impactSearch | Impact finder resolution search configuration leveraging the SearchPathImpactFinder API. Sample configurations are inlcuded below, next to the previous rule definitions.

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -107,7 +107,7 @@ propertyFileExtension=properties
 #  true  = leverages the DBB SearchPathDependencyResolver and SearchParthImpactFinder APIs introduced with DBB 1.1.2
 #          configuration is based on the lang_dependencySearch and impactSearch build properties
 #
-useSearchConfiguration=false
+useSearchConfiguration=true
 
 #
 # boolean flag to configure the SearchPathDependencyResolver to evaluate if resolved dependencies impact

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -98,22 +98,9 @@ propertyFileExtension=properties
 # Dependency Analysis and Impact Analysis configuration
 ###############################################################
 #
-# flag to define which DBB API is used for dependency and impact analysis
-# 
-#  false = uses the DependencyResolver and ImpactResolver APIs (default)
-#          please note that DependencyResolver and ImpactResolver APIs are deprecated
-#          configuration is based on the lang_resolutionRules and impactResolutionRules build properties
-#
-#  true  = leverages the DBB SearchPathDependencyResolver and SearchParthImpactFinder APIs introduced with DBB 1.1.2
-#          configuration is based on the lang_dependencySearch and impactSearch build properties
-#
-useSearchConfiguration=true
-
-#
 # boolean flag to configure the SearchPathDependencyResolver to evaluate if resolved dependencies impact
 #  the file flags isCICS, isSQL, isDLI, isMQ when creating the LogicalFile
 # 
-#  requires to use new APIs via useSearchConfiguration=true
 #  default:false 
 resolveSubsystems=false
 

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -28,7 +28,6 @@ loadFileLevelProperties | Flag to enable the zAppBuild capability to load indivi
 propertyFilePath | relative path to folder containing individual property files | true
 propertyFileExtension | file extension for individual property files | true
 **Dependency and Impact resolution configuration** ||
-useSearchConfiguration | Flag to define which DBB API is used for dependency and impact analysis. `false` uses DependencyResolver and ImpactResolver APIs, while `true` leverages the DBB SearchPathDependencyResolver and SearchParthImpactFinder APIs introduced with DBB 1.1.2 | false
 resolveSubsystems | boolean flag to configure the SearchPathDependencyResolver to evaluate if resolved dependencies impact the file flags isCICS, isSQL, isDLI, isMQ when creating the LogicalFile | false
 impactResolutionRules | Comma separated list of resolution rule properties used for impact builds.  Sample resolution rule properties (in JSON format) are included below. ** deprecated ** Please consider moving to new SearchPathDepedencyAPI leveraging `impactSearch` configuration. | true, recommended in file.properties
 impactSearch | Impact finder resolution search configuration leveraging the SearchPathImpactFinder API. Sample configurations are inlcuded below, next to the previous rule definitions. | true

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -117,22 +117,9 @@ propertyFileExtension=properties
 # Dependency Analysis and Impact Analysis configuration
 ###############################################################
 #
-# flag to define which DBB API is used for dependency and impact analysis
-# 
-#  false = uses the DependencyResolver and ImpactResolver APIs (default)
-#          please note that DependencyResolver and ImpactResolver APIs are deprecated
-#          configuration is based on the lang_resolutionRules and impactResolutionRules build properties
-#
-#  true  = leverages the DBB SearchPathDependencyResolver and SearchParthImpactFinder APIs introduced with DBB 1.1.2
-#          configuration is based on the lang_dependencySearch and impactSearch build properties
-#
-useSearchConfiguration=true
-
-#
 # boolean flag to configure the SearchPathDependencyResolver to evaluate if resolved dependencies impact
 #  the file flags isCICS, isSQL, isDLI, isMQ when creating the LogicalFile
 # 
-#  requires to use new APIs via useSearchConfiguration=true
 #  default:false 
 resolveSubsystems=false
 

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -126,7 +126,7 @@ propertyFileExtension=properties
 #  true  = leverages the DBB SearchPathDependencyResolver and SearchParthImpactFinder APIs introduced with DBB 1.1.2
 #          configuration is based on the lang_dependencySearch and impactSearch build properties
 #
-useSearchConfiguration=false
+useSearchConfiguration=true
 
 #
 # boolean flag to configure the SearchPathDependencyResolver to evaluate if resolved dependencies impact

--- a/samples/userBuildDependencyFile/sample.json
+++ b/samples/userBuildDependencyFile/sample.json
@@ -1,12 +1,12 @@
 {
-    "fileName": "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/cobol/epscmort.cbl",
+    "fileName": "MortgageApplication/cobol/epscmort.cbl",
     "isCICS": true,
     "isSQL": true,
     "isDLI": false,
     "isMQ": false,
     "dependencies": [
-        "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsmtcom.cpy",
-        "/u/burgess/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsnbrpm.cpy",
+        "MortgageApplication/copybook/epsmtcom.cpy",
+        "MortgageApplication/copybook/epsnbrpm.cpy",
         "MortgageApplication/copybook/epsmtinp.cpy",
         "MortgageApplication/copybook/epsmtout.cpy"
     ],

--- a/utilities/BindUtilities.groovy
+++ b/utilities/BindUtilities.groovy
@@ -1,6 +1,6 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
 import com.ibm.dbb.build.*
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import groovy.transform.*
 import groovy.cli.commons.*

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
@@ -115,10 +115,7 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMap
 		String lname = CopyToPDS.createMemberName(buildFile)
 		String language = props.getFileProperty('dbb.DependencyScanner.languageHint', buildFile) ?: 'UNKN'
 		LogicalFile lfile = new LogicalFile(lname, buildFile, language, depFileData.isCICS, depFileData.isSQL, depFileData.isDLI)
-		// set logical file in the dependency resolver if using deprecated API
-		if (dependencyResolver && (dependencyResolver instanceof DependencyResolver)) 
-			dependencyResolver.setLogicalFile(lfile) 
-
+		
 		// get list of dependencies from userBuildDependencyFile
 		List<String> dependencyPaths = depFileData.dependencies
 
@@ -158,23 +155,10 @@ def copySourceFiles(String buildFile, String srcPDS, String dependencyDatasetMap
 	}
 	else if (dependencyDatasetMapping && dependencyResolver) {
 		// resolve the logical dependencies to physical files to copy to data sets
-		List<PhysicalDependency> physicalDependencies
-
-		if (dependencyResolver instanceof DependencyResolver) { // deprecated DependencyResolver
-			physicalDependencies = dependencyResolver.resolve()
-			if (props.verbose) {
-				println "*** Resolution rules for $buildFile:"
-
-				if (props.formatConsoleOutput && props.formatConsoleOutput.toBoolean()) {
-					printResolutionRules(dependencyResolver.getResolutionRules())
-				} else {
-					dependencyResolver.getResolutionRules().each{ rule -> println rule }
-				}
-			}
-		} else if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) {
-			resolverUtils = loadScript(new File("ResolverUtilities.groovy"))
-			physicalDependencies = resolverUtils.resolveDependencies(dependencyResolver, buildFile)
-		}
+		
+		resolverUtils = loadScript(new File("ResolverUtilities.groovy"))
+		List<PhysicalDependency> physicalDependencies = resolverUtils.resolveDependencies(dependencyResolver, buildFile)
+		
 
 		if (props.verbose) println "*** Physical dependencies for $buildFile:"
 
@@ -284,11 +268,11 @@ def sortBuildList(List<String> buildList, String rankPropertyName) {
  * updateBuildResult - used by language scripts to update the build result after a build step
  */
 def updateBuildResult(Map args) {
-	// args : errorMsg / warningMsg, logs[logName:logFile], client:repoClient
+	// args : errorMsg / warningMsg, logs[logName:logFile], store:repoClient
 
 	// update build results only in non-userbuild scenarios
-	if (args.client && !props.userBuild) {
-		def buildResult = args.client.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
+	if (args.store && !props.userBuild) {
+		def buildResult = args.store.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 		if (!buildResult) {
 			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
 			return
@@ -312,12 +296,11 @@ def updateBuildResult(Map args) {
 		if (args.logs) {
 			args.logs.each { logName, logFile ->
 				if (logFile)
+					println(logName)
 					buildResult.addAttachment(logName, new FileInputStream(logFile))
 			}
 		}
 
-		// save result
-		buildResult.save()
 	}
 }
 
@@ -325,48 +308,48 @@ def updateBuildResult(Map args) {
  * createDependencyResolver - Creates a dependency resolver using resolution rules declared
  * in a build or file property (json format).
  */
-def createDependencyResolver(String buildFile, String rules) {
-	if (props.verbose) println "*** Creating dependency resolver for $buildFile with $rules rules"
+// def createDependencyResolver(String buildFile, String rules) {
+// 	if (props.verbose) println "*** Creating dependency resolver for $buildFile with $rules rules"
 
-	// create a dependency resolver for the build file
-	DependencyResolver resolver = new DependencyResolver().file(buildFile)
-			.sourceDir(props.workspace)
+// 	// create a dependency resolver for the build file
+// 	DependencyResolver resolver = new DependencyResolver().file(buildFile)
+// 			.sourceDir(props.workspace)
 	
-	// add scanner if userBuild Dep File not provided, or not a user build
-	if (!props.userBuildDependencyFile || !props.userBuild)
-		resolver.setScanner(getScanner(buildFile))
+// 	// add scanner if userBuild Dep File not provided, or not a user build
+// 	if (!props.userBuildDependencyFile || !props.userBuild)
+// 		resolver.setScanner(getScanner(buildFile))
 
-	// add resolution rules
-	if (rules)
-		resolver.setResolutionRules(parseResolutionRules(rules))
+// 	// add resolution rules
+// 	if (rules)
+// 		resolver.setResolutionRules(parseResolutionRules(rules))
 
-	return resolver
-}
+// 	return resolver
+// }
 
-def parseResolutionRules(String json) {
-	List<ResolutionRule> rules = new ArrayList<ResolutionRule>()
-	JsonSlurper slurper = new groovy.json.JsonSlurper()
-	List jsonRules = slurper.parseText(json)
-	if (jsonRules) {
-		jsonRules.each { jsonRule ->
-			ResolutionRule resolutionRule = new ResolutionRule()
-			resolutionRule.library(jsonRule.library)
-			resolutionRule.lname(jsonRule.lname)
-			resolutionRule.category(jsonRule.category)
-			if (jsonRule.searchPath) {
-				jsonRule.searchPath.each { jsonPath ->
-					DependencyPath dependencyPath = new DependencyPath()
-					dependencyPath.collection(jsonPath.collection)
-					dependencyPath.sourceDir(jsonPath.sourceDir)
-					dependencyPath.directory(jsonPath.directory)
-					resolutionRule.path(dependencyPath)
-				}
-			}
-			rules << resolutionRule
-		}
-	}
-	return rules
-}
+// def parseResolutionRules(String json) {
+// 	List<ResolutionRule> rules = new ArrayList<ResolutionRule>()
+// 	JsonSlurper slurper = new groovy.json.JsonSlurper()
+// 	List jsonRules = slurper.parseText(json)
+// 	if (jsonRules) {
+// 		jsonRules.each { jsonRule ->
+// 			ResolutionRule resolutionRule = new ResolutionRule()
+// 			resolutionRule.library(jsonRule.library)
+// 			resolutionRule.lname(jsonRule.lname)
+// 			resolutionRule.category(jsonRule.category)
+// 			if (jsonRule.searchPath) {
+// 				jsonRule.searchPath.each { jsonPath ->
+// 					DependencyPath dependencyPath = new DependencyPath()
+// 					dependencyPath.collection(jsonPath.collection)
+// 					dependencyPath.sourceDir(jsonPath.sourceDir)
+// 					dependencyPath.directory(jsonPath.directory)
+// 					resolutionRule.path(dependencyPath)
+// 				}
+// 			}
+// 			rules << resolutionRule
+// 		}
+// 	}
+// 	return rules
+// }
 
 
 
@@ -538,20 +521,20 @@ def getLangPrefix(String scriptName){
 }
 
 /*
- * retrieveLastBuildResult(RepositoryClient)
+ * retrieveLastBuildResult(MetadataStore)
  * returns last successful build result
  *
  */
-def retrieveLastBuildResult(RepositoryClient repositoryClient){
+def retrieveLastBuildResult(MetadataStore metadataStore){
 
 	// get the last build result
-	def lastBuildResult = repositoryClient.getLastBuildResult(props.applicationBuildGroup, BuildResult.COMPLETE, BuildResult.CLEAN)
+	def lastBuildResult = metadataStore.getLastBuildResult(props.applicationBuildGroup, BuildResult.COMPLETE, BuildResult.CLEAN)
 
 	if (lastBuildResult == null && props.topicBranchBuild){
 		// if this is the first topic branch build get the main branch build result
 		if (props.verbose) println "** No previous successful topic branch build result. Retrieving last successful main branch build result."
 		String mainBranchBuildGroup = "${props.application}-${props.mainBuildBranch}"
-		lastBuildResult = repositoryClient.getLastBuildResult(mainBranchBuildGroup, BuildResult.COMPLETE, BuildResult.CLEAN)
+		lastBuildResult = metadataStore.getLastBuildResult(mainBranchBuildGroup, BuildResult.COMPLETE, BuildResult.CLEAN)
 	}
 
 	if (lastBuildResult == null) {
@@ -704,29 +687,29 @@ def retrieveHFSFileEncoding(File file) {
  * Logs the resolution rules of the DependencyResolver in a table format
  * 
  */
-def printResolutionRules(List<ResolutionRule> rules) {
+// def printResolutionRules(List<ResolutionRule> rules) {
 
-	println("*** Configured resulution rules:")
+// 	println("*** Configured resulution rules:")
 	
-	// Print header of table
-	println("    " + "Library".padRight(10) + "Category".padRight(12) + "SourceDir/File".padRight(50) + "Directory".padRight(36) + "Collection".padRight(24) + "Archive".padRight(20))
-	println("    " + " ".padLeft(10,"-") + " ".padLeft(12,"-") + " ".padLeft(50,"-") + " ".padLeft(36,"-") + " ".padLeft(24,"-") + " ".padLeft(20,"-"))
+// 	// Print header of table
+// 	println("    " + "Library".padRight(10) + "Category".padRight(12) + "SourceDir/File".padRight(50) + "Directory".padRight(36) + "Collection".padRight(24) + "Archive".padRight(20))
+// 	println("    " + " ".padLeft(10,"-") + " ".padLeft(12,"-") + " ".padLeft(50,"-") + " ".padLeft(36,"-") + " ".padLeft(24,"-") + " ".padLeft(20,"-"))
 
-	// iterate over rules configured for the dependencyResolver
-	rules.each{ rule ->
-		searchPaths = rule.getSearchPath()
-		searchPaths.each { DependencyPath searchPath ->
-			def libraryName = (rule.getLibrary() != null) ? rule.getLibrary().padRight(10) : "N/A".padRight(10)
-			def categoryName = (rule.getCategory() != null) ? rule.getCategory().padRight(12) : "N/A".padRight(12)
-			def srcDir = (searchPath.getSourceDir() != null) ? searchPath.getSourceDir().padRight(50) : "N/A".padRight(50)
-			def directory = (searchPath.getDirectory() != null) ? searchPath.getDirectory().padRight(36) : "N/A".padRight(36)
-			def collection = (searchPath.getCollection() != null) ? searchPath.getCollection().padRight(24) : "N/A".padRight(24)
-			def archiveFile = (searchPath.getArchive() != null) ? searchPath.getArchive().padRight(20) : "N/A".padRight(20)
-			println("    " + libraryName + categoryName + srcDir + directory + collection + archiveFile)
+// 	// iterate over rules configured for the dependencyResolver
+// 	rules.each{ rule ->
+// 		searchPaths = rule.getSearchPath()
+// 		searchPaths.each { DependencyPath searchPath ->
+// 			def libraryName = (rule.getLibrary() != null) ? rule.getLibrary().padRight(10) : "N/A".padRight(10)
+// 			def categoryName = (rule.getCategory() != null) ? rule.getCategory().padRight(12) : "N/A".padRight(12)
+// 			def srcDir = (searchPath.getSourceDir() != null) ? searchPath.getSourceDir().padRight(50) : "N/A".padRight(50)
+// 			def directory = (searchPath.getDirectory() != null) ? searchPath.getDirectory().padRight(36) : "N/A".padRight(36)
+// 			def collection = (searchPath.getCollection() != null) ? searchPath.getCollection().padRight(24) : "N/A".padRight(24)
+// 			def archiveFile = (searchPath.getArchive() != null) ? searchPath.getArchive().padRight(20) : "N/A".padRight(20)
+// 			println("    " + libraryName + categoryName + srcDir + directory + collection + archiveFile)
 
-		}
-	}
-}
+// 		}
+// 	}
+// }
 
 /*
  * Logs information about the physical dependencies in a table format

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -624,7 +624,9 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 		assert depFileData."${depFileProp}" != null : "*! Missing required dependency file field '$depFileProp'"
 	}
 	// Validate depFileData.fileName == buildFile
-	assert getAbsolutePath(depFileData.fileName) == getAbsolutePath(buildFile) : "*! Dependency file mismatch: fileName does not match build file"
+	String depFilePath = getAbsolutePath(depFileData.fileName)
+	String buildFilePath = getAbsolutePath(buildFile)
+	assert depFilePath == buildFilePath : "*! Dependency file mismatch: \nfile path: ${depFilePath} \nbuild file path: ${buildFilePath}"
 	return depFileData // return the parsed JSON object
 }
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -625,7 +625,8 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 	}
 	// Validate depFileData.fileName == buildFile
 	String buildFilePath = getAbsolutePath(buildFile)
-	assert depFilePath == buildFilePath : "*! Dependency file mismatch: \nfile path: ${depFilePath} \nbuild file path: ${buildFilePath}"
+	String fileNamePath = getAbsolutePath(depFileData.fileName)
+	assert fileNamePath == buildFilePath : "*! Dependency file mismatch: The dependency file 'fileName' value does not match build file"
 	return depFileData // return the parsed JSON object
 }
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -268,11 +268,11 @@ def sortBuildList(List<String> buildList, String rankPropertyName) {
  * updateBuildResult - used by language scripts to update the build result after a build step
  */
 def updateBuildResult(Map args) {
-	// args : errorMsg / warningMsg, logs[logName:logFile], client:repoClient
-
+	// args : errorMsg / warningMsg, logs[logName:logFile]
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	// update build results only in non-userbuild scenarios
-	if (args.client && !props.userBuild) {
-		def buildResult = args.store.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
+	if (metadataStore && !props.userBuild) {
+		def buildResult = metadataStore.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 		if (!buildResult) {
 			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
 			return
@@ -296,7 +296,6 @@ def updateBuildResult(Map args) {
 		if (args.logs) {
 			args.logs.each { logName, logFile ->
 				if (logFile)
-					println(logName)
 					buildResult.addAttachment(logName, new FileInputStream(logFile))
 			}
 		}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -520,12 +520,12 @@ def getLangPrefix(String scriptName){
 }
 
 /*
- * retrieveLastBuildResult(MetadataStore)
+ * retrieveLastBuildResult()
  * returns last successful build result
  *
  */
-def retrieveLastBuildResult(MetadataStore metadataStore){
-
+def retrieveLastBuildResult(){
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	// get the last build result
 	def lastBuildResult = metadataStore.getLastBuildResult(props.applicationBuildGroup, BuildResult.COMPLETE, BuildResult.CLEAN)
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -599,9 +599,9 @@ def generateDb2InfoRecord(String buildFile){
 def validateDependencyFile(String buildFile, String depFilePath) {
 	String[] allowedEncodings = ["UTF-8", "IBM-1047"]
 	String[] reqDepFileProps = ["fileName", "isCICS", "isSQL", "isDLI", "isMQ", "dependencies", "schemaVersion"]
-	
+	depFilePath = getAbsolutePath(depFilePath)
 	// Load dependency file and verify existance
-	File depFile = new File(getAbsolutePath(depFilePath))
+	File depFile = new File(depFilePath)
 	assert depFile.exists() : "*! Dependency file not found: ${depFile.getAbsolutePath()}"
 	
 	// Parse the JSON file
@@ -625,7 +625,6 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 	}
 	// Validate depFileData.fileName == buildFile
 	String depFilePath = getAbsolutePath(depFileData.fileName)
-	String buildFilePath = getAbsolutePath(buildFile)
 	assert depFilePath == buildFilePath : "*! Dependency file mismatch: \nfile path: ${depFilePath} \nbuild file path: ${buildFilePath}"
 	return depFileData // return the parsed JSON object
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -624,7 +624,7 @@ def validateDependencyFile(String buildFile, String depFilePath) {
 		assert depFileData."${depFileProp}" != null : "*! Missing required dependency file field '$depFileProp'"
 	}
 	// Validate depFileData.fileName == buildFile
-	String depFilePath = getAbsolutePath(depFileData.fileName)
+	String buildFilePath = getAbsolutePath(buildFile)
 	assert depFilePath == buildFilePath : "*! Dependency file mismatch: \nfile path: ${depFilePath} \nbuild file path: ${buildFilePath}"
 	return depFileData // return the parsed JSON object
 }

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -268,10 +268,10 @@ def sortBuildList(List<String> buildList, String rankPropertyName) {
  * updateBuildResult - used by language scripts to update the build result after a build step
  */
 def updateBuildResult(Map args) {
-	// args : errorMsg / warningMsg, logs[logName:logFile], store:repoClient
+	// args : errorMsg / warningMsg, logs[logName:logFile], client:repoClient
 
 	// update build results only in non-userbuild scenarios
-	if (args.store && !props.userBuild) {
+	if (args.client && !props.userBuild) {
 		def buildResult = args.store.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 		if (!buildResult) {
 			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -405,14 +405,14 @@ def updateBuildResult(Map args) {
 		// add error message
 		if (args.errorMsg) {
 			buildResult.setStatus(buildResult.ERROR)
-			buildResult.setProperty("error", args.errorMsg)
+			buildResult.addProperty("error", args.errorMsg)
 		}
 		// add warning message, but keep result status
 		if (args.warningMsg) {
 			// buildResult.setStatus(buildResult.WARNING)
-			buildResult.setProperty("warning", args.warningMsg)
+			buildResult.addProperty("warning", args.warningMsg)
 		}
 		// save result
-		buildResult.save()
+		//buildResult.save()
 	}
 }

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -25,7 +25,7 @@ def isGitDir(String dir) {
 	if (gitError) {
 		String warningMsg = "*? Warning executing isGitDir($dir). Git command: $cmd error: $gitError"
 		println(warningMsg)
-		updateBuildResult(warningMsg:warningMsg,client:getMetadataStore())
+		updateBuildResult(warningMsg:warningMsg)
 	}
 	else if (gitResponse) {
 		isGit = gitResponse.toString().trim().toBoolean()
@@ -145,7 +145,7 @@ def getCurrentGitHash(String gitDir, boolean abbrev) {
 		String errorMsg = "*! Error executing Git command: $cmd error: $gitError"
 		println(errorMsg)
 		props.error = "true"
-		updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
+		updateBuildResult(errorMsg:errorMsg)
 	}
 	return gitHash.toString().trim()
 }
@@ -260,7 +260,7 @@ def getChangedFiles(String cmd) {
 		String errorMsg = "*! Error executing Git command: $cmd error: $git_error \n *! Attempting to parse unstable git command for changed files..."
 		println(errorMsg)
 		props.error = "true"
-		updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
+		updateBuildResult(errorMsg:errorMsg)
 	}
 
 	for (line in git_diff.toString().split("\n")) {
@@ -393,11 +393,12 @@ def getMetadataStore() {
  * updateBuildResult - for git cmd related issues
  */
 def updateBuildResult(Map args) {
-	// args : errorMsg / warningMsg, client:repoClient
+	// args : errorMsg / warningMsg
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 
 	// update build results only in non-userbuild scenarios
-	if (args.client && !props.userBuild) {
-		def buildResult = args.client.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
+	if (metadataStore && !props.userBuild) {
+		def buildResult = metadataStore.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
 		if (!buildResult) {
 			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
 			return
@@ -412,7 +413,5 @@ def updateBuildResult(Map args) {
 			// buildResult.setStatus(buildResult.WARNING)
 			buildResult.addProperty("warning", args.warningMsg)
 		}
-		// save result
-		//buildResult.save()
 	}
 }

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -1,11 +1,11 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
 
 @Field BuildProperties props = BuildProperties.getInstance()
-@Field RepositoryClient repositoryClient
+@Field MetadataStore metadataStore
 
 /*
  * Tests if directory is in a local git repository
@@ -25,7 +25,7 @@ def isGitDir(String dir) {
 	if (gitError) {
 		String warningMsg = "*? Warning executing isGitDir($dir). Git command: $cmd error: $gitError"
 		println(warningMsg)
-		updateBuildResult(warningMsg:warningMsg,client:getRepositoryClient())
+		updateBuildResult(warningMsg:warningMsg,client:getMetadataStore())
 	}
 	else if (gitResponse) {
 		isGit = gitResponse.toString().trim().toBoolean()
@@ -145,7 +145,7 @@ def getCurrentGitHash(String gitDir, boolean abbrev) {
 		String errorMsg = "*! Error executing Git command: $cmd error: $gitError"
 		println(errorMsg)
 		props.error = "true"
-		updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+		updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
 	}
 	return gitHash.toString().trim()
 }
@@ -260,7 +260,7 @@ def getChangedFiles(String cmd) {
 		String errorMsg = "*! Error executing Git command: $cmd error: $git_error \n *! Attempting to parse unstable git command for changed files..."
 		println(errorMsg)
 		props.error = "true"
-		updateBuildResult(errorMsg:errorMsg,client:getRepositoryClient())
+		updateBuildResult(errorMsg:errorMsg,client:getMetadataStore())
 	}
 
 	for (line in git_diff.toString().split("\n")) {
@@ -383,10 +383,10 @@ def getChangedProperties(String gitDir, String baseline, String currentHash, Str
 
 /** helper methods **/
 
-def getRepositoryClient() {
-	if (!repositoryClient && props."dbb.RepositoryClient.url")
-		repositoryClient = new RepositoryClient().forceSSLTrusted(true)
-	return repositoryClient
+def getMetadataStore() {
+	if (!metadataStore)
+		metadataStore = MetadataStoreFactory.getMetadataStore()
+	return metadataStore
 }
 
 /*
@@ -405,12 +405,12 @@ def updateBuildResult(Map args) {
 		// add error message
 		if (args.errorMsg) {
 			buildResult.setStatus(buildResult.ERROR)
-			buildResult.addProperty("error", args.errorMsg)
+			buildResult.setProperty("error", args.errorMsg)
 		}
 		// add warning message, but keep result status
 		if (args.warningMsg) {
 			// buildResult.setStatus(buildResult.WARNING)
-			buildResult.addProperty("warning", args.warningMsg)
+			buildResult.setProperty("warning", args.warningMsg)
 		}
 		// save result
 		buildResult.save()

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -28,7 +28,7 @@ def createImpactBuildList() {
 	Set<String> changedBuildProperties = new HashSet<String>()
 
 	// get the last build result to get the baseline hashes
-	def lastBuildResult = buildUtils.retrieveLastBuildResult(metadataStore)
+	def lastBuildResult = buildUtils.retrieveLastBuildResult()
 
 	// calculate changed files
 	if (lastBuildResult || props.baselineRef) {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -72,31 +72,10 @@ def createImpactBuildList(MetadataStore metadataStore) {
 			// get exclude list
 			List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
 			
-			// list of impacts
-				
+			// Get impacted files using the SearchPathImpactFinder
 			String impactSearch = props.getFileProperty('impactSearch', changedFile)
 			def impacts = resolverUtils.findImpactedFiles(impactSearch, changedFile)
 			println(" ***** Impacts for changed file ${changedFile}: ${impacts.toString()}")
-		
-			// else {
-			// 	String impactResolutionRules = props.getFileProperty('impactResolutionRules', changedFile)
-			// 	ImpactResolver impactResolver = createImpactResolver(changedFile, impactResolutionRules, metadataStore)
-
-			// 	// Print impactResolverConfiguration
-			// 	if (props.verbose && props.formatConsoleOutput && props.formatConsoleOutput.toBoolean()) {
-			// 		// print collection information
-			// 		println("    " + "Collection".padRight(20) )
-			// 		println("    " + " ".padLeft(20,"-"))
-			// 		impactResolver.getCollections().each{ collectionName ->
-			// 			println("    " + collectionName)
-			// 		}
-			// 		// print impact resolution rule in table format
-			// 		buildUtils.printResolutionRules(impactResolver.getResolutionRules())
-			// 	}
-
-			// 	// resolving impacts
-			// 	impacts = impactResolver.resolve()
-			// }
 			
 			impacts.each { impact ->
 				def impactFile = impact.getFile()

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -597,9 +597,9 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 						// update build result
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
-							buildUtils.updateBuildResult(errorMsg:msg,client:metadataStore)
+							buildUtils.updateBuildResult(errorMsg:msg)
 						} else {
-							buildUtils.updateBuildResult(warningMsg:msg,client:metadataStore)
+							buildUtils.updateBuildResult(warningMsg:msg)
 						}
 					}
 					else
@@ -619,9 +619,9 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 						// update build result
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
-							buildUtils.updateBuildResult(errorMsg:msg,client:metadataStore)
+							buildUtils.updateBuildResult(errorMsg:msg)
 						} else {
-							buildUtils.updateBuildResult(warningMsg:msg,client:metadataStore)
+							buildUtils.updateBuildResult(warningMsg:msg)
 						}
 					}
 					else
@@ -641,9 +641,9 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 						// update build result
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
-							buildUtils.updateBuildResult(errorMsg:msg,client:metadataStore)
+							buildUtils.updateBuildResult(errorMsg:msg)
 						} else {
-							buildUtils.updateBuildResult(warningMsg:msg,client:metadataStore)
+							buildUtils.updateBuildResult(warningMsg:msg)
 						}
 					}
 					else
@@ -897,7 +897,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 			} catch (Exception e) {
 
 				String warningMsg = "***** Scanning failed for file $file (${props.workspace}/${file})"
-				buildUtils.updateBuildResult(warningMsg:warningMsg,client:getMetadataStore())
+				buildUtils.updateBuildResult(warningMsg:warningMsg)
 				println(warningMsg)
 				e.printStackTrace()
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -659,7 +659,8 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
  * Configured through reportExternalImpacts* build properties
  */
 
-def reportExternalImpacts(MetadataStore metadataStore, Set<String> changedFiles){
+def reportExternalImpacts(Set<String> changedFiles){
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	// query external collections to produce externalImpactList
 
 	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>() // <collection><List impactRecords>

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -17,11 +17,9 @@ import java.util.regex.*
 @Field def resolverUtils
 
 
-def createImpactBuildList(MetadataStore metadataStore) {
-	
-	// Conditionally load the ResolverUtilities.groovy which require at least DBB 1.1.2
-	if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) {
-		resolverUtils = loadScript(new File("ResolverUtilities.groovy")) }
+def createImpactBuildList() {
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
+	resolverUtils = loadScript(new File("ResolverUtilities.groovy")) 
 	
 	// local variables
 	Set<String> changedFiles = new HashSet<String>()
@@ -44,8 +42,6 @@ def createImpactBuildList(MetadataStore metadataStore) {
 
 	// scan files and update source collection for impact analysis
 	updateCollection(changedFiles, deletedFiles, renamedFiles, metadataStore)
-
-
 
 	// create build list using impact analysis
 	if (props.verbose) println "*** Perform impacted analysis for changed files."

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -500,7 +500,7 @@ def scanOnlyStaticDependencies(List buildList){
 				if ((isLinkEdited && isLinkEdited.toBoolean()) || scriptMapping == "LinkEdit.groovy"){
 					try{
 						if (props.verbose) println ("*** Scanning load module $loadPDSMember of $buildFile")
-						saveStaticLinkDependencies(buildFile, props."${langPrefix}_loadPDS", logicalFile, metadataStore)
+						saveStaticLinkDependencies(buildFile, props."${langPrefix}_loadPDS", logicalFile)
 					}
 					catch (com.ibm.dbb.build.ValidationException e){
 						println ("!* Error scanning output file for $buildFile  : $loadPDSMember")
@@ -929,7 +929,8 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
  * saveStaticLinkDependencies - Scan the load module to determine LINK dependencies. Impact resolver can use
  * these to determine that this file gets rebuilt if a LINK dependency changes.
  */
-def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile logicalFile, MetadataStore metadataStore) {
+def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile logicalFile) {
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	if (metadataStore) {
 		LinkEditScanner scanner = new LinkEditScanner()
 		if (props.verbose) println "*** Scanning load module for $buildFile"

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -198,7 +198,7 @@ def createImpactBuildList(MetadataStore metadataStore) {
 
 					// create logical dependency and query collections for logical files with this dependency
 					LogicalDependency lDependency = new LogicalDependency("$changedProp","BUILDPROPERTIES","PROPERTY")
-					logicalFileList = repositoryClient.getAllLogicalFiles(props.applicationCollectionName, lDependency)
+					logicalFileList = metadataStore.getLogicalFiles(props.applicationCollectionName, lDependency)
 
 
 					// get excludeListe
@@ -508,7 +508,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
  * Scenario: Migrate Source to Git and scan against existing set of loadmodules.
  * Limitation: Sample for cobol
  */
-def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient){
+def scanOnlyStaticDependencies(List buildList, MetadataStore metadataStore){
 	buildList.each { buildFile ->
 		def scriptMapping = ScriptMappings.getScriptName(buildFile)
 		if(scriptMapping != null){
@@ -525,7 +525,7 @@ def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient
 				if ((isLinkEdited && isLinkEdited.toBoolean()) || scriptMapping == "LinkEdit.groovy"){
 					try{
 						if (props.verbose) println ("*** Scanning load module $loadPDSMember of $buildFile")
-						saveStaticLinkDependencies(buildFile, props."${langPrefix}_loadPDS", logicalFile, repositoryClient)
+						saveStaticLinkDependencies(buildFile, props."${langPrefix}_loadPDS", logicalFile, metadataStore)
 					}
 					catch (com.ibm.dbb.build.ValidationException e){
 						println ("!* Error scanning output file for $buildFile  : $loadPDSMember")
@@ -550,11 +550,11 @@ def scanOnlyStaticDependencies(List buildList, RepositoryClient repositoryClient
  *
  * Invokes method generateConcurrentChangesReports to produce the reports
  *
- * @param repositoryClient
+ * @param metadataStore
  * @param buildSet
  *
  */
-def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> buildSet) {
+def calculateConcurrentChanges(MetadataStore metadataStore, Set<String> buildSet) {
 	
 		// initialize patterns
 		List<Pattern> gitRefMatcherPatterns = createMatcherPatterns(props.reportConcurrentChangesGitBranchReferencePatterns)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -696,7 +696,7 @@ def reportExternalImpacts(Set<String> changedFiles){
 			}
 
 			if (externalImpactReportingList.size() != 0) {
-				(collectionImpactsSetMap, impactedFiles) = calculateLogicalImpactedFiles(externalImpactReportingList, changedFiles, collectionImpactsSetMap, metadataStore, "***", "buildSet")
+				(collectionImpactsSetMap, impactedFiles) = calculateLogicalImpactedFiles(externalImpactReportingList, changedFiles, collectionImpactsSetMap, "***", "buildSet")
 
 
 				// get impacted files of idenfied impacted files
@@ -707,7 +707,7 @@ def reportExternalImpacts(Set<String> changedFiles){
 
 					}
 					def impactsBin
-					(collectionImpactsSetMap, impactsBin) = calculateLogicalImpactedFiles(new ArrayList(impactedFiles), changedFiles, collectionImpactsSetMap, metadataStore, "****", "impactSet")
+					(collectionImpactsSetMap, impactsBin) = calculateLogicalImpactedFiles(new ArrayList(impactedFiles), changedFiles, collectionImpactsSetMap, "****", "impactSet")
 				}
 
 			}
@@ -745,7 +745,8 @@ def reportExternalImpacts(Set<String> changedFiles){
  * Used to inspect dbb collections for potential impacts, sub-method to reportExternalImpacts
  */
 
-def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFiles, Map<String,HashSet> collectionImpactsSetMap, MetadataStore metadataStore, String indentationMsg, String analysisMode) {
+def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFiles, Map<String,HashSet> collectionImpactsSetMap, String indentationMsg, String analysisMode) {
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 
 	// local matchers to inspect files and collections
 	List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.reportExternalImpactsCollectionPatterns)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -482,7 +482,8 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
  * Scenario: Migrate Source to Git and scan against existing set of loadmodules.
  * Limitation: Sample for cobol
  */
-def scanOnlyStaticDependencies(List buildList, MetadataStore metadataStore){
+def scanOnlyStaticDependencies(List buildList){
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	buildList.each { buildFile ->
 		def scriptMapping = ScriptMappings.getScriptName(buildFile)
 		if(scriptMapping != null){

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -215,7 +215,8 @@ def createImpactBuildList() {
  *
  */
 
-def createMergeBuildList(MetadataStore metadataStore){
+def createMergeBuildList(){
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	Set<String> changedFiles = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -529,7 +529,8 @@ def scanOnlyStaticDependencies(List buildList){
  * @param buildSet
  *
  */
-def calculateConcurrentChanges(MetadataStore metadataStore, Set<String> buildSet) {
+def calculateConcurrentChanges(Set<String> buildSet) {
+		MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	
 		// initialize patterns
 		List<Pattern> gitRefMatcherPatterns = createMatcherPatterns(props.reportConcurrentChangesGitBranchReferencePatterns)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -119,7 +119,7 @@ def createImpactBuildList() {
 
 				// create logical dependency and query collections for logical files with this dependency
 				LogicalDependency lDependency = new LogicalDependency("$changedProp","BUILDPROPERTIES","PROPERTY")
-				logicalFileList = metadataStore.getAllLogicalFiles(props.applicationCollectionName, lDependency)
+				logicalFileList = metadataStore.getCollection(props.applicationCollectionName).getLogicalFiles(lDependency)
 
 
 				// get excludeListe
@@ -171,7 +171,7 @@ def createImpactBuildList() {
 
 					// create logical dependency and query collections for logical files with this dependency
 					LogicalDependency lDependency = new LogicalDependency("$changedProp","BUILDPROPERTIES","PROPERTY")
-					logicalFileList = metadataStore.getLogicalFiles(props.applicationCollectionName, lDependency)
+					logicalFileList = metadataStore.getCollection(props.applicationCollectionName).getLogicalFiles(lDependency)
 
 
 					// get excludeListe
@@ -216,7 +216,6 @@ def createImpactBuildList() {
  */
 
 def createMergeBuildList(){
-	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	Set<String> changedFiles = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()
@@ -483,7 +482,6 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
  * Limitation: Sample for cobol
  */
 def scanOnlyStaticDependencies(List buildList){
-	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	buildList.each { buildFile ->
 		def scriptMapping = ScriptMappings.getScriptName(buildFile)
 		if(scriptMapping != null){
@@ -525,12 +523,10 @@ def scanOnlyStaticDependencies(List buildList){
  *
  * Invokes method generateConcurrentChangesReports to produce the reports
  *
- * @param metadataStore
  * @param buildSet
  *
  */
 def calculateConcurrentChanges(Set<String> buildSet) {
-		MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	
 		// initialize patterns
 		List<Pattern> gitRefMatcherPatterns = createMatcherPatterns(props.reportConcurrentChangesGitBranchReferencePatterns)
@@ -570,7 +566,6 @@ def calculateConcurrentChanges(Set<String> buildSet) {
  */
 
 def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference){
-	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges.txt"
 
 	File concurrentChangesReportFile = new File(concurrentChangesReportLoc)
@@ -660,7 +655,6 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
  */
 
 def reportExternalImpacts(Set<String> changedFiles){
-	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	// query external collections to produce externalImpactList
 
 	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>() // <collection><List impactRecords>

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -76,7 +76,7 @@ def createImpactBuildList(MetadataStore metadataStore) {
 				
 			String impactSearch = props.getFileProperty('impactSearch', changedFile)
 			def impacts = resolverUtils.findImpactedFiles(impactSearch, changedFile)
-			println(" ***** Impacts: ${impacts.toString()}")
+			println(" ***** Impacts for changed file ${changedFile}: ${impacts.toString()}")
 		
 			// else {
 			// 	String impactResolutionRules = props.getFileProperty('impactResolutionRules', changedFile)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -73,13 +73,11 @@ def createImpactBuildList(MetadataStore metadataStore) {
 			List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
 			
 			// list of impacts
-			def impacts
-
-			if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && props.impactSearch  && buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) { // use new SearchPathDependencyResolver
 				
-				String impactSearch = props.getFileProperty('impactSearch', changedFile)
-				impacts = resolverUtils.findImpactedFiles(impactSearch, changedFile)
-			}
+			String impactSearch = props.getFileProperty('impactSearch', changedFile)
+			def impacts = resolverUtils.findImpactedFiles(impactSearch, changedFile)
+			println(" ***** Impacts: ${impacts.toString()}")
+		
 			// else {
 			// 	String impactResolutionRules = props.getFileProperty('impactResolutionRules', changedFile)
 			// 	ImpactResolver impactResolver = createImpactResolver(changedFile, impactResolutionRules, metadataStore)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -904,7 +904,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 			// save logical files in batches of 500 to avoid running out of heap space
 			if (logicalFiles.size() == 500) {
 				if (props.verbose)
-					println "** Storing ${logicalFiles.size()} logical files in repository collection '$props.applicationCollectionName'"
+					println "** Storing ${logicalFiles.size()} logical files in MetadataStore collection '$props.applicationCollectionName'"
 				metadataStore.getCollection(props.applicationCollectionName).addLogicalFiles(logicalFiles)
 				logicalFiles.clear()
 			}
@@ -913,7 +913,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 
 	// save logical files
 	if (props.verbose)
-		println "** Storing ${logicalFiles.size()} logical files in repository collection '$props.applicationCollectionName'"
+		println "** Storing ${logicalFiles.size()} logical files in MetadataStore collection '$props.applicationCollectionName'"
 	metadataStore.getCollection(props.applicationCollectionName).addLogicalFiles(logicalFiles)
 	
 }

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -822,7 +822,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 	List<LogicalFile> logicalFiles = new ArrayList<LogicalFile>()
 	List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
 
-	verifyCollections(metadataStore)
+	verifyCollections()
 
 	// remove deleted files from collection
 	deletedFiles.each { file ->
@@ -950,7 +950,8 @@ def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile log
  * create or clone the collections.
  * Uses build properties
  */
-def verifyCollections(MetadataStore metadataStore) {
+def verifyCollections() {
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	if (!metadataStore) {
 		if (props.verbose) println "** Unable to verify collections. No metadata store."
 		return

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -558,7 +558,7 @@ def calculateConcurrentChanges(Set<String> buildSet) {
 				(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, concurrentBuildProperties) = calculateChangedFiles(null, true, gitReference)
 	
 				// generate reports and verify for intersects
-				generateConcurrentChangesReports(buildSet, concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference, metadataStore)
+				generateConcurrentChangesReports(buildSet, concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference)
 	
 			}
 		}
@@ -569,7 +569,8 @@ def calculateConcurrentChanges(Set<String> buildSet) {
  * Method to generate the Concurrent Changes reports and validate if the current build list intersects with concurrent changes
  */
 
-def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference, MetadataStore metadataStore){
+def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference){
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges.txt"
 
 	File concurrentChangesReportFile = new File(concurrentChangesReportLoc)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -829,8 +829,8 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 		// files in a collection are stored as relative paths from a source directory
 		if (props.verbose) println "*** Deleting logical file for $file"
 		logicalFile = buildUtils.relativizePath(file)
-		metadataStore.deleteLogicalFile(props.applicationCollectionName, logicalFile)
-		metadataStore.deleteLogicalFile(props.applicationOutputsCollectionName, logicalFile)
+		metadataStore.getCollection(props.applicationCollectionName).deleteLogicalFile(logicalFile)
+		metadataStore.getCollection(props.applicationOutputsCollectionName).deleteLogicalFile(logicalFile)
 	}
 
 	// remove renamed files from collection
@@ -838,8 +838,8 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 		// files in a collection are stored as relative paths from a source directory
 		if (props.verbose) println "*** Deleting renamed logical file for $file"
 		logicalFile = buildUtils.relativizePath(file)
-		metadataStore.deleteLogicalFile(props.applicationCollectionName, logicalFile)
-		metadataStore.deleteLogicalFile(props.applicationOutputsCollectionName, logicalFile)
+		metadataStore.getCollection(props.applicationCollectionName).deleteLogicalFile(logicalFile)
+		metadataStore.getCollection(props.applicationOutputsCollectionName).deleteLogicalFile(logicalFile)
 	}
 
 	if (props.createTestcaseDependency && props.createTestcaseDependency.toBoolean() && changedFiles && changedFiles.size() > 1) {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import java.nio.file.FileSystems
@@ -17,7 +17,7 @@ import java.util.regex.*
 @Field def resolverUtils
 
 
-def createImpactBuildList(RepositoryClient repositoryClient) {
+def createImpactBuildList(MetadataStore metadataStore) {
 	
 	// Conditionally load the ResolverUtilities.groovy which require at least DBB 1.1.2
 	if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) {
@@ -28,12 +28,9 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()
 	Set<String> changedBuildProperties = new HashSet<String>()
-	Set<String> buildSet = new HashSet<String>()
-	
-	boolean calculatedChanges = true 
 
 	// get the last build result to get the baseline hashes
-	def lastBuildResult = buildUtils.retrieveLastBuildResult(repositoryClient)
+	def lastBuildResult = buildUtils.retrieveLastBuildResult(metadataStore)
 
 	// calculate changed files
 	if (lastBuildResult || props.baselineRef) {
@@ -41,72 +38,122 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
 	}
 	else {
 		// else create a fullBuild list
-		println "*! No prior build result located.  Creating a full build list."
+		println "*! No prior build result located.  Building all programs"
 		changedFiles = buildUtils.createFullBuildList()
-		buildSet = changedFiles
-		
-		// skip impact calculation and return the generated build list
-		calculatedChanges = false
 	}
 
 	// scan files and update source collection for impact analysis
-	updateCollection(changedFiles, deletedFiles, renamedFiles, repositoryClient)
+	updateCollection(changedFiles, deletedFiles, renamedFiles, metadataStore)
 
 
-	if (calculatedChanges) {
 
-		// create build list using impact analysis
-		if (props.verbose) println "*** Perform impacted analysis for changed files."
+	// create build list using impact analysis
+	if (props.verbose) println "*** Perform impacted analysis for changed files."
 
-		PropertyMappings githashBuildableFilesMap = new PropertyMappings("githashBuildableFilesMap")
+	Set<String> buildSet = new HashSet<String>()
+	Set<String> changedBuildPropertyFiles = new HashSet<String>()
+	
+	PropertyMappings githashBuildableFilesMap = new PropertyMappings("githashBuildableFilesMap")
+	
+	
+	changedFiles.each { changedFile ->
+		// if the changed file has a build script then add to build list
+		if (ScriptMappings.getScriptName(changedFile)) {
+			buildSet.add(changedFile)
+			if (props.verbose) println "** Found build script mapping for $changedFile. Adding to build list"
+		}
 
+		// check if impact calculation should be performed, default true
+		if (shouldCalculateImpacts(changedFile)){
 
-		changedFiles.each { changedFile ->
-			// if the changed file has a build script then add to build list
-			if (ScriptMappings.getScriptName(changedFile)) {
-				buildSet.add(changedFile)
-				if (props.verbose) println "** Found build script mapping for $changedFile. Adding to build list"
+			// perform impact analysis on changed file
+			if (props.verbose) println "** Performing impact analysis on changed file $changedFile"
+
+			// get exclude list
+			List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
+			
+			// list of impacts
+			def impacts
+
+			if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && props.impactSearch  && buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) { // use new SearchPathDependencyResolver
+				
+				String impactSearch = props.getFileProperty('impactSearch', changedFile)
+				impacts = resolverUtils.findImpactedFiles(impactSearch, changedFile)
+			}
+			// else {
+			// 	String impactResolutionRules = props.getFileProperty('impactResolutionRules', changedFile)
+			// 	ImpactResolver impactResolver = createImpactResolver(changedFile, impactResolutionRules, metadataStore)
+
+			// 	// Print impactResolverConfiguration
+			// 	if (props.verbose && props.formatConsoleOutput && props.formatConsoleOutput.toBoolean()) {
+			// 		// print collection information
+			// 		println("    " + "Collection".padRight(20) )
+			// 		println("    " + " ".padLeft(20,"-"))
+			// 		impactResolver.getCollections().each{ collectionName ->
+			// 			println("    " + collectionName)
+			// 		}
+			// 		// print impact resolution rule in table format
+			// 		buildUtils.printResolutionRules(impactResolver.getResolutionRules())
+			// 	}
+
+			// 	// resolving impacts
+			// 	impacts = impactResolver.resolve()
+			// }
+			
+			impacts.each { impact ->
+				def impactFile = impact.getFile()
+				if (props.verbose) println "** Found impacted file $impactFile"
+				// only add impacted files that have a build script mapped to it
+				if (ScriptMappings.getScriptName(impactFile)) {
+					// only add impacted files, that are in scope of the build.
+					if (!matches(impactFile, excludeMatchers)){
+						
+						// calculate abbreviated gitHash for impactFile
+						filePattern = FileSystems.getDefault().getPath(impactFile).getParent().toString()
+						if (filePattern != null && githashBuildableFilesMap.getValue(impactFile) == null) {
+							abbrevCurrentHash = gitUtils.getCurrentGitHash(buildUtils.getAbsolutePath(filePattern), true)
+							githashBuildableFilesMap.addFilePattern(abbrevCurrentHash, filePattern+"/*")
+						}
+						
+						// add file to buildset
+						buildSet.add(impactFile)
+						if (props.verbose) println "** $impactFile is impacted by changed file $changedFile. Adding to build list."
+					}
+					else {
+						// impactedFile found, but on Exclude List
+						//   Possible reasons: Exclude of file was defined after building the collection.
+						//   Rescan/Rebuild Collection to synchronize it with defined build scope.
+						if (props.verbose) println "!! $impactFile is impacted by changed file $changedFile, but is on Exlude List. Not added to build list."
+					}
+				}
 			}
 
-			// check if impact calculation should be performed, default true
-			if (shouldCalculateImpacts(changedFile)){
+		}else {
+			if (props.verbose) println "** Impact analysis for $changedFile has been skipped due to configuration."
+		}
+	}
 
-				// perform impact analysis on changed file
-				if (props.verbose) println "** Performing impact analysis on changed file $changedFile"
+	// Perform impact analysis for property changes
+	if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean()){
+		if (props.verbose) println "*** Perform impacted analysis for property changes."
 
-				// get exclude list
+		changedBuildProperties.each { changedProp ->
+
+			if (props.impactBuildOnBuildPropertyList.contains(changedProp.toString())){
+
+				// perform impact analysis on changed property
+				if (props.verbose) println "** Performing impact analysis on property $changedProp"
+
+				// create logical dependency and query collections for logical files with this dependency
+				LogicalDependency lDependency = new LogicalDependency("$changedProp","BUILDPROPERTIES","PROPERTY")
+				logicalFileList = metadataStore.getAllLogicalFiles(props.applicationCollectionName, lDependency)
+
+
+				// get excludeListe
 				List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
 
-				// list of impacts
-				def impacts
-
-				if (props.useSearchConfiguration && props.useSearchConfiguration.toBoolean() && props.impactSearch  && buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, "1.1.2")) { // use new SearchPathDependencyResolver
-
-					String impactSearch = props.getFileProperty('impactSearch', changedFile)
-					impacts = resolverUtils.findImpactedFiles(impactSearch, changedFile, repositoryClient)
-				}
-				else {
-					String impactResolutionRules = props.getFileProperty('impactResolutionRules', changedFile)
-					ImpactResolver impactResolver = createImpactResolver(changedFile, impactResolutionRules, repositoryClient)
-
-					// Print impactResolverConfiguration
-					if (props.verbose && props.formatConsoleOutput && props.formatConsoleOutput.toBoolean()) {
-						// print collection information
-						println("    " + "Collection".padRight(20) )
-						println("    " + " ".padLeft(20,"-"))
-						impactResolver.getCollections().each{ collectionName ->
-							println("    " + collectionName)
-						}
-						// print impact resolution rule in table format
-						buildUtils.printResolutionRules(impactResolver.getResolutionRules())
-					}
-
-					// resolving impacts
-					impacts = impactResolver.resolve()
-				}
-
-				impacts.each { impact ->
-					def impactFile = impact.getFile()
+				logicalFileList.each { logicalFile ->
+					def impactFile = logicalFile.getFile()
 					if (props.verbose) println "** Found impacted file $impactFile"
 					// only add impacted files that have a build script mapped to it
 					if (ScriptMappings.getScriptName(impactFile)) {
@@ -195,7 +242,7 @@ def createImpactBuildList(RepositoryClient repositoryClient) {
  *
  */
 
-def createMergeBuildList(RepositoryClient repositoryClient){
+def createMergeBuildList(MetadataStore metadataStore){
 	Set<String> changedFiles = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()
@@ -204,7 +251,7 @@ def createMergeBuildList(RepositoryClient repositoryClient){
 	(changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = calculateChangedFiles(null)
 
 	// scan files and update source collection
-	updateCollection(changedFiles, deletedFiles, renamedFiles, repositoryClient)
+	updateCollection(changedFiles, deletedFiles, renamedFiles, metadataStore)
 
 	// iterate over changed file and add them to the buildSet
 
@@ -535,7 +582,7 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
 				(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, concurrentBuildProperties) = calculateChangedFiles(null, true, gitReference)
 	
 				// generate reports and verify for intersects
-				generateConcurrentChangesReports(buildSet, concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference, repositoryClient)
+				generateConcurrentChangesReports(buildSet, concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference, metadataStore)
 	
 			}
 		}
@@ -546,7 +593,7 @@ def calculateConcurrentChanges(RepositoryClient repositoryClient, Set<String> bu
  * Method to generate the Concurrent Changes reports and validate if the current build list intersects with concurrent changes
  */
 
-def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference, RepositoryClient repositoryClient){
+def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference, MetadataStore metadataStore){
 	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges.txt"
 
 	File concurrentChangesReportFile = new File(concurrentChangesReportLoc)
@@ -573,9 +620,9 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 						// update build result
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
-							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
+							buildUtils.updateBuildResult(errorMsg:msg,client:metadataStore)
 						} else {
-							buildUtils.updateBuildResult(warningMsg:msg,client:repositoryClient)
+							buildUtils.updateBuildResult(warningMsg:msg,client:metadataStore)
 						}
 					}
 					else
@@ -595,9 +642,9 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 						// update build result
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
-							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
+							buildUtils.updateBuildResult(errorMsg:msg,client:metadataStore)
 						} else {
-							buildUtils.updateBuildResult(warningMsg:msg,client:repositoryClient)
+							buildUtils.updateBuildResult(warningMsg:msg,client:metadataStore)
 						}
 					}
 					else
@@ -617,9 +664,9 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
 						// update build result
 						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
 							props.error = "true"
-							buildUtils.updateBuildResult(errorMsg:msg,client:repositoryClient)
+							buildUtils.updateBuildResult(errorMsg:msg,client:metadataStore)
 						} else {
-							buildUtils.updateBuildResult(warningMsg:msg,client:repositoryClient)
+							buildUtils.updateBuildResult(warningMsg:msg,client:metadataStore)
 						}
 					}
 					else
@@ -635,7 +682,7 @@ def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurre
  * Configured through reportExternalImpacts* build properties
  */
 
-def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changedFiles){
+def reportExternalImpacts(MetadataStore metadataStore, Set<String> changedFiles){
 	// query external collections to produce externalImpactList
 
 	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>() // <collection><List impactRecords>
@@ -671,7 +718,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 			}
 
 			if (externalImpactReportingList.size() != 0) {
-				(collectionImpactsSetMap, impactedFiles) = calculateLogicalImpactedFiles(externalImpactReportingList, changedFiles, collectionImpactsSetMap, repositoryClient, "***", "buildSet")
+				(collectionImpactsSetMap, impactedFiles) = calculateLogicalImpactedFiles(externalImpactReportingList, changedFiles, collectionImpactsSetMap, metadataStore, "***", "buildSet")
 
 
 				// get impacted files of idenfied impacted files
@@ -682,7 +729,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
 
 					}
 					def impactsBin
-					(collectionImpactsSetMap, impactsBin) = calculateLogicalImpactedFiles(new ArrayList(impactedFiles), changedFiles, collectionImpactsSetMap, repositoryClient, "****", "impactSet")
+					(collectionImpactsSetMap, impactsBin) = calculateLogicalImpactedFiles(new ArrayList(impactedFiles), changedFiles, collectionImpactsSetMap, metadataStore, "****", "impactSet")
 				}
 
 			}
@@ -720,7 +767,7 @@ def reportExternalImpacts(RepositoryClient repositoryClient, Set<String> changed
  * Used to inspect dbb collections for potential impacts, sub-method to reportExternalImpacts
  */
 
-def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFiles, Map<String,HashSet> collectionImpactsSetMap, RepositoryClient repositoryClient, String indentationMsg, String analysisMode) {
+def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFiles, Map<String,HashSet> collectionImpactsSetMap, MetadataStore metadataStore, String indentationMsg, String analysisMode) {
 
 	// local matchers to inspect files and collections
 	List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.reportExternalImpactsCollectionPatterns)
@@ -747,19 +794,13 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
 	if(logicalDependencies.size != 0) {
 
 		// iterate over collections
-		repositoryClient.getAllCollections().each{ collection ->
+		metadataStore.getCollections().each{ collection ->
 			String cName = collection.getName()
 			if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
 
 				def Set<String> externalImpactList = collectionImpactsSetMap.get(cName) ?: new HashSet<String>()
 				// query dbb web app for files with all logicalDependencies
-				def logicalImpactedFiles = repositoryClient.getAllImpactedFiles([cName], logicalDependencies);
-
-				// API request unable to be processed
-				if (repositoryClient.getLastStatusCode() == 400 ) {
-					def exceptionMsg = "*!* (ImpactUtilities.calculateLogicalImpactedFiles) API to getAllImpactedFiles returned an error code (${repositoryClient.getLastStatusCode()}). Skipping calculation of external impacts. Please make sure the DBB Server is on 1.1.3 or later to be able to process the request."
-					throw new Exception(exceptionMsg)
-				}
+				def logicalImpactedFiles = metadataStore.getImpactedFiles([cName], logicalDependencies);
 				
 				logicalImpactedFiles.each{ logicalFile ->
 					if (props.verbose) println("$indentationMsg Potential external impact found ${logicalFile.getLname()} (${logicalFile.getFile()}) in collection ${cName} ")
@@ -789,24 +830,9 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
 	]
 }
 
-def createImpactResolver(String changedFile, String rules, RepositoryClient repositoryClient) {
-	if (props.verbose) println "*** Creating impact resolver for $changedFile with $rules rules"
-
-	// create an impact resolver for the changed file
-	ImpactResolver resolver = new ImpactResolver().file(changedFile)
-			.collection(props.applicationCollectionName)
-			.collection(props.applicationOutputsCollectionName)
-			.repositoryClient(repositoryClient)
-	// add resolution rules
-	if (rules)
-		resolver.setResolutionRules(buildUtils.parseResolutionRules(rules))
-
-	return resolver
-}
-
-def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient repositoryClient) {
-	if (!repositoryClient) {
-		if (props.verbose) println "** Unable to update collections. No repository client."
+def updateCollection(changedFiles, deletedFiles, renamedFiles, MetadataStore metadataStore) {
+	if (!metadataStore) {
+		if (props.verbose) println "** Unable to update collections. No Metadata Store."
 		return
 	}
 
@@ -815,15 +841,15 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 	List<LogicalFile> logicalFiles = new ArrayList<LogicalFile>()
 	List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
 
-	verifyCollections(repositoryClient)
+	verifyCollections(metadataStore)
 
 	// remove deleted files from collection
 	deletedFiles.each { file ->
 		// files in a collection are stored as relative paths from a source directory
 		if (props.verbose) println "*** Deleting logical file for $file"
 		logicalFile = buildUtils.relativizePath(file)
-		repositoryClient.deleteLogicalFile(props.applicationCollectionName, logicalFile)
-		repositoryClient.deleteLogicalFile(props.applicationOutputsCollectionName, logicalFile)
+		metadataStore.deleteLogicalFile(props.applicationCollectionName, logicalFile)
+		metadataStore.deleteLogicalFile(props.applicationOutputsCollectionName, logicalFile)
 	}
 
 	// remove renamed files from collection
@@ -831,8 +857,8 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 		// files in a collection are stored as relative paths from a source directory
 		if (props.verbose) println "*** Deleting renamed logical file for $file"
 		logicalFile = buildUtils.relativizePath(file)
-		repositoryClient.deleteLogicalFile(props.applicationCollectionName, logicalFile)
-		repositoryClient.deleteLogicalFile(props.applicationOutputsCollectionName, logicalFile)
+		metadataStore.deleteLogicalFile(props.applicationCollectionName, logicalFile)
+		metadataStore.deleteLogicalFile(props.applicationOutputsCollectionName, logicalFile)
 	}
 
 	if (props.createTestcaseDependency && props.createTestcaseDependency.toBoolean() && changedFiles && changedFiles.size() > 1) {
@@ -872,7 +898,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 							// find in local list of logical files first (batch processing)
 							def testCaseFiles = logicalFiles.findAll{it.getLname().equals(sysTestDependency.getLname())}
 							if (!testCaseFiles){ // alternate retrieve it from the collection
-								testCaseFiles = repositoryClient.getAllLogicalFiles(props.applicationCollectionName, sysTestDependency.getLname()).find{
+								testCaseFiles = metadataStore.getAllLogicalFiles(props.applicationCollectionName, sysTestDependency.getLname()).find{
 									it.getLanguage().equals("COB")
 								}
 							}
@@ -890,7 +916,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 			} catch (Exception e) {
 
 				String warningMsg = "***** Scanning failed for file $file (${props.workspace}/${file})"
-				buildUtils.updateBuildResult(warningMsg:warningMsg,client:getRepositoryClient())
+				buildUtils.updateBuildResult(warningMsg:warningMsg,client:getMetadataStore())
 				println(warningMsg)
 				e.printStackTrace()
 
@@ -905,8 +931,8 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 			if (logicalFiles.size() == 500) {
 				if (props.verbose)
 					println "** Storing ${logicalFiles.size()} logical files in repository collection '$props.applicationCollectionName'"
-				repositoryClient.saveLogicalFiles(props.applicationCollectionName, logicalFiles);
-				if (props.verbose) println(repositoryClient.getLastStatus())
+				metadataStore.saveLogicalFiles(props.applicationCollectionName, logicalFiles);
+				if (props.verbose) println(metadataStore.getLastStatus())
 				logicalFiles.clear()
 			}
 		}
@@ -915,16 +941,16 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, RepositoryClient 
 	// save logical files
 	if (props.verbose)
 		println "** Storing ${logicalFiles.size()} logical files in repository collection '$props.applicationCollectionName'"
-	repositoryClient.saveLogicalFiles(props.applicationCollectionName, logicalFiles);
-	if (props.verbose) println(repositoryClient.getLastStatus())
+	metadataStore.getCollection( props.applicationCollectionName ).addLogicalFiles(logicalFiles);
+	
 }
 
 /*
  * saveStaticLinkDependencies - Scan the load module to determine LINK dependencies. Impact resolver can use
  * these to determine that this file gets rebuilt if a LINK dependency changes.
  */
-def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile logicalFile, RepositoryClient repositoryClient) {
-	if (repositoryClient) {
+def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile logicalFile, MetadataStore metadataStore) {
+	if (metadataStore) {
 		LinkEditScanner scanner = new LinkEditScanner()
 		if (props.verbose) println "*** Scanning load module for $buildFile"
 		LogicalFile scannerLogicalFile = scanner.scan(buildUtils.relativizePath(buildFile), loadPDS)
@@ -934,7 +960,7 @@ def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile log
 		logicalFile.setLogicalDependencies(scannerLogicalFile.getLogicalDependencies())
 
 		// Store logical file and indirect dependencies to the outputs collection
-		repositoryClient.saveLogicalFile("${props.applicationOutputsCollectionName}", logicalFile );
+		metadataStore.getCollection("${props.applicationOutputsCollectionName}").addLogicalFile( logicalFile );
 	}
 }
 
@@ -943,9 +969,9 @@ def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile log
  * create or clone the collections.
  * Uses build properties
  */
-def verifyCollections(RepositoryClient repositoryClient) {
-	if (!repositoryClient) {
-		if (props.verbose) println "** Unable to verify collections. No repository client."
+def verifyCollections(MetadataStore metadataStore) {
+	if (!metadataStore) {
+		if (props.verbose) println "** Unable to verify collections. No metadata store."
 		return
 	}
 
@@ -953,49 +979,49 @@ def verifyCollections(RepositoryClient repositoryClient) {
 	String mainOutputsCollectionName = "${props.application}-${props.mainBuildBranch}-outputs"
 
 	// check source collection
-	if (!repositoryClient.collectionExists(props.applicationCollectionName)) {
+	if (!metadataStore.collectionExists(props.applicationCollectionName)) {
 		if (props.topicBranchBuild) {
-			if (repositoryClient.collectionExists(mainCollectionName)) {
-				repositoryClient.copyCollection(mainCollectionName, props.applicationCollectionName)
+			if (metadataStore.collectionExists(mainCollectionName)) {
+				metadataStore.copyCollection(mainCollectionName, props.applicationCollectionName)
 				if (props.verbose) println "** Cloned collection ${props.applicationCollectionName} from $mainCollectionName"
 			}
 			else {
-				repositoryClient.createCollection(props.applicationCollectionName)
+				metadataStore.createCollection(props.applicationCollectionName)
 				if (props.verbose) println "** Created collection ${props.applicationCollectionName}"
 			}
 		}
 		else {
-			repositoryClient.createCollection(props.applicationCollectionName)
+			metadataStore.createCollection(props.applicationCollectionName)
 			if (props.verbose) println "** Created collection ${props.applicationCollectionName}"
 		}
 	}
 
 	// check outputs collection
-	if (!repositoryClient.collectionExists(props.applicationOutputsCollectionName)) {
+	if (!metadataStore.collectionExists(props.applicationOutputsCollectionName)) {
 		if (props.topicBranchBuild) {
-			if (repositoryClient.collectionExists(mainOutputsCollectionName)) {
-				repositoryClient.copyCollection("${mainOutputsCollectionName}", props.applicationOutputsCollectionName)
+			if (metadataStore.collectionExists(mainOutputsCollectionName)) {
+				metadataStore.copyCollection("${mainOutputsCollectionName}", props.applicationOutputsCollectionName)
 				if (props.verbose) println "** Cloned collection ${props.applicationOutputsCollectionName} from $mainOutputsCollectionName"
 			}
 			else {
-				repositoryClient.createCollection(props.applicationOutputsCollectionName)
+				metadataStore.createCollection(props.applicationOutputsCollectionName)
 				if (props.verbose) println "** Created collection ${props.applicationOutputsCollectionName}"
 			}
 		}
 		else {
-			repositoryClient.createCollection(props.applicationOutputsCollectionName)
+			metadataStore.createCollection(props.applicationOutputsCollectionName)
 			if (props.verbose) println "** Created collection ${props.applicationOutputsCollectionName}"
 		}
 	}
 
 }
 
-/*
+/* 
  *  calculates the correct filepath from the git diff, due to different offsets in the directory path
  *  like nested projects, projects at root level, no root folder
- *
+ *  
  *  returns null if file not found + mustExist
- *
+ *  
  *  scenarios / mode
  *  1 - Application projects are nested (e.q Mortgage in zAppBuild), Projects on Rootlevel
  *  2 - Repository name is used as Application Root dir
@@ -1039,7 +1065,7 @@ def fixGitDiffPath(String file, String dir, boolean mustExist, mode) {
 	if (mode==3 && !mustExist) return [fixedFileName, 3]
 
 	// Scenario 4:
-	//    Repository name is used as application root directory and
+	//    Repository name is used as application root directory and 
 	//      applicationSrcDirs is scoping the build scope by filtering on a subdirectory
 	//        applicationSrcDirs=nazare-demo-genapp/src
 	fixedFileName = "${props.application}/$file"
@@ -1070,7 +1096,7 @@ def matches(String file, List<PathMatcher> pathMatchers) {
 
 /**
  *  shouldCalculateImpacts
- *
+ *  
  *  Method to calculate if impact analysis should be performed for a changedFile in an impactBuild scenario
  *   returns a boolean - default true
  */

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -71,7 +71,6 @@ def createImpactBuildList() {
 			// Get impacted files using the SearchPathImpactFinder
 			String impactSearch = props.getFileProperty('impactSearch', changedFile)
 			def impacts = resolverUtils.findImpactedFiles(impactSearch, changedFile)
-			println(" ***** Impacts for changed file ${changedFile}: ${impacts.toString()}")
 			
 			impacts.each { impact ->
 				def impactFile = impact.getFile()

--- a/utilities/ResolverUtilities.groovy
+++ b/utilities/ResolverUtilities.groovy
@@ -1,6 +1,6 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
 import com.ibm.dbb.dependency.*
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
 
@@ -41,7 +41,7 @@ def createSearchPathDependencyResolver(String dependencySearch) {
 	return new SearchPathDependencyResolver(dependencySearch)
 }
 
-def findImpactedFiles(String impactSearch, String changedFile, RepositoryClient repositoryClient) {
+def findImpactedFiles(String impactSearch, String changedFile) {
 	
 	List<String> collections = new ArrayList<String>()
 	collections.add(props.applicationCollectionName)
@@ -50,7 +50,7 @@ def findImpactedFiles(String impactSearch, String changedFile, RepositoryClient 
 	if (props.verbose)
 		println ("*** Creating SearchPathImpactFinder with collections " + collections + " and impactSearch configuration " + impactSearch)
 	
-	def finder = new SearchPathImpactFinder(impactSearch, collections, repositoryClient)
+	def finder = new SearchPathImpactFinder(impactSearch, collections)
 	
 	// Find all files impacted by the changed file
 	impacts = finder.findImpactedFiles(changedFile, props.workspace)

--- a/utilities/ScannerUtilities.groovy
+++ b/utilities/ScannerUtilities.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
+import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import groovy.transform.*


### PR DESCRIPTION
In this PR we introduce zAppBuild support of the MetadataStore and DBB 2.0. These changes are NOT compatible with any older versions of DBB. DBB 2.0 is required. 

Noteworthy Changes:
- Replacement of the RepositoryClient with the MetadataStore for collection and build result data storage. 
- All builds will use the new SearchPathDependencyResolver and SearchPathImpactFinder APIs
- Introduction of a new build property `metadataStoreType` controls which "version" of the MetadataStore to use. Valid options are 'file' and 'db2'. Default is 'file' which has no external dependencies. 
- With File MetadataStore, all operations which in the past required a RepositoryClient connection are now supported right out of the box (i.e. impactBuild) with no db connection necessary. This is useful for POC development before moving into production with the Db2 MetadataStore. 
- Removal of RepositoryClient/MetadataStore variable from language scripts. With the introduction of the MDS, we can now utilize the MetadataStoreFactory class to create a static MDS instance and retrieve that instance whenever we want. Thus, there is no need to pass around the object anymore. It has been removed from any places in the code where it is not being utilized, including the language scripts. 
- Removal of RepositoryClient/MDS as a method parameter. Similar to the point above, the RepositoryClient was included as a parameter in several methods throughout the code base. With the introduction of the MDS, this is no longer required, so it has been removed as a parameter in any methods across the board and replaced with the MetadataStoreFactory getter method to retrieve the instance. 