### PR TITLE
Externalize the Build Folder Timestamp Format

### DIFF
--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -10,7 +10,7 @@ buildPropFiles=datasets.properties,dependencyReport.properties,Assembler.propert
 buildListFileExt=txt
 
 #
-# Service URL for the Git provider to have a visual comparision of two hashes  
+# Service URL for the Git provider to have a visual comparision of two hashes
 # Leveraged as a build result property <props.gitRepositoryURL>/compare/
 # samples: GitHub : /compare/ ; GitLab :  /-/compare/
 gitRepositoryCompareService=/compare/
@@ -44,7 +44,7 @@ applicationConfRootDir=
 
 #
 # Minimum required DBB ToolkitVersion to run this version of zAppBuild
-#  Build initialization process validates the DBB Toolkit Version in use and matches that against this setting 
+#  Build initialization process validates the DBB Toolkit Version in use and matches that against this setting
 requiredDBBToolkitVersion=2.0.0
 
 #
@@ -117,14 +117,20 @@ continueOnScanFailure=true
 createBuildOutputSubfolder=true
 
 #
+# Build Timestamp Format
+# Applies to all build types except userBuild
+# Default: yyyyMMdd.HHmmss.mmm - See Date format method pattern strings
+buildOutputTSformat=yyyyMMdd.HHmmss.mmm
+
+#
 # Flag to determine if the build framework should document deletions of outputs in DBB Build Report
 # for build files being mapped to language scripts
 #
-# Requires the DBB toolkit 1.1.3 or higher. Backward compatibility of zAppBuild is preserved, 
+# Requires the DBB toolkit 1.1.3 or higher. Backward compatibility of zAppBuild is preserved,
 # when feature is turned off
-# 
+#
 # Default : false
-documentDeleteRecords=false 
+documentDeleteRecords=false
 
 # MetadataStore configuration properties:
 
@@ -139,7 +145,7 @@ metadataStoreType=file
 #metadataStoreDb2Url=jdbc:db2:<Db2 server location>
 
 # Db2 connection configuration property file
-# Sample is povided at $DBB_HOME/conf/db2Connection.conf 
+# Sample is povided at $DBB_HOME/conf/db2Connection.conf
 #metadataStoreDb2ConnectionConf=
 
 

--- a/build.groovy
+++ b/build.groovy
@@ -21,9 +21,9 @@ import groovy.cli.commons.*
 @Field String giturlPrefix = ':giturl:'
 @Field String gitchangedfilesPrefix = ':gitchangedfiles:'
 @Field MetadataStore metadataStore
+@Field startTime = new Date()
 
 // start time message
-def startTime = new Date()
 props.startTime = startTime.format("yyyyMMdd.hhmmss.mmm")
 println("\n** Build start at $props.startTime")
 
@@ -446,7 +446,7 @@ def populateBuildProperties(def opts) {
 
 	props.topicBranchBuild = (props.applicationCurrentBranch.equals(props.mainBuildBranch)) ? null : 'true'
 	props.applicationBuildGroup = ((props.applicationCurrentBranch) ? "${props.application}-${props.applicationCurrentBranch}" : "${props.application}") as String
-	props.applicationBuildLabel = "build.${props.startTime}" as String
+	props.applicationBuildLabel = ("build." + ( (props.buildOutputTSformat) ? startTime.format("${props.buildOutputTSformat}") : "${props.startTime}" ) ) as String
 	props.applicationCollectionName = ((props.applicationCurrentBranch) ? "${props.application}-${props.applicationCurrentBranch}" : "${props.application}") as String
 	props.applicationOutputsCollectionName = "${props.applicationCollectionName}-outputs" as String
 


### PR DESCRIPTION
Currently in zAppBuild the timestamp used to construct the build folder is in 12 hour format. Clients have complained that this 12 hour format makes it difficult to sort the build output folders in chronological order. They would like the timestamp to be in 24 hour clock.

This update will create a new property in the `build.properties` file called `buildOutputTSformat` that will allow the client set the Date format method pattern string to what ever format they desire. The default value for this new property will be set to `yyyyMMdd.HHhmmss.mmm` to represent 24 hour format. This only applies to the build folder timestamp and build results entry name.

Within build.groovy a `** Build start at [timestamp]` message is emitted with a timestamp format in 12 hour format. This will not change so as not to impact any client-side automation.

If the new `buildOutputTSformat` property is not set (or blank), then the timestamp of the build folder will be set to the hardcoded format currently found in `build.groovy`.
