### PR TITLE
Update required DBB Toolkit version

### DIFF
--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -45,7 +45,7 @@ applicationConfRootDir=
 #
 # Minimum required DBB ToolkitVersion to run this version of zAppBuild
 #  Build initialization process validates the DBB Toolkit Version in use and matches that against this setting 
-requiredDBBToolkitVersion=1.0.3
+requiredDBBToolkitVersion=2.0.0
 
 #
 # Comma separated list of required build properties for zAppBuild/build.groovy


### PR DESCRIPTION
Updating the required DBB Toolkit Version. 

However, users will face a _unable to resolve class exception_ when running with an old toolkit, while a MetadataStore object is defined as a global variable.

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
/u/dbehm/userBuild/zAppBuild/build.groovy: 23: unable to resolve class MetadataStore

 @ line 23, column 22.
   @Field MetadataStore metadataStore
```