### PR TITLE
Stop updating output collection when build state in error (zAppBuild 3.0 stream)

### DIFF
--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -881,7 +881,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
  */
 def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile logicalFile) {
 	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
-	if (metadataStore) {
+	if (metadataStore && !props.error) {
 		LinkEditScanner scanner = new LinkEditScanner()
 		if (props.verbose) println "*** Scanning load module for $buildFile"
 		LogicalFile scannerLogicalFile = scanner.scan(buildUtils.relativizePath(buildFile), loadPDS)


### PR DESCRIPTION
This implements issue https://github.com/IBM/dbb-zappbuild/issues/258 for the zAppBuild_3.0 stream. Problem description can be found in the raised issue.