### PR TITLE
Updating zappbuild test framework

### DIFF
--- a/test/testScripts/fullBuild.groovy
+++ b/test/testScripts/fullBuild.groovy
@@ -57,7 +57,7 @@ try {
 catch(AssertionError e) {
 	def result = e.getMessage()
 	assertionList << result;
-	props.testsSucceeded = false
+	props.testsSucceeded = 'false'
 }
 finally {
 	cleanUpDatasets()

--- a/test/testScripts/impactBuild.groovy
+++ b/test/testScripts/impactBuild.groovy
@@ -102,7 +102,7 @@ def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings,
     catch(AssertionError e) {
         def result = e.getMessage()
         assertionList << result;
-		props.testsSucceeded = false
+		props.testsSucceeded = 'false'
  }
 }
 def cleanUpDatasets() {

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -25,7 +25,7 @@ fullBuildCommand << "--url ${props.url}"
 fullBuildCommand << "--id ${props.id}"
 fullBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 fullBuildCommand << (props.verbose ? "--verbose" : "")
-fullBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_deletion_buildPropSetting}" : "")
+fullBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_deletion_buildPropSetting}" : "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_deletion_buildPropSetting}")
 fullBuildCommand << "--fullBuild"
 
 // create impact build command
@@ -41,7 +41,7 @@ impactBuildCommand << "--url ${props.url}"
 impactBuildCommand << "--id ${props.id}"
 impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 impactBuildCommand << "--verbose"
-impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_deletion_buildPropSetting}" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_deletion_buildPropSetting}" : "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_deletion_buildPropSetting}")
 impactBuildCommand << "--impactBuild"
 
 // iterate through change files to test impact build

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -147,6 +147,7 @@ def validateImpactBuild(String deleteFile, PropertyMappings outputsDeletedMappin
 	catch(AssertionError e) {
 		def result = e.getMessage()
 		assertionList << result;
+		props.testsSucceeded = 'false'
 	}
 }
 def cleanUpDatasets() {

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -25,7 +25,7 @@ fullBuildCommand << "--url ${props.url}"
 fullBuildCommand << "--id ${props.id}"
 fullBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 fullBuildCommand << (props.verbose ? "--verbose" : "")
-fullBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}" : "")
+fullBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}" : "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}")
 fullBuildCommand << "--fullBuild"
 
 // create impact build command
@@ -41,7 +41,7 @@ impactBuildCommand << "--url ${props.url}"
 impactBuildCommand << "--id ${props.id}"
 impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
 impactBuildCommand << (props.verbose ? "--verbose" : "")
-impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}" : "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}")
 impactBuildCommand << "--impactBuild"
 
 // iterate through change files to test impact build

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -126,7 +126,7 @@ def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings,
 	catch(AssertionError e) {
 		def result = e.getMessage()
 		assertionList << result;
-		props.testsSucceeded = false
+		props.testsSucceeded = 'false'
  }
 }
 def cleanUpDatasets() {

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -113,7 +113,7 @@ def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, 
 	catch(AssertionError e) {
 		def result = e.getMessage()
 		assertionList << result;
-		props.testsSucceeded = false
+		props.testsSucceeded = 'false'
 	}
 }
 def cleanUpDatasets() {

--- a/test/testScripts/mergeBuild.groovy
+++ b/test/testScripts/mergeBuild.groovy
@@ -117,7 +117,7 @@ def validateMergeBuild(String changedFile, PropertyMappings filesBuiltMappings, 
     catch(AssertionError e) {
         def result = e.getMessage()
         assertionList << result;
-		props.testsSucceeded = false
+		props.testsSucceeded = 'false'
  }
 }
 def cleanUpDatasets() {

--- a/test/testScripts/resetBuild.groovy
+++ b/test/testScripts/resetBuild.groovy
@@ -33,12 +33,20 @@ def process = ['bash', '-c', resetBuildCommand.join(" ")].execute()
 def outputStream = new StringBuffer();
 process.waitForProcessOutput(outputStream, System.err)
 
-// Validate reset build
-println "** Validating reset build"
 
-// Validate clean reset build
-assert (outputStream.contains("Build finished")) && (process.exitValue() == 0) : "*! RESET OF THE BUILD FAILED\nOUTPUT STREAM:\n$outputStream\n"
-  
-println "**"
-println "** RESET OF THE BUILD : PASSED **"
-println "**"
+try {
+	// Validate reset build
+	println "** Validating reset build"
+
+	// Validate clean reset build
+	assert (outputStream.contains("Build finished")) && (process.exitValue() == 0) : "*! RESET OF THE BUILD FAILED\nOUTPUT STREAM:\n$outputStream\n"
+
+	println "**"
+	println "** RESET OF THE BUILD : PASSED **"
+	println "**"
+
+}catch(AssertionError e) {
+	def result = e.getMessage()
+	assertionList << result;
+	props.testsSucceeded = 'false'
+}

--- a/test/testScripts/resetBuild.groovy
+++ b/test/testScripts/resetBuild.groovy
@@ -37,7 +37,7 @@ process.waitForProcessOutput(outputStream, System.err)
 println "** Validating reset build"
 
 // Validate clean reset build
-assert (outputStream.contains("Build finished")) && (process.exitValue() != 0) : "*! RESET OF THE BUILD FAILED\nOUTPUT STREAM:\n$outputStream\n"
+assert (outputStream.contains("Build finished")) && (process.exitValue() == 0) : "*! RESET OF THE BUILD FAILED\nOUTPUT STREAM:\n$outputStream\n"
   
 println "**"
 println "** RESET OF THE BUILD : PASSED **"

--- a/test/testScripts/resetBuild.groovy
+++ b/test/testScripts/resetBuild.groovy
@@ -37,7 +37,7 @@ process.waitForProcessOutput(outputStream, System.err)
 println "** Validating reset build"
 
 // Validate clean reset build
-assert outputStream.contains("Deleting collection") && ("Deleting build result group") && ("Build finished") : "*! RESET OF THE BUILD FAILED\nOUTPUT STREAM:\n$outputStream\n"
+assert (outputStream.contains("Build finished")) && (process.exitValue() != 0) : "*! RESET OF THE BUILD FAILED\nOUTPUT STREAM:\n$outputStream\n"
   
 println "**"
 println "** RESET OF THE BUILD : PASSED **"


### PR DESCRIPTION
This PR is fixing several minor bugs in the test framework:

* #316 Fix CCE and pass value as a String to document the overall test result
* Enhancing the `resetBuild.groovy` testcase
* Implementing the strategy when `--propFiles` is not passed.