### PR TITLE
ZunitConfig.groovy updates

### DIFF
--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -38,7 +38,7 @@ buildUtils.createLanguageDatasets(langQualifier)
 	buildUtils.copySourceFiles(buildFile, props.zunit_bzucfgPDS, 'zunit_dependenciesDatasetMapping', null, dependencyResolver)
 
 	// get logical file
-	LogicalFile logicalFile = dependencyResolver.getLogicalFile()
+	LogicalFile logicalFile = buildUtils.createLogicalFile(dependencyResolver, buildFile)
 		
 	// get playback dependency for bzucfg file from logicalFile
 	boolean hasPlayback = false

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -10,7 +10,6 @@ import groovy.xml.*
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("${props.zAppBuildDir}/utilities/ImpactUtilities.groovy"))
-@Field def bindUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BindUtilities.groovy"))
 
 println("** Building files mapped to ${this.class.getName()}.groovy script")
 
@@ -36,12 +35,15 @@ buildUtils.createLanguageDatasets(langQualifier)
 	SearchPathDependency dependencyResolver = new SearchPathDependencyResolver(dependencySearch)
 	
 	// copy build file and dependency files to data sets
-	buildUtils.copySourceFiles(buildUtils.getAbsolutePath(buildFile), props.zunit_bzucfgPDS, 'zunit_dependenciesDatasetMapping', null, dependencyResolver)
+	buildUtils.copySourceFiles(buildFile, props.zunit_bzucfgPDS, 'zunit_dependenciesDatasetMapping', null, dependencyResolver)
 
-	// Parse the playback from the bzucfg file
-	Boolean hasPlayback = false
-	String playback
-	(hasPlayback, playback) = getPlaybackFile(buildFile);
+	// get logical file
+	LogicalFile logicalFile = dependencyResolver.getLogicalFile()
+		
+	// get playback dependency for bzucfg file from logicalFile
+	boolean hasPlayback = false
+ 	LogicalDependency playbackFile
+ 	(hasPlayback, playbackFile) = getPlaybackFile(logicalFile);
 	
 	// Create JCLExec String
 	String jobcard = props.jobCard.replace("\\n", "\n")
@@ -67,7 +69,7 @@ jcl += """\
 	if (hasPlayback) { // bzucfg contains reference to a playback file
 		jcl +=
 		"//REPLAY.BZUPLAY DD DISP=SHR, \n" +
-		"// DSN=${props.zunit_bzuplayPDS}(${playback}) \n"
+		"// DSN=${props.zunit_bzuplayPDS}(${playbackFile.getLname()}) \n"
 	} else { // no playbackfile referenced
 		jcl +=
 		"//REPLAY.BZUPLAY DD DUMMY   \n"
@@ -216,17 +218,17 @@ zunitDebugParm = props.getFileProperty('zunit_userDebugSessionTestParm', buildFi
  */
 
 /*
- * returns containsPlayback, 
+ * returns the LogicalDependency of the playbackfile
  */
-def getPlaybackFile(String xmlFile) {
-	String xml = new File(buildUtils.getAbsolutePath(xmlFile)).getText("IBM-1047")
-	def parser = new XmlParser().parseText(xml)
-	if (parser.'runner:playback'.playbackFile.size()==0) return [false, null]
-	else {
-		String playbackFileName = parser.'runner:playback'.@moduleName[0]
-		return [true, playbackFileName]
-	}
-}
+def getPlaybackFile(LogicalFile logicalFile) {
+ 	// find playback file dependency
+ 	LogicalDependency playbackDependency = logicalFile.getLogicalDependencies().find {
+ 		it.getLibrary() == "SYSPLAY"
+ 	}
+ 	if (playbackDependency) {
+ 		return [true, playbackDependency]
+ 	} 
+ }
 
 /**
  *  Parsing the result file and prints summary of the result

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -32,7 +32,7 @@ buildUtils.createLanguageDatasets(langQualifier)
 
 	
 	String dependencySearch = props.getFileProperty('zunit_dependencySearch', buildFile)
-	SearchPathDependency dependencyResolver = new SearchPathDependencyResolver(dependencySearch)
+	SearchPathDependencyResolver dependencyResolver = new SearchPathDependencyResolver(dependencySearch)
 	
 	// copy build file and dependency files to data sets
 	buildUtils.copySourceFiles(buildFile, props.zunit_bzucfgPDS, 'zunit_dependenciesDatasetMapping', null, dependencyResolver)


### PR DESCRIPTION
This PR is updating the ZunitConfig.groovy

(apologies, I have to redo it due to a missing signature of the squash merge commit)

pass a relative path to the copySourceFile method
fixes a syntax issue when creating the SearchPathDependencyResolver
leverages the DBBs dependency data rather then parsing the XML.

FYI - https://github.com/IBM/dbb-zappbuild/pull/246 performed the updates for the zAppBuild_2_x stream.