### PR TITLE
Added Language Definition Properties

### DIFF
--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -290,4 +290,4 @@ transfer_outputDatasets | List of output datasets to document deletions ** Can 
 ### langDefProps01.properties
 Sample Language Definition properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
 
-This is a custom properties file to override file properties for a group of files, based on mapping defined in zAppBuild/samples/application-conf/languageDefinitionMapping.properties. Multiple Language Definition property files can be defined and mapped against different file groups in zAppBuild/samples/application-conf/languageDefinitionMapping.properties.
+This is a custom properties file to override file properties for a group of files, based on mapping defined in `zAppBuild/samples/application-conf/languageDefinitionMapping.properties`. Multiple Language Definition property files can be defined and mapped against different file groups in `zAppBuild/samples/application-conf/languageDefinitionMapping.properties`.

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -286,3 +286,8 @@ transfer_jclPDS | Sample dataset for JCL members
 transfer_xmlPDS | Sample dataset for xml members
 transfer_srcOptions | BPXWDYN creation options for creating 'source' type data sets
 transfer_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property. ** If used for multiple, use a file property to set transfer_outputDatasets 
+
+### langDefProps01.properties
+Sample Language Definition properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
+
+This is a custom properties file to override file properties for a group of files, based on mapping defined in zAppBuild/samples/application-conf/languageDefinitionMapping.properties. Multiple Language Definition property files can be defined and mapped against different file groups in zAppBuild/samples/application-conf/languageDefinitionMapping.properties.

--- a/build-conf/langDefProps01.properties
+++ b/build-conf/langDefProps01.properties
@@ -1,0 +1,12 @@
+# Sample of an language definition property files overwrite for group langDefProps01
+
+# For details, check out section <Build Property management> in application.properties
+
+#
+# Sample to merge properties of this file level overwrite with the default setting for cobol_linkEditParms
+# A more exclusive overwrite would be cobol_linkEditParms=NCAL
+cobol_linkEditParms=${cobol_linkEditParms},NCAL
+
+# Add custom language definition properties below if any
+
+cobol_linkEditStream=    INCLUDE OBJECT(@{member}) 

--- a/build.groovy
+++ b/build.groovy
@@ -587,6 +587,13 @@ def createBuildList() {
 		println "** Populating file level properties from individual property files."
 		buildUtils.loadFileLevelPropertiesFromFile(buildList)
 	}
+	// Loading file/member level properties from member specific properties files
+	if (props.filePropertyValueKeySet().getAt("loadFileLevelProperties") 
+	    || (props.loadFileLevelProperties && props.loadFileLevelProperties.toBoolean())
+		|| (props.loadLanguageDefinitionProperties && props.loadLanguageDefinitionProperties.toBoolean())) {
+		println "** Populating file level properties from individual property files."
+		buildUtils.loadFileLevelPropertiesFromFile(buildList)
+	}
 	
 	// Perform analysis and build report of external impacts
 	if (props.reportExternalImpacts && props.reportExternalImpacts.toBoolean()){

--- a/build.groovy
+++ b/build.groovy
@@ -583,11 +583,6 @@ def createBuildList() {
 	}
 	
 	// Loading file/member level properties from member specific properties files
-	if (props.filePropertyValueKeySet().getAt("loadFileLevelProperties") || props.loadFileLevelProperties) {
-		println "** Populating file level properties from individual property files."
-		buildUtils.loadFileLevelPropertiesFromFile(buildList)
-	}
-	// Loading file/member level properties from member specific properties files
 	if (props.filePropertyValueKeySet().getAt("loadFileLevelProperties") 
 	    || (props.loadFileLevelProperties && props.loadFileLevelProperties.toBoolean())
 		|| (props.loadLanguageDefinitionProperties && props.loadLanguageDefinitionProperties.toBoolean())) {

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -3,8 +3,8 @@
 In ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. For example, the same application can have COBOL object modules that needs to be link edited with option NCAL and without option NCAL for different purposes. This can happen with any build parameters like compile parameters, bind parameters, link edit parameters etc. This can be customized in legacy SCMs using process type/name used to build the file. When the user check-in the component back to SCM, they can provide the process type/name which will be used to build the component with the correct build parameters. 
 
 This documents talks about how to customize the build properties at a file level in the zAppBuild framework.  In order to handle such scenarios to override default file properties for specific file/set of files, zAppBuild has got two options:
-  1. Individual file property -  Override file parameters for individual files
-  2. Language Definition property - Override file parameters for group of files
+  1. Individual file property -  To override file parameters for individual files
+  2. Language Definition property - To override file parameters for group of files
 
 If both Individual file property and Language Definition property is enabled for a file, then the individual file property will take precedence over language definition property. The order of precedence of adding the file property is:
 
@@ -17,30 +17,30 @@ This will be a file property merge, i.e. if both individual file property and la
 
 ### 1. Individual File Property
 
-The Individual File Property option can be enabled setting the property `loadFileLevelProperties` in `application-conf/application.properties` file as `'true'`.  To enable this option for a specific file/set of files the property `loadFileLevelProperties` needs to be set as `'true'` in `application-conf/file.properties` file. Below is a sample to enable Individual File Property for all the programs starting with `'eps'` and `'lga'` in `application-conf/file.properties` file.
+The Individual File Property option can be enabled by setting the property `loadFileLevelProperties` in `application-conf/application.properties` file as `'true'`.  To enable this option for a specific file/set of files the property `loadFileLevelProperties` needs to be set as `'true'` in `application-conf/file.properties` file. Below is a sample to enable Individual File Property for all the programs starting with `'eps'` and `'lga'` in `application-conf/file.properties` file.
 
 `loadFileLevelProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl` 
 
-Once the `loadFileLevelProperties` property is enabled, create a properties file for each program for which the Individual File Properties needs to be overridden.  For example: to override file parameters for file `epsmlist.cbl` create the properties file `epsmlist.cbl.properties`.  
+Once the `loadFileLevelProperties` property is enabled, create a properties file for each program, for which the Individual File Properties needs to be overridden.  For example: to override file parameters for file `epsmlist.cbl` create the properties file `epsmlist.cbl.properties`.  
+
+The name of the properties file needs to have the entire file name including the extension i.e. the properties file for `epsmlist.cbl` needs to be `epsmlist.cbl.properties` and not `epsmlist.properties`.
 
 This properties file needs to be created in the folder mentioned in `propertyFilePath` in `application-conf/application.properties`. For example: if `propertyFilePath=properties`, the properties file created needs to be kept in `properties` folder. 
 
-The name of the properties file needs to have the entire file name including the extension i.e. the properties file for `epsmlist.cbl` needs to be `epsmlist.cbl.properties` and not `epsmlist.properties`.  
-
 The extension of the properties file needs to be mentioned in `propertyFileExtension` in `application-conf/application.properties` i.e. if `propertyFileExtension=properties`, the properties file extension needs to be kept as `properties`.
 
-Add the individual file properties that needs to be added to the file in the properties file created for that file.  Please refer sample properties file - [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties).
+Add the individual file properties that needs to be added to the file in the individual properties file created for that file.  Please refer sample properties file - [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties).
 
 
 ### 2. Language Definition Property
 
-The Language Definition Property option can be enabled setting the property `loadLanguageDefinitionProperties` in `application-conf/application.properties` file as `'true'`.  To enable this option for a specific file/set of files the property `loadLanguageDefinitionProperties` needs to be set as `'true'` in `application-conf/file.properties` file. Below is a sample to enable Individual File Property for all the programs starting with `'eps'` and `'lga'` in `application-conf/file.properties` file.
+The Language Definition Property option can be enabled by setting the property `loadLanguageDefinitionProperties` in `application-conf/application.properties` file as `'true'`.  To enable this option for a specific file/set of files the property `loadLanguageDefinitionProperties` needs to be set as `'true'` in `application-conf/file.properties` file. Below is a sample to enable Language Definition Property for all the programs starting with `'eps'` and `'lga'` in `application-conf/file.properties` file.
 
 `loadLanguageDefinitionProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl` 
 
-The Language Definition Property files need to be created in `build-conf` folder.  Add the file properties that needs tobe grouped together in the Language Definition Property files.  We can create multiple property files under `build-conf` folder.  Please refer sample properties file [langDefProps01.properties](../build-conf/langDefProps01.properties).  
+The Language Definition Property files need to be created in `build-conf` folder.  Add the file properties that need to be grouped together in the Language Definition Property file.  We can create multiple Language Definition Property files under `build-conf` folder.  Please refer sample Language Definition Property file - [langDefProps01.properties](../build-conf/langDefProps01.properties).  
 
-Create `languageDefinitionMapping.properties` file in `application-conf` folder and add the program file - property file mapping in the language definition mapping file. For example, the entry `epsnbrvl.cbl=langDefProps01` means the file `epsnbrvl.cbl` uses `build-conf/langDefProps01.properties` for file property override.  Please refer the sample language definition mapping file - [languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties).
+Create `languageDefinitionMapping.properties` file in `application-conf` folder and add the program file - property file mapping in the language definition mapping file. For example, the entry `epsnbrvl.cbl=langDefProps01` in the language definition mapping file means that the file `epsnbrvl.cbl` uses `build-conf/langDefProps01.properties` for Language Definition Property override.  Please refer the sample language definition mapping file - [languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties).
 
 The extension of the properties file needs to be mentioned in `propertyFileExtension` in `application-conf/application.properties` i.e. if `propertyFileExtension=properties`, the properties file extension needs to be kept as `properties`.
 

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -2,7 +2,7 @@
 
 In a ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. For example, we can see COBOL object modules that are link edited with option NCAL and without option NCAL under the same applciation. This documents talks about how to customize the file level build properties. 
 
-In order to handle such scenarios to override default file properties for specific set of file, zAppBuild has got two options:
+In order to handle such scenarios to override default file properties for specific set of file/files, zAppBuild has got two options:
   1. Individual file property -  Override for individual files
   2. Language Definition property - Override for group of files
 

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -1,7 +1,10 @@
 # File Property Management
 
-In a ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. For example, we can see COBOL object modules that are link edited with option NCAL and without option NCAL under the same applciation.
+In a ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. For example, we can see COBOL object modules that are link edited with option NCAL and without option NCAL under the same applciation. 
 
+In order to handle such scenarios to override default file properties for specific set of file, zAppBuild has got two options:
+  1. Individual file property -  Override for individual files
+  2. Language Definition property - Override for group of files
 
 
 ## Individual File Property

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -1,15 +1,15 @@
 # File Property Management
 
-In a ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. For example, we can see COBOL object modules that are link edited with option NCAL and without option NCAL under the same applciation. 
+In a ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. For example, we can see COBOL object modules that are link edited with option NCAL and without option NCAL under the same applciation. This documents talks about how to customize the file level build properties. 
 
 In order to handle such scenarios to override default file properties for specific set of file, zAppBuild has got two options:
   1. Individual file property -  Override for individual files
   2. Language Definition property - Override for group of files
 
 
-## Individual File Property
+## 1. Individual File Property
 
 
 
 
-## Language File Definition
+## 2. Language File Definition

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -1,6 +1,8 @@
 # File Property Management
 
-In a ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. For example, we can see COBOL object modules that are link edited with option NCAL and without option NCAL under the same applciation. This documents talks about how to customize the file level build properties. 
+In a ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. 
+
+For example, we can see COBOL object modules that are link edited with option NCAL and without option NCAL under the same application for different purpose. This used to be customized in legacy SCMs using process type/name used to build the file. This documents talks about how to customize the file level build properties in zAppBuild framework. 
 
 In order to handle such scenarios to override default file properties for specific set of file/files, zAppBuild has got two options:
   1. Individual file property -  Override for individual files

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -16,7 +16,8 @@ This will be a file property merge, i.e. if both individual file property and la
 
 
 ### 1. Individual File Property
-The Individual File Property option can be enabled setting the property `loadFileLevelProperties` in `application-conf/application.properties` file as `true`.  To enable this option for a specific file/set of files the property `loadFileLevelProperties` needs to be set as true in `application-conf/file.properties` file. Below is a sample to enable Individual File Property for all the programs starting with `eps` and `lga` in `application-conf/file.properties` file.
+
+The Individual File Property option can be enabled setting the property `loadFileLevelProperties` in `application-conf/application.properties` file as `'true'`.  To enable this option for a specific file/set of files the property `loadFileLevelProperties` needs to be set as `'true'` in `application-conf/file.properties` file. Below is a sample to enable Individual File Property for all the programs starting with `'eps'` and `'lga'` in `application-conf/file.properties` file.
 
 `loadFileLevelProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl` 
 
@@ -26,11 +27,20 @@ This properties file needs to be created in the folder mentioned in `propertyFil
 
 The name of the properties file needs to have the entire file name including the extension i.e. the properties file for `epsmlist.cbl` needs to be `epsmlist.cbl.properties` and not `epsmlist.properties`.  
 
-The extension of the properties file needs to be mentioned in `propertyFileExtension` in `application-conf/application.properties` i.e. if `propertyFileExtension=properties`, the properties file extersion needs to be kept as `.properties`.
+The extension of the properties file needs to be mentioned in `propertyFileExtension` in `application-conf/application.properties` i.e. if `propertyFileExtension=properties`, the properties file extension needs to be kept as `properties`.
 
-Please refer sample properties file in [properties](../samples/MortgageApplication/properties) folder
-
-
+Add the individual file properties that needs to be added to the file in the properties file created for that file.  Please refer sample properties file - [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties).
 
 
-### 2. Language File Definition
+### 2. Language Definition Property
+
+The Language Definition Property option can be enabled setting the property `loadLanguageDefinitionProperties` in `application-conf/application.properties` file as `'true'`.  To enable this option for a specific file/set of files the property `loadLanguageDefinitionProperties` needs to be set as `'true'` in `application-conf/file.properties` file. Below is a sample to enable Individual File Property for all the programs starting with `'eps'` and `'lga'` in `application-conf/file.properties` file.
+
+`loadLanguageDefinitionProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl` 
+
+The Language Definition Property files need to be created in `build-conf` folder.  Add the file properties that needs tobe grouped together in the Language Definition Property files.  We can create multiple property files under `build-conf` folder.  Please refer sample properties file [langDefProps01.properties](../build-conf/langDefProps01.properties).  
+
+Create `languageDefinitionMapping.properties` file in `application-conf` folder and add the program file - property file mapping in the language definition mapping file. For example, the entry `epsnbrvl.cbl=langDefProps01` means the file `epsnbrvl.cbl` uses `build-conf/langDefProps01.properties` for file property override.  Please refer the sample language definition mapping file - [languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties).
+
+The extension of the properties file needs to be mentioned in `propertyFileExtension` in `application-conf/application.properties` i.e. if `propertyFileExtension=properties`, the properties file extension needs to be kept as `properties`.
+

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -1,17 +1,36 @@
-# File Property Management
+## File Property Management
 
-In a ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. 
+In ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. For example, the same application can have COBOL object modules that needs to be link edited with option NCAL and without option NCAL for different purposes. This can happen with any build parameters like compile parameters, bind parameters, link edit parameters etc. This can be customized in legacy SCMs using process type/name used to build the file. When the user check-in the component back to SCM, they can provide the process type/name which will be used to build the component with the correct build parameters. 
 
-For example, we can see COBOL object modules that are link edited with option NCAL and without option NCAL under the same application for different purpose. This used to be customized in legacy SCMs using process type/name used to build the file. This documents talks about how to customize the file level build properties in zAppBuild framework. 
+This documents talks about how to customize the build properties at a file level in the zAppBuild framework.  In order to handle such scenarios to override default file properties for specific file/set of files, zAppBuild has got two options:
+  1. Individual file property -  Override file parameters for individual files
+  2. Language Definition property - Override file parameters for group of files
 
-In order to handle such scenarios to override default file properties for specific set of file/files, zAppBuild has got two options:
-  1. Individual file property -  Override for individual files
-  2. Language Definition property - Override for group of files
+If both Individual file property and Language Definition property is enabled for a file, then the individual file property will take precedence over language definition property. The order of precedence of adding the file property is:
+
+  1. Individual file property
+  2. Language Definition property
+  3. Default file properties
+
+This will be a file property merge, i.e. if both individual file property and language definition property is set for a file, then file properties mentioned individual file property will be added to the file and those properties which are not mentioned in individual file property will be added from lower levels - Language Definition property and then from default file properties. 
 
 
-## 1. Individual File Property
+### 1. Individual File Property
+The Individual File Property option can be enabled setting the property `loadFileLevelProperties` in `application-conf/application.properties` file as `true`.  To enable this option for a specific file/set of files the property `loadFileLevelProperties` needs to be set as true in `application-conf/file.properties` file. Below is a sample to enable Individual File Property for all the programs starting with `eps` and `lga` in `application-conf/file.properties` file.
+
+`loadFileLevelProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl` 
+
+Once the `loadFileLevelProperties` property is enabled, create a properties file for each program for which the Individual File Properties needs to be overridden.  For example: to override file parameters for file `epsmlist.cbl` create the properties file `epsmlist.cbl.properties`.  
+
+This properties file needs to be created in the folder mentioned in `propertyFilePath` in `application-conf/application.properties`. For example: if `propertyFilePath=properties`, the properties file created needs to be kept in `properties` folder. 
+
+The name of the properties file needs to have the entire file name including the extension i.e. the properties file for `epsmlist.cbl` needs to be `epsmlist.cbl.properties` and not `epsmlist.properties`.  
+
+The extension of the properties file needs to be mentioned in `propertyFileExtension` in `application-conf/application.properties` i.e. if `propertyFileExtension=properties`, the properties file extersion needs to be kept as `.properties`.
+
+Please refer sample properties file in [properties](../samples/MortgageApplication/properties) folder
 
 
 
 
-## 2. Language File Definition
+### 2. Language File Definition

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -1,0 +1,12 @@
+# File Property Management
+
+In a ZOS application environment, we normally see scenarios like application files/programs of same type being build with different properties. For example, we can see COBOL object modules that are link edited with option NCAL and without option NCAL under the same applciation.
+
+
+
+## Individual File Property
+
+
+
+
+## Language File Definition

--- a/samples/MortgageApplication/application-conf/README.md
+++ b/samples/MortgageApplication/application-conf/README.md
@@ -99,7 +99,7 @@ Sample Language Definition mapping properties used by dbb-zappbuild/utilities/Bu
 
 This contain the mapping of the files and their corresponding Language Definition properties file residing in `zAppBuild/build-conf` to override the default file properties.
 
-Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
+Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file `epsnbrvl.cbl` will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
 
 Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in `application.properties` or in `file.properties`.  If both individual file property set by `loadFileLevelProperties` flag and language definition property is set for a file, then the individual file property will take precedence over language definition property. 
 

--- a/samples/MortgageApplication/application-conf/README.md
+++ b/samples/MortgageApplication/application-conf/README.md
@@ -94,3 +94,9 @@ linkedit_deployTypeDLI | deployType for build output for build files with isDLI=
 linkedit_scanLoadModule | Flag indicating to scan the load module for link dependencies and store in the application's outputs collection. | true
 linkEdit_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
+### languageDefinitionMapping.properties
+Sample Language Definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
+
+This contain the mapping of the files and their corresponding Language Definition properties file residing in zAppBuild/build-conf to override the default file properties.
+Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in zAppBuild/build-conf/langDefProps01.properties
+Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in application.properties or in file.properties.  

--- a/samples/MortgageApplication/application-conf/README.md
+++ b/samples/MortgageApplication/application-conf/README.md
@@ -97,6 +97,6 @@ linkEdit_linkEditSyslibConcatenation | A comma-separated list of libraries to be
 ### languageDefinitionMapping.properties
 Sample Language Definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
 
-This contain the mapping of the files and their corresponding Language Definition properties file residing in zAppBuild/build-conf to override the default file properties.
-Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in zAppBuild/build-conf/langDefProps01.properties
+This contain the mapping of the files and their corresponding Language Definition properties file residing in `zAppBuild/build-conf` to override the default file properties.
+Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
 Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in application.properties or in file.properties.  

--- a/samples/MortgageApplication/application-conf/README.md
+++ b/samples/MortgageApplication/application-conf/README.md
@@ -98,5 +98,15 @@ linkEdit_linkEditSyslibConcatenation | A comma-separated list of libraries to be
 Sample Language Definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
 
 This contain the mapping of the files and their corresponding Language Definition properties file residing in `zAppBuild/build-conf` to override the default file properties.
+
 Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
-Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in application.properties or in file.properties.  
+
+Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in `application.properties` or in `file.properties`.  If both individual file property set by `loadFileLevelProperties` flag and language definition property is set for a file, then the individual file property will take precedence over language definition property. 
+
+The order of precedence of adding the file property is:
+  1. Individual file property 
+  2. Language Definition property 
+  3. Default file properties
+
+This will be a file property merge, i.e. if both individual file property and language definition property is set for a file, then file properties mentioned individual file property will be added to the file and those properties which are not mentioned in individual file property will be added from lower levels - Language Definition property and then from default file properties.
+

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of additional application property files to load
 # Supports both relative path (to ${application}/application-conf/) and absolute path
-applicationPropFiles=file.properties,BMS.properties,Cobol.properties,LinkEdit.properties
+applicationPropFiles=file.properties,BMS.properties,Cobol.properties,LinkEdit.properties,languageDefinitionMapping.properties
 
 #
 # Comma separated list all source directories included in application build. Supports both absolute 
@@ -85,6 +85,14 @@ skipImpactCalculationList=
 # syntax instead. (i.e. loadFileLevelProperties=true :: **/cobol/*.cbl to enable it for all cobol files)
 # default: false
 loadFileLevelProperties=false
+
+# Property to enable/disable and configure build property overwrites using language definition property mapping 
+# file - languageDefinitionMapping.properties
+# If loadFileLevelProperties is set as true above, the properties from the individual property files will override the 
+# properties from language definition properties file.
+# Note: To activate the loading of property files for a group of files, it is recommended to use the file property path
+# syntax instead. (i.e. loadLanguageDefinitionProperties=true :: **/cobol/*.cbl to enable it for all cobol files)
+loadLanguageDefinitionProperties=false
 
 # relative path to folder containing individual property files
 # assumed to be relative to ${workspace}/${application}

--- a/samples/MortgageApplication/application-conf/file.properties
+++ b/samples/MortgageApplication/application-conf/file.properties
@@ -27,4 +27,13 @@ isCICS = true :: **/cobol/epsmlist.cbl, **/link/epsmlist.lnk, **/cobol/epscsmrt.
 # Flag to enable the zAppBuild capability to load individual property files for source files,
 # This file path pattern looks for an individual property file for epsmlist.cbl. 
 # Please see detailed description in application.properties 
-loadFileLevelProperties = true :: **/cobol/epsmlist.cbl  
+loadFileLevelProperties = true :: **/cobol/epsmlist.cbl 
+
+#
+# Language Definition properties Management
+#
+# Flag to enable the zAppBuild capability to load language definition property files for source files,
+# This file path pattern looks for an language definition property file for epsnbrvl.cbl and epsmpmt.cbl 
+# in languageDefinitionMapping.properties file. 
+# Please see detailed description in application.properties 
+loadLanguageDefinitionProperties = true :: **/cobol/epsnbrvl.cbl, **/cobol/epsmpmt.cbl  

--- a/samples/MortgageApplication/application-conf/languageDefinitionMapping.properties
+++ b/samples/MortgageApplication/application-conf/languageDefinitionMapping.properties
@@ -1,0 +1,9 @@
+# This file maps the program file with the corresponding language definition properties file in the build-conf folder.
+
+# For example: As shown below, the programs - epsnbrvl.cbl and epsmpmt.cbl will map to the language definition file 
+# langDefProps01.properties in build-conf folder
+
+epsnbrvl.cbl=langDefProps01
+epsmpmt.cbl=langDefProps01
+
+# Insert all the file ==> language definition properties mapping here!!!

--- a/samples/MortgageApplication/application-conf/languageDefinitionMapping.properties
+++ b/samples/MortgageApplication/application-conf/languageDefinitionMapping.properties
@@ -6,4 +6,4 @@
 epsnbrvl.cbl=langDefProps01
 epsmpmt.cbl=langDefProps01
 
-# Insert all the file ==> language definition properties mapping here!!!
+# Insert all the (file = language definition properties) mapping here!!!

--- a/samples/MortgageApplication/properties/epsmlist.cbl.properties
+++ b/samples/MortgageApplication/properties/epsmlist.cbl.properties
@@ -10,3 +10,8 @@ cobol_compileParms=${cobol_compileParms},SOURCE
 #
 # Defines exclusively the compile options for this file
 #cobol_compilerVersion=V4
+
+# Sample to map a language definition property file in application-conf - langDefAppProps01.properties in 
+# application-conf folder to cobol/epsmlist.cbl
+
+languageDefGroup=langDefAppProps01

--- a/samples/MortgageApplication/properties/langDefAppProps01.properties
+++ b/samples/MortgageApplication/properties/langDefAppProps01.properties
@@ -1,0 +1,12 @@
+# Sample of an language definition property files overwrite for group langDefProps01
+
+# For details, check out section <Build Property management> in application.properties
+
+#
+# Sample to merge properties of this file level overwrite with the default setting for cobol_linkEditParms
+# A more exclusive overwrite would be cobol_linkEditParms=NCAL
+cobol_linkEditParms=${cobol_linkEditParms},NCAL
+
+# Add custom language definition properties below if any
+
+cobol_linkEditStream=    INCLUDE OBJECT(@{member}) 

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -25,6 +25,7 @@ skipImpactCalculationList | Files for which the impact analysis should be skippe
 jobCard | JOBCARD for JCL execs | false
 **Build Property management** | | 
 loadFileLevelProperties | Flag to enable the zAppBuild capability to load individual property files for a build file | true
+loadLanguageDefinitionProperties | Flag to enable the zAppBuild capability to load language definition properties for build files mapped in languageDefinitionMapping.properties | true
 propertyFilePath | relative path to folder containing individual property files | true
 propertyFileExtension | file extension for individual property files | true
 **Dependency and Impact resolution configuration** ||
@@ -282,3 +283,10 @@ Application properties used by zAppBuild/language/Transfer.groovy
 Property | Description | Overridable
 --- | --- | ---
 transfer_deployType | deployType | true
+
+### languageDefinitionMapping.properties
+Sample Language Definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
+
+This contain the mapping of the files and their corresponding Language Definition properties file residing in zAppBuild/build-conf to override the default file properties.
+Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in zAppBuild/build-conf/langDefProps01.properties
+Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in application.properties or in file.properties.  

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -289,7 +289,7 @@ Sample Language Definition mapping properties used by dbb-zappbuild/utilities/Bu
 
 This contain the mapping of the files and their corresponding Language Definition properties file residing in `zAppBuild/build-conf` to override the default file properties.
 
-Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
+Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file `epsnbrvl.cbl` will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
 
 Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in `application.properties` or in `file.properties`.  If both individual file property set by `loadFileLevelProperties` flag and language definition property is set for a file, then the individual file property will take precedence over language definition property. 
 

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -287,6 +287,6 @@ transfer_deployType | deployType | true
 ### languageDefinitionMapping.properties
 Sample Language Definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
 
-This contain the mapping of the files and their corresponding Language Definition properties file residing in zAppBuild/build-conf to override the default file properties.
-Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in zAppBuild/build-conf/langDefProps01.properties
+This contain the mapping of the files and their corresponding Language Definition properties file residing in `zAppBuild/build-conf` to override the default file properties.
+Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
 Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in application.properties or in file.properties.  

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -288,5 +288,14 @@ transfer_deployType | deployType | true
 Sample Language Definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
 
 This contain the mapping of the files and their corresponding Language Definition properties file residing in `zAppBuild/build-conf` to override the default file properties.
+
 Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file epsnbrvl.cbl will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
-Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in application.properties or in file.properties.  
+
+Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in `application.properties` or in `file.properties`.  If both individual file property set by `loadFileLevelProperties` flag and language definition property is set for a file, then the individual file property will take precedence over language definition property. 
+
+The order of precedence of adding the file property is:
+  1. Individual file property 
+  2. Language Definition property 
+  3. Default file properties
+
+This will be a file property merge, i.e. if both individual file property and language definition property is set for a file, then file properties mentioned individual file property will be added to the file and those properties which are not mentioned in individual file property will be added from lower levels - Language Definition property and then from default file properties.

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -8,7 +8,7 @@
 #
 # Comma separated list of additional application property files to load
 # Supports both relative path (to ${application}/application-conf/) and absolute path
-applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,REXX.properties,ZunitConfig.properties,Transfer.properties,reports.properties
+applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,REXX.properties,ZunitConfig.properties,Transfer.properties,reports.properties,languageDefinitionMapping.properties
 
 #
 # Comma separated list all source directories included in application build. Supports both absolute
@@ -104,6 +104,14 @@ jobCard=
 # syntax instead. (i.e. loadFileLevelProperties=true :: **/cobol/*.cbl to enable it for all cobol files)
 # default: false
 loadFileLevelProperties=false
+
+# Property to enable/disable and configure build property overwrites using language definition property mapping 
+# file - languageDefinitionMapping.properties
+# If loadFileLevelProperties is set as true above, the properties from the individual property files will override the 
+# properties from language definition properties file.
+# Note: To activate the loading of property files for a group of files, it is recommended to use the file property path
+# syntax instead. (i.e. loadLanguageDefinitionProperties=true :: **/cobol/*.cbl to enable it for all cobol files)
+loadLanguageDefinitionProperties=false
 
 # relative path to folder containing individual property files
 # assumed to be relative to ${workspace}/${application}

--- a/samples/application-conf/languageDefinitionMapping.properties
+++ b/samples/application-conf/languageDefinitionMapping.properties
@@ -1,0 +1,9 @@
+# This file maps the program file with the corresponding language definition properties file in the build-conf folder.
+
+# For example: As shown below, the programs - epsnbrvl.cbl and epsmpmt.cbl will map to the language definition file 
+# langDefProps01.properties in build-conf folder
+
+epsnbrvl.cbl=langDefProps01
+epsmpmt.cbl=langDefProps01
+
+# Insert all the file ==> language definition properties mapping here!!!

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -774,7 +774,8 @@ def loadFileLevelPropertiesFromFile(List<String> buildList) {
 	    String member = new File(buildFile).getName()
 	    
 	    // check for language definition group level overwrite
-	    if (props.loadLanguageDefinitionProperties && props.loadLanguageDefinitionProperties.toBoolean()) {
+	    loadLanguageDefinitionProperties = props.getFileProperty('loadLanguageDefinitionProperties', buildFile)
+	    if (loadLanguageDefinitionProperties && loadLanguageDefinitionProperties.toBoolean()) {
 	    	String languageDefinitionPropertyFileName = props."$member"
 	        if (languageDefinitionPropertyFileName != null) {
 	    			


### PR DESCRIPTION
The Language Definition properties will give you an option to group the file properties and map it to multiple files to override the default file properties.  The order of precedence of file properties will be Individual file property, Language Definition property and then default file properties.

Reference - [#127](https://github.ibm.com/IBMZSoftware/dat-tech-projects/issues/127)