### PR TITLE
Uplift Transfer.groovy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The zAppBuild sample provides the following *language* build scripts by default:
 * PSBgen.groovy
 * MFS.groovy
 * ZunitConfig.groovy
+* Transfer.groovy (for transport non-buildable files like JCL or PROC into build libraries and register them as build output)
 
 All language scripts both compile and optionally link-edit programs. The language build scripts are intended to be useful out of the box but depending on the complexity of your applications' build requirements, may require modifications to meet your development team's needs.  By following the examples used in the existing language build scripts of keeping all application specific references out of the build scripts and instead using configuration properties with strong default values, the zAppBuild sample can continue to be a generic build solution for all of your specific applications.
 

--- a/build-conf/Transfer.properties
+++ b/build-conf/Transfer.properties
@@ -1,7 +1,7 @@
 # Releng properties used by language/Transfer.groovy
 
 # Comma separated list of required build properties for Cobol.groovy
-transfer_requiredBuildProperties=transfer_srcPDS,transfer_srcOptions,\
+transfer_requiredBuildProperties=transfer_srcPDS,transfer_dsOptions,\
   transfer_deployType
 
 #
@@ -20,8 +20,8 @@ transfer_xmlPDS=${hlq}.XML
 #
 # This is using the DBB PropertyMapping syntax allowing multiple mappings of
 #  the target source dataset definitions to the required options
-transfer_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_srcPDS, transfer_jclPDS
-transfer_srcOptions=cyl space(1,1) lrecl(144) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_xmlPDS
+transfer_dsOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_srcPDS, transfer_jclPDS
+transfer_dsOptions=cyl space(1,1) lrecl(144) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_xmlPDS
 
 
 # List of output datasets to document deletions

--- a/build-conf/Transfer.properties
+++ b/build-conf/Transfer.properties
@@ -17,7 +17,9 @@ transfer_xmlPDS=${hlq}.XML
 
 #
 # dataset creation options
-transfer_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
+transfer_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_srcPDS
+transfer_srcOptions=cyl space(1,1) lrecl(144) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_xmlPDS, transfer_jclPDS
+
 
 # List of output datasets to document deletions
 transfer_outputDatasets=${transfer_srcPDS}

--- a/build-conf/Transfer.properties
+++ b/build-conf/Transfer.properties
@@ -5,11 +5,11 @@ transfer_requiredBuildProperties=transfer_srcPDS,transfer_dsOptions,\
   transfer_deployType
 
 #
-# transfer source data sets
+# Transfer source data sets
 # Add additional dataset definitions, depending on your requirements
 #
 # Please note, that files in the repository require to be mapped by a PropertyMapping in file.properties
-# to one of the dataset definitions
+# to one of the dataset definitions. See samples/application-conf/file.properties
 #
 transfer_srcPDS=${hlq}.SOURCE
 transfer_jclPDS=${hlq}.JCL
@@ -19,10 +19,7 @@ transfer_xmlPDS=${hlq}.XML
 # dataset creation options
 #
 # This is using the DBB PropertyMapping syntax allowing multiple mappings of
-#  the target source dataset definitions to the required options
+#  target source dataset definitions to the required options
+# 
 transfer_dsOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_srcPDS, transfer_jclPDS
 transfer_dsOptions=cyl space(1,1) lrecl(144) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_xmlPDS
-
-
-# List of output datasets to document deletions
-transfer_outputDatasets=${transfer_srcPDS}

--- a/build-conf/Transfer.properties
+++ b/build-conf/Transfer.properties
@@ -17,8 +17,11 @@ transfer_xmlPDS=${hlq}.XML
 
 #
 # dataset creation options
-transfer_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_srcPDS
-transfer_srcOptions=cyl space(1,1) lrecl(144) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_xmlPDS, transfer_jclPDS
+#
+# This is using the DBB PropertyMapping syntax allowing multiple mappings of
+#  the target source dataset definitions to the required options
+transfer_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_srcPDS, transfer_jclPDS
+transfer_srcOptions=cyl space(1,1) lrecl(144) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_xmlPDS
 
 
 # List of output datasets to document deletions

--- a/languages/Transfer.groovy
+++ b/languages/Transfer.groovy
@@ -55,16 +55,28 @@ buildList.each { buildFile ->
 
 		// evaluate the datasetmapping, which maps build files to targetDataset defintions
 		PropertyMappings dsMapping = new PropertyMappings("transfer_datasetMapping")
+		PropertyMappings dsOptionsMapping = new PropertyMappings("transfer_srcOptions")
 
 		// obtain the target dataset based on the mapped dataset key
-		String targetDataset = props.getProperty(dsMapping.getValue(buildFile))
-
+		mappedDatesetDef = dsMapping.getValue(buildFile)
+		String targetDataset = props.getProperty(mappedDatesetDef)
+		
 		if (targetDataset != null) {
-
+			
+			// obtain the dataset reference for targetDataset
+			String datasetOptions = dsOptionsMapping.getValue(mappedDatesetDef)
+			
+			if (datasetOptions == null) {
+				String errorMsg =  "*! Dataset options for $buildFile could not be obtained PropertyMappings <transfer_srcOptions>. "
+				println(errorMsg)
+				props.error = "true"
+				buildUtils.updateBuildResult(errorMsg:errorMsg)
+			} 
+			
 			// allocate target dataset
 			if (!verifiedBuildDatasets.contains(targetDataset)) { // using a cache not to allocate all defined datasets
 				verifiedBuildDatasets.add(targetDataset)
-				buildUtils.createDatasets(targetDataset.split(), props.transfer_srcOptions)
+				buildUtils.createDatasets(targetDataset.split(), datasetOptions)
 			}
 
 			// copy the file to the target dataset
@@ -72,7 +84,7 @@ buildList.each { buildFile ->
 
 			try {
 				int rc = new CopyToPDS().file(new File(buildUtils.getAbsolutePath(buildFile))).dataset(targetDataset).member(member).output(true).deployType(deployType).execute()
-				if (props.verbose) println "** Copyied $buildFile to $targetDataset with deployTyoe $deployType; rc = $rc"
+				if (props.verbose) println "** Copied $buildFile to $targetDataset with deployType $deployType (rc = $rc)"
 
 				if (rc!=0){
 					String errorMsg = "*! The CopyToPDS return code ($rc) for $buildFile exceeded the maximum return code allowed (0)."

--- a/languages/Transfer.groovy
+++ b/languages/Transfer.groovy
@@ -55,7 +55,7 @@ buildList.each { buildFile ->
 
 		// evaluate the datasetmapping, which maps build files to targetDataset defintions
 		PropertyMappings dsMapping = new PropertyMappings("transfer_datasetMapping")
-		PropertyMappings dsOptionsMapping = new PropertyMappings("transfer_srcOptions")
+		PropertyMappings dsOptionsMapping = new PropertyMappings("transfer_dsOptions")
 
 		// obtain the target dataset based on the mapped dataset key
 		mappedDatesetDef = dsMapping.getValue(buildFile)
@@ -67,7 +67,7 @@ buildList.each { buildFile ->
 			String datasetOptions = dsOptionsMapping.getValue(mappedDatesetDef)
 			
 			if (datasetOptions == null) {
-				String errorMsg =  "*! Dataset options for $buildFile could not be obtained PropertyMappings <transfer_srcOptions>. "
+				String errorMsg =  "*! Dataset options for $buildFile could not be obtained PropertyMappings <transfer_dsOptions>. "
 				println(errorMsg)
 				props.error = "true"
 				buildUtils.updateBuildResult(errorMsg:errorMsg)

--- a/languages/Transfer.groovy
+++ b/languages/Transfer.groovy
@@ -21,6 +21,17 @@ import groovy.transform.*
  * * File names cannot exeed more than 8 characters, so they can be stored in
  *   the target dataset.
  * 
+ * * Review configurations in 
+ * 
+ *   build-conf/Transfer.properties
+ *     to define target datasets and dataset characteristics  
+ * 
+ *   application-conf/file.properties
+ *     to map files and define the deployType
+ *     
+ *   application-conf/Transfer.properties  
+ *     to specify the default deployType
+ *   
  */
 
 // define script properties

--- a/samples/application-conf/file.properties
+++ b/samples/application-conf/file.properties
@@ -36,6 +36,10 @@ dbb.scannerMapping = ZUnitConfigScanner :: **/*.bzucfg
 # mapping for overwriting the impactResolution rules in application.properties
 # impactResolutionRules=[${copybookRule},${linkRule}] :: **/copy/*.cpy,**/cobol/*.cbl
 
+#########
+# Configuration for Transfer.groovy which copies files to target datasets and report them
+# in the BuildReport 
+#########
 #
 # PropertyMapping to map files using the Transfer.groovy language script to different target datasets 
 #

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -539,6 +539,9 @@ def getLangPrefix(String scriptName){
 		case "PSBgen.groovy":
 			langPrefix = 'psbgen'
 			break;
+		case "Transfer.groovy":
+			langPrefix = 'transfer'
+			break;
 		default:
 			if (props.verbose) println ("*** ! No language prefix defined for $scriptName.")
 			break;

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -26,7 +26,7 @@ def assertBuildProperties(String requiredProps) {
 
 		buildProps.each { buildProp ->
 			buildProp = buildProp.trim()
-			assert props."$buildProp" : "*! Missing required build property '$buildProp'"
+			assert (props."$buildProp" || !(new PropertyMappings("$buildProp").getValues().isEmpty())) : "*! Missing required build property '$buildProp'"
 		}
 	}
 }


### PR DESCRIPTION
This PR is enhancing the `Transfer.groovy` script, which is uploading a non-buildable file to a target dataset library.

The enhancements are:
* Allow different dataset characteristics for the various target libraries, defined in `transfer_dsOptions` in `build-conf/Transfer.properties`
* Document the deletion based on the mapped target dataset.

This will close #251 and #272