### PR TITLE
Removal of redundant code block in ZunitConfig.groovy

### DIFF
--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -10,7 +10,6 @@ import groovy.xml.*
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
-@Field def bindUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BindUtilities.groovy"))
 @Field RepositoryClient repositoryClient
 
 @Field def resolverUtils
@@ -61,15 +60,6 @@ buildUtils.createLanguageDatasets(langQualifier)
 		logicalFile = dependencyResolver.getLogicalFile()
 	}
 
-	// get logical file
-	LogicalFile logicalFile
-	if (buildUtils.useSearchPathAPI()) {
-		logicalFile = resolverUtils.createLogicalFile(dependencyResolver, buildFile)
-	}
-	else {
-		logicalFile = dependencyResolver.getLogicalFile()
-	}
-	
 	// Parse the playback from the bzucfg file
 	boolean hasPlayback = false
  	LogicalDependency playbackFile


### PR DESCRIPTION
Removing duplicate code block in ZunitConfig.groovy in zAppBuild_2_x stream, see issue https://github.com/IBM/dbb-zappbuild/issues/263

(the replaces PR #264 with the correct originating repo)