### PR TITLE
Remove zunit_resolutionRules from required build properties

### DIFF
--- a/build-conf/ZunitConfig.properties
+++ b/build-conf/ZunitConfig.properties
@@ -2,7 +2,7 @@
 
 zunit_requiredBuildProperties=zunit_srcDatasets,zunit_loadDatasets,zunit_reportDatasets,zunit_bzucfgPDS,\
   zunit_bzureportPDS,zunit_bzuplayPDS,zunit_srcOptions,zunit_loadOptions,zunit_reportOptions,\
-  jobCard,zunit_maxPassRC,zunit_maxWarnRC,zunit_playbackFileExtension,zunit_resolutionRules,\
+  jobCard,zunit_maxPassRC,zunit_maxWarnRC,zunit_playbackFileExtension,\
   zunit_bzuplayParms,zunit_userDebugSessionTestParm, \
   zunit_dependencySearch
 


### PR DESCRIPTION
This is removing the old zunit_resolutionRules from the list of required build properties for ZUnitConfig.groovy and fixes #306 