### PR TITLE
Refactor zAppBuild reporting capabilities

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -17,6 +17,7 @@ import groovy.cli.commons.*
 @Field def gitUtils= loadScript(new File("utilities/GitUtilities.groovy"))
 @Field def buildUtils= loadScript(new File("utilities/BuildUtilities.groovy"))
 @Field def impactUtils= loadScript(new File("utilities/ImpactUtilities.groovy"))
+@Field def reportingUtils= loadScript(new File("utilities/ReportingUtilities.groovy"))
 @Field def filePropUtils= loadScript(new File("utilities/FilePropUtilities.groovy"))
 @Field String hashPrefix = ':githash:'
 @Field String giturlPrefix = ':giturl:'
@@ -596,18 +597,18 @@ def createBuildList() {
 	if (props.reportExternalImpacts && props.reportExternalImpacts.toBoolean()){
 		if (buildSet && changedFiles) {
 			println "** Perform analysis and reporting of external impacted files for the build list including changed files."
-			impactUtils.reportExternalImpacts(buildSet.plus(changedFiles))
+			reportingUtils.reportExternalImpacts(buildSet.plus(changedFiles))
 		}
 		else if(buildSet) {
 			println "** Perform analysis and reporting of external impacted files for the build list."
-			impactUtils.reportExternalImpacts(buildSet)
+			reportingUtils.reportExternalImpacts(buildSet)
 		}
 	}
 	
 	// Document and validate concurrent changes
 	if (props.reportConcurrentChanges && props.reportConcurrentChanges.toBoolean()){
 		println "** Calculate and document concurrent changes."
-		impactUtils.calculateConcurrentChanges(buildSet)
+		reportingUtils.calculateConcurrentChanges(buildSet)
 	}
 	
 	// document deletions in build report

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,5 @@ This folder contains supplemental documentation to help explain the implementati
 
 |File|Description|
 |-|-|
-|FilePropertyManagement|Documentation on managing default and overriding build properties for specific application files|
+|[FilePropertyManagement](FilePropertyManagement.md)|Documentation on managing default and overriding build properties for specific application files|
+|[Reporting Capabilities](REPORTS.md)|Documentation of zAppBuild reporting capabilities like reporting external impacted file and reporting of concurrent changes|

--- a/docs/REPORTS.md
+++ b/docs/REPORTS.md
@@ -110,7 +110,7 @@ App-EPSM/cobol/epsplist.cbl
 
 ### Purpose
 
-Concurrent development activies in separated isolated branches on the same source code, lead to the need to merge the code at some point in time. Git does an excellent job for this task and supports the developer for this task. While pessimistic locking is a common practise on the mainframe, developers will need to keep an eye on what is happening in the git repository, which follows the optimistic locking approach.
+Concurrent development activities in separated isolated branches on the same source code, lead to the need to merge the code at some point in time. Git does an excellent job for this task and supports the developer for this task. While pessimistic locking is a common practise on the mainframe, developers will need to keep an eye on what is happening in the git repository, which follows the optimistic locking approach.
 
 The _Report concurrent changes_ feature can be activated to generate a report to document changes in other configurations within the repository. Additionally, it validates if the current build list intersects with those changes.
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -790,3 +790,21 @@ def getShortGitHash(String buildFile) {
 	if (props.verbose) println "*! Could not obtain abbreviated githash for buildFile $buildFile"
 	return null
 }
+
+/**
+ * createPathMatcherPattern
+ * Generic method to build PathMatcher from a build property
+ */
+
+def createPathMatcherPattern(String property) {
+	List<PathMatcher> pathMatchers = new ArrayList<PathMatcher>()
+	if (property) {
+		property.split(',').each{ filePattern ->
+			if (!filePattern.startsWith('glob:') || !filePattern.startsWith('regex:'))
+				filePattern = "glob:$filePattern"
+			PathMatcher matcher = FileSystems.getDefault().getPathMatcher(filePattern)
+			pathMatchers.add(matcher)
+		}
+	}
+	return pathMatchers
+}

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -9,6 +9,9 @@ import groovy.json.JsonSlurper
 import com.ibm.dbb.build.DBBConstants.CopyMode
 import com.ibm.dbb.build.report.records.*
 import com.ibm.jzos.FileAttribute
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.nio.file.PathMatcher
 import groovy.ant.*
 
 // define script properties

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -811,3 +811,19 @@ def createPathMatcherPattern(String property) {
 	}
 	return pathMatchers
 }
+
+/**
+ * matches
+ * Generic method to validate if a file is matching any pathmatchers  
+ * 
+ */
+def matches(String file, List<PathMatcher> pathMatchers) {
+	def result = pathMatchers.any { matcher ->
+		Path path = FileSystems.getDefault().getPath(file);
+		if ( matcher.matches(path) )
+		{
+			return true
+		}
+	}
+	return result
+}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -85,7 +85,7 @@ def createImpactBuildList() {
 					// only add impacted files that have a build script mapped to it
 					if (ScriptMappings.getScriptName(impactFile)) {
 						// only add impacted files, that are in scope of the build.
-						if (!matches(impactFile, excludeMatchers)){
+						if (!buildUtils.matches(impactFile, excludeMatchers)){
 
 							// calculate abbreviated gitHash for impactFile
 							filePattern = FileSystems.getDefault().getPath(impactFile).getParent().toString()
@@ -137,7 +137,7 @@ def createImpactBuildList() {
 						// only add impacted files that have a build script mapped to it
 						if (ScriptMappings.getScriptName(impactFile)) {
 							// only add impacted files, that are in scope of the build.
-							if (!matches(impactFile, excludeMatchers)){
+							if (!buildUtils.matches(impactFile, excludeMatchers)){
 								buildSet.add(impactFile)
 								if (props.verbose) println "** $impactFile is impacted by changed property $changedProp. Adding to build list."
 							}
@@ -410,7 +410,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 		changed.each { file ->
 			(file, mode) = fixGitDiffPath(file, dir, true, null)
 			if ( file != null ) {
-				if ( !matches(file, excludeMatchers)) {
+				if ( !buildUtils.matches(file, excludeMatchers)) {
 					changedFiles << file
 					if (!calculateConcurrentChanges) githashBuildableFilesMap.addFilePattern(abbrevCurrent, file)
 					if (props.verbose) println "**** $file"
@@ -427,7 +427,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 
 		if (props.verbose) println "*** Deleted files for directory $dir $msg:"
 		deleted.each { file ->
-			if ( !matches(file, excludeMatchers)) {
+			if ( !buildUtils.matches(file, excludeMatchers)) {
 				(file, mode) = fixGitDiffPath(file, dir, false, mode)
 				deletedFiles << file
 				if (props.verbose) println "**** $file"
@@ -436,7 +436,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 
 		if (props.verbose) println "*** Renamed files for directory $dir $msg:"
 		renamed.each { file ->
-			if ( !matches(file, excludeMatchers)) {
+			if ( !buildUtils.matches(file, excludeMatchers)) {
 				(file, mode) = fixGitDiffPath(file, dir, false, mode)
 				renamedFiles << file
 				if (props.verbose) println "**** $file"
@@ -538,7 +538,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 	changedFiles.each { file ->
 
 		// make sure file is not an excluded file
-		if ( new File("${props.workspace}/${file}").exists() && !matches(file, excludeMatchers)) {
+		if ( new File("${props.workspace}/${file}").exists() && !buildUtils.matches(file, excludeMatchers)) {
 			// files in a collection are stored as relative paths from a source directory
 			if (props.verbose) println "*** Scanning file $file (${props.workspace}/${file})"
 
@@ -752,17 +752,6 @@ def fixGitDiffPath(String file, String dir, boolean mustExist, mode) {
 	return [defaultValue, null]
 }
 
-def matches(String file, List<PathMatcher> pathMatchers) {
-	def result = pathMatchers.any { matcher ->
-		Path path = FileSystems.getDefault().getPath(file);
-		if ( matcher.matches(path) )
-		{
-			return true
-		}
-	}
-	return result
-}
-
 /**
  *  shouldCalculateImpacts
  *
@@ -772,7 +761,7 @@ def matches(String file, List<PathMatcher> pathMatchers) {
 def boolean shouldCalculateImpacts(String changedFile){
 	// retrieve Pathmaters from property and check
 	List<PathMatcher> nonImpactingFiles = buildUtils.createPathMatcherPattern(props.skipImpactCalculationList)
-	onskipImpactCalculationList = matches(changedFile, nonImpactingFiles)
+	onskipImpactCalculationList = buildUtils.matches(changedFile, nonImpactingFiles)
 
 	// return false if changedFile found in skipImpactCalculationList
 	if (onskipImpactCalculationList) return false

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -72,7 +72,7 @@ def createImpactBuildList() {
 				if (props.verbose) println "** Performing impact analysis on changed file $changedFile"
 
 				// get exclude list
-				List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
+				List<PathMatcher> excludeMatchers = buildUtils.createPathMatcherPattern(props.excludeFileList)
 
 				// list of impacts
 				String impactSearch = props.getFileProperty('impactSearch', changedFile)
@@ -129,7 +129,7 @@ def createImpactBuildList() {
 
 
 					// get excludeListe
-					List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
+					List<PathMatcher> excludeMatchers = buildUtils.createPathMatcherPattern(props.excludeFileList)
 
 					logicalFileList.each { logicalFile ->
 						def impactFile = logicalFile.getFile()
@@ -404,7 +404,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 		def mode = null
 
 		// make sure file is not an excluded file
-		List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
+		List<PathMatcher> excludeMatchers = buildUtils.createPathMatcherPattern(props.excludeFileList)
 
 		if (props.verbose) println "*** Changed files for directory $dir $msg:"
 		changed.each { file ->
@@ -494,292 +494,7 @@ def scanOnlyStaticDependencies(List buildList){
 
 
 
-/**
- * Method to calculate and report the changes between the current configuration and concurrent configurations;
- * leverages the existing infrastructure to calculateChangedFiles - in this case for concurrent configs.
- *
- * Invokes method generateConcurrentChangesReports to produce the reports
- *
- * @param buildSet
- *
- */
-def calculateConcurrentChanges(Set<String> buildSet) {
-	
-		// initialize patterns
-		List<Pattern> gitRefMatcherPatterns = createMatcherPatterns(props.reportConcurrentChangesGitBranchReferencePatterns)
-	
-		// obtain all current remote branches
-		// TODO: Handle / Exclude branches from other repositories
-		Set<String> remoteBranches = new HashSet<String>()
-		props.applicationSrcDirs.split(",").each { dir ->
-			dir = buildUtils.getAbsolutePath(dir)
-			remoteBranches.addAll(gitUtils.getRemoteGitBranches(dir))
-		}
-		
-		// Run analysis for each remoteBranch, which matches the configured criteria
-		remoteBranches.each { gitReference ->
-	
-			if (matchesPattern(gitReference,gitRefMatcherPatterns) && !gitReference.equals(props.applicationCurrentBranch)){
-	
-				Set<String> concurrentChangedFiles = new HashSet<String>()
-				Set<String> concurrentRenamedFiles = new HashSet<String>()
-				Set<String> concurrentDeletedFiles = new HashSet<String>()
-				Set<String> concurrentBuildProperties = new HashSet<String>()
-	
-				if (props.verbose) println "***  Analysing and validating changes for branch $gitReference ."
-	
-				(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, concurrentBuildProperties) = calculateChangedFiles(null, true, gitReference)
-	
-				// generate reports and verify for intersects
-				generateConcurrentChangesReports(buildSet, concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference)
-	
-			}
-		}
-	
-	}
 
-/*
- * Method to generate the Concurrent Changes reports and validate if the current build list intersects with concurrent changes
- */
-
-def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference){
-	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges.txt"
-
-	File concurrentChangesReportFile = new File(concurrentChangesReportLoc)
-	String enc = props.logEncoding ?: 'IBM-1047'
-	concurrentChangesReportFile.withWriterAppend(enc) { writer ->
-
-		if (!(concurrentChangedFiles.size() == 0 &&  concurrentRenamedFiles.size() == 0 && concurrentDeletedFiles.size() == 0)) {
-
-			if (props.verbose) println("** Writing report of concurrent changes to $concurrentChangesReportLoc for configuration $gitReference")
-
-			writer.write("\n=============================================== \n")
-			writer.write("** Report for configuration: $gitReference \n")
-			writer.write("========\n")
-
-			if (concurrentChangedFiles.size() != 0) {
-				writer.write("** Changed Files \n")
-				concurrentChangedFiles.each { file ->
-					if (props.verbose) println " Changed: ${file}"
-					if (buildList.contains(file)) {
-						writer.write("* $file is changed and intersects with the current build list.\n")
-						String msg = "*!! $file is changed on branch $gitReference and intersects with the current build list."
-						println msg
-						
-						// update build result
-						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
-							props.error = "true"
-							buildUtils.updateBuildResult(errorMsg:msg)
-						} else {
-							buildUtils.updateBuildResult(warningMsg:msg)
-						}
-					}
-					else
-						writer.write("  $file\n")
-				}
-			}
-
-			if (concurrentRenamedFiles.size() != 0) {
-				writer.write("** Renamed Files \n")
-				concurrentRenamedFiles.each { file ->
-					if (props.verbose) println " Renamed: ${file}"
-					if (buildList.contains(file)) {
-						writer.write("* $file got renamed and intersects with the current build list.\n")
-						String msg = "*!! $file is renamed on branch $gitReference and intersects with the current build list."
-						println msg
-						
-						// update build result
-						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
-							props.error = "true"
-							buildUtils.updateBuildResult(errorMsg:msg)
-						} else {
-							buildUtils.updateBuildResult(warningMsg:msg)
-						}
-					}
-					else
-						writer.write("  $file\n")
-				}
-			}
-
-			if (concurrentDeletedFiles.size() != 0) {
-				writer.write("** Deleted Files \n")
-				concurrentDeletedFiles.each { file ->
-					if (props.verbose) println " Deleted: ${file}"
-					if (buildList.contains(file)) {
-						writer.write("* $file is deleted and intersects with the current build list.\n")
-						String msg = "*!! $file is deleted on branch $gitReference and intersects with the current build list."
-						println msg
-						
-						// update build result
-						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
-							props.error = "true"
-							buildUtils.updateBuildResult(errorMsg:msg)
-						} else {
-							buildUtils.updateBuildResult(warningMsg:msg)
-						}
-					}
-					else
-						writer.write("  $file\n")
-				}
-			}
-		}
-	}
-}
-
-/**
- * Method to query the DBB collections with a list of files
- * Configured through reportExternalImpacts* build properties
- */
-
-def reportExternalImpacts(Set<String> changedFiles){
-	// query external collections to produce externalImpactList
-
-	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>() // <collection><List impactRecords>
-	Set<String> impactedFiles = new HashSet<String>()
-
-	List<String> externalImpactReportingList = new ArrayList()
-
-	if (props.verbose) println("*** Running external impact analysis with file filter ${props.reportExternalImpactsAnalysisFileFilter} and collection patterns ${props.reportExternalImpactsCollectionPatterns} with analysis mode ${props.reportExternalImpactsAnalysisDepths}")
-
-
-	try {
-
-		if (props.reportExternalImpactsAnalysisDepths == "simple" || props.reportExternalImpactsAnalysisDepths == "deep"){
-
-			// get directly impacted candidates first
-			if (props.verbose) println("*** Running external impact analysis for files ")
-
-			// calculate and collect external impacts
-			changedFiles.each{ changedFile ->
-
-				List<PathMatcher> fileMatchers = createPathMatcherPattern(props.reportExternalImpactsAnalysisFileFilter)
-
-				// check that file is on reportExternalImpactsAnalysisFileFilter
-				if(matches(changedFile, fileMatchers)){
-
-					// get directly impacted candidates first
-					if (props.verbose) println("     $changedFile ")
-
-					externalImpactReportingList.add(changedFile)
-				}
-				else {
-					if (props.verbose) println("*** Analysis and reporting has been skipped for changed file $changedFile due to build framework configuration (see configuration of build property reportExternalImpactsAnalysisFileFilter)")
-				}
-			}
-
-			if (externalImpactReportingList.size() != 0) {
-				(collectionImpactsSetMap, impactedFiles) = calculateLogicalImpactedFiles(externalImpactReportingList, changedFiles, collectionImpactsSetMap, "***", "buildSet")
-
-
-				// get impacted files of idenfied impacted files
-				if (props.reportExternalImpactsAnalysisDepths == "deep") {
-					if (props.verbose) println("**** Running external impact analysis for identified external impacted files as dependent files of the initial set. ")
-					impactedFiles.each{ impactedFile ->
-						if (props.verbose) println("     $impactedFile ")
-
-					}
-					def impactsBin
-					(collectionImpactsSetMap, impactsBin) = calculateLogicalImpactedFiles(new ArrayList(impactedFiles), changedFiles, collectionImpactsSetMap, "****", "impactSet")
-				}
-
-			}
-
-			// generate reports by collection / application
-			collectionImpactsSetMap.each{ entry ->
-				externalImpactList = entry.value
-				if (externalImpactList.size()!=0){
-					// write impactedFiles per application to build workspace
-					String impactListFileLoc = "${props.buildOutDir}/externalImpacts_${entry.key}.${props.buildListFileExt}"
-					if (props.verbose) println("*** Writing report of external impacts to file $impactListFileLoc")
-					File impactListFile = new File(impactListFileLoc)
-					String enc = props.logEncoding ?: 'IBM-1047'
-					impactListFile.withWriter(enc) { writer ->
-						externalImpactList.each { file ->
-							// if (props.verbose) println file
-							writer.write("$file\n")
-						}
-					}
-				}
-			}
-
-		}
-		else {
-			println("*! build property reportExternalImpactsAnalysisDepths has an invalid value : ${props.reportExternalImpactsAnaylsisDepths} , valid: simple | deep")
-		}
-
-	} catch (Exception e) {
-		println("*! (ImpactUtilities.reportExternalImpacts) Exception caught during reporting of external impacts. Build continues.")
-		println(e.getMessage())
-	}
-}
-
-/*
- * Used to inspect dbb collections for potential impacts, sub-method to reportExternalImpacts
- */
-
-def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFiles, Map<String,HashSet> collectionImpactsSetMap, String indentationMsg, String analysisMode) {
-	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
-
-	// local matchers to inspect files and collections
-	List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.reportExternalImpactsCollectionPatterns)
-
-	// local
-	List<LogicalDependency> logicalDependencies = new ArrayList()
-	
-	// will be returned
-	Set<String> impactedFiles = new HashSet<String>()
-
-	// creating a list logical dependencies
-	fileList.each{ file ->
-		// go after all the files passed in; assess the identified impacted files to skip analysis for files from an impactSet which are on the changed files
-		if(analysisMode.equals('buildSet') || (analysisMode.equals('impactSet') && !changedFiles.contains(file))){
-			String memberName = CopyToPDS.createMemberName(file)
-			def ldepFile = new LogicalDependency(memberName, null, null);
-			logicalDependencies.add(ldepFile)
-		}else {
-			// debug-output
-			// println("$indentationMsg!* Skipped redundant analysis. $file was already or will be procceed soon.")
-		}
-	}
-
-	if(logicalDependencies.size != 0) {
-
-		// iterate over collections
-		metadataStore.getCollections().each{ collection ->
-			String cName = collection.getName()
-			if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
-
-				def Set<String> externalImpactList = collectionImpactsSetMap.get(cName) ?: new HashSet<String>()
-				// query dbb web app for files with all logicalDependencies
-				def logicalImpactedFiles = metadataStore.getImpactedFiles([cName], logicalDependencies);
-				
-				logicalImpactedFiles.each{ logicalFile ->
-					if (props.verbose) println("$indentationMsg Potential external impact found ${logicalFile.getLname()} (${logicalFile.getFile()}) in collection ${cName} ")
-					def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"
-					externalImpactList.add(impactRecord)
-					impactedFiles.add(logicalFile.getFile())
-				}
-				// adding updated record
-				collectionImpactsSetMap.put(cName, externalImpactList)
-
-			}
-			else{
-				// debug-output
-				//if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
-			}
-		}
-	}
-	else {
-		// debug-output
-		//if (props.verbose) println("Empty fileList")
-	}
-
-
-	return [
-		collectionImpactsSetMap,
-		impactedFiles
-	]
-}
 
 def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 
@@ -792,7 +507,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 	if (props.verbose) println "** Updating collections ${props.applicationCollectionName} and ${props.applicationOutputsCollectionName}"
 	//def scanner = new DependencyScanner()
 	List<LogicalFile> logicalFiles = new ArrayList<LogicalFile>()
-	List<PathMatcher> excludeMatchers = createPathMatcherPattern(props.excludeFileList)
+	List<PathMatcher> excludeMatchers = buildUtils.createPathMatcherPattern(props.excludeFileList)
 
 	verifyCollections()
 
@@ -1056,58 +771,12 @@ def matches(String file, List<PathMatcher> pathMatchers) {
  */
 def boolean shouldCalculateImpacts(String changedFile){
 	// retrieve Pathmaters from property and check
-	List<PathMatcher> nonImpactingFiles = createPathMatcherPattern(props.skipImpactCalculationList)
+	List<PathMatcher> nonImpactingFiles = buildUtils.createPathMatcherPattern(props.skipImpactCalculationList)
 	onskipImpactCalculationList = matches(changedFile, nonImpactingFiles)
 
 	// return false if changedFile found in skipImpactCalculationList
 	if (onskipImpactCalculationList) return false
 	return true //default
-}
-
-/**
- * createPathMatcherPattern
- * Generic method to build PathMatcher from a build property
- */
-
-def createPathMatcherPattern(String property) {
-	List<PathMatcher> pathMatchers = new ArrayList<PathMatcher>()
-	if (property) {
-		property.split(',').each{ filePattern ->
-			if (!filePattern.startsWith('glob:') || !filePattern.startsWith('regex:'))
-				filePattern = "glob:$filePattern"
-			PathMatcher matcher = FileSystems.getDefault().getPathMatcher(filePattern)
-			pathMatchers.add(matcher)
-		}
-	}
-	return pathMatchers
-}
-
-/**
- * create List of Regex Patterns
- */
-
-def createMatcherPatterns(String property) {
-	List<Pattern> patterns = new ArrayList<Pattern>()
-	if (property) {
-		property.split(',').each{ patternString ->
-			Pattern pattern = Pattern.compile(patternString);
-			patterns.add(pattern)
-		}
-	}
-	return patterns
-}
-
-/**
- * match a String against a list of patterns
- */
-def matchesPattern(String name, List<Pattern> patterns) {
-	def result = patterns.any { pattern ->
-		if (pattern.matcher(name).matches())
-		{
-			return true
-		}
-	}
-	return result
 }
 
 /**

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -150,17 +150,23 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
 			if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
 
 				def Set<String> externalImpactList = collectionImpactsSetMap.get(cName) ?: new HashSet<String>()
-				// query dbb web app for files with all logicalDependencies
-				def logicalImpactedFiles = metadataStore.getImpactedFiles([cName], logicalDependencies);
+				// query dbb metadatastore for files with all logicalDependencies
+				def logicalImpactedFilesCollections = metadataStore.getImpactedFiles([cName], logicalDependencies);
 				
-				logicalImpactedFiles.each{ logicalFile ->
-					if (props.verbose) println("$indentationMsg Potential external impact found ${logicalFile.getLname()} (${logicalFile.getFile()}) in collection ${cName} ")
-					def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"
-					externalImpactList.add(impactRecord)
-					impactedFiles.add(logicalFile.getFile())
+				logicalImpactedFilesCollections.each { collection ->
+					List<LogicalFile> logicalImpactedFiles = collection.getLogicalFiles()
+					logicalImpactedFiles.each{ logicalFile ->
+						if (props.verbose) println("$indentationMsg Potential external impact found ${logicalFile.getLname()} (${logicalFile.getFile()}) in collection ${cName} ")
+						def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"
+						externalImpactList.add(impactRecord)
+						impactedFiles.add(logicalFile.getFile())
+					}
+					// adding updated record
+					collectionImpactsSetMap.put(cName, externalImpactList)
+					
 				}
-				// adding updated record
-				collectionImpactsSetMap.put(cName, externalImpactList)
+				
+				
 
 			}
 			else{

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -109,6 +109,7 @@ def reportExternalImpacts(Set<String> changedFiles){
 	} catch (Exception e) {
 		println("*! (ReportingUtilities.reportExternalImpacts) Exception caught during reporting of external impacts. Build continues.")
 		println(e.getMessage())
+		println(e.printStackTrace())
 	}
 }
 

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -5,6 +5,7 @@ import com.ibm.dbb.build.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.metadata.*
 import groovy.transform.*
+import java.net.URLEncoder
 
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()
@@ -88,7 +89,9 @@ def reportExternalImpacts(Set<String> changedFiles){
 				externalImpactList = entry.value
 				if (externalImpactList.size()!=0){
 					// write impactedFiles per application to build workspace
-					String impactListFileLoc = "${props.buildOutDir}/externalImpacts_${entry.key}.${props.buildListFileExt}"
+					// naming convention: externalImpacts_<collectionName>.log
+					String encodedFileName = URLEncoder.encode("externalImpacts_${entry.key}.log", "UTF-8")
+					String impactListFileLoc = "${props.buildOutDir}/${encodedFileName}"
 					if (props.verbose) println("*** Writing report of external impacts to file $impactListFileLoc")
 					File impactListFile = new File(impactListFileLoc)
 					String enc = props.logEncoding ?: 'IBM-1047'

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -1,0 +1,344 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import java.nio.file.PathMatcher
+import java.util.regex.*
+import com.ibm.dbb.build.*
+import com.ibm.dbb.dependency.*
+import groovy.transform.*
+
+// define script properties
+@Field BuildProperties props = BuildProperties.getInstance()
+@Field def gitUtils= loadScript(new File("GitUtilities.groovy"))
+@Field def buildUtils= loadScript(new File("BuildUtilities.groovy"))
+
+/**
+ * This utilities script is a collection of methods for the reporting 
+ * capabilities of zAppBuild - for details see docs/REPORTS.md
+ * 
+ * This includes
+ * 
+ *  - Report external impacted files (impacted logical files in other collections)
+ *  - Report concurrent changes to document changes in other configurations within the repository 
+ * 
+ */
+
+
+// Methods for reporting external impacted files
+
+/**
+ * Method to query the DBB collections with a list of files
+ * Configured through reportExternalImpacts* build properties
+ */
+
+def reportExternalImpacts(Set<String> changedFiles){
+	// query external collections to produce externalImpactList
+
+	Map<String,HashSet> collectionImpactsSetMap = new HashMap<String,HashSet>() // <collection><List impactRecords>
+	Set<String> impactedFiles = new HashSet<String>()
+
+	List<String> externalImpactReportingList = new ArrayList()
+
+	if (props.verbose) println("*** Running external impact analysis with file filter ${props.reportExternalImpactsAnalysisFileFilter} and collection patterns ${props.reportExternalImpactsCollectionPatterns} with analysis mode ${props.reportExternalImpactsAnalysisDepths}")
+
+
+	try {
+
+		if (props.reportExternalImpactsAnalysisDepths == "simple" || props.reportExternalImpactsAnalysisDepths == "deep"){
+
+			// get directly impacted candidates first
+			if (props.verbose) println("*** Running external impact analysis for files ")
+
+			// calculate and collect external impacts
+			changedFiles.each{ changedFile ->
+
+				List<PathMatcher> fileMatchers = buildUtils.createPathMatcherPattern(props.reportExternalImpactsAnalysisFileFilter)
+
+				// check that file is on reportExternalImpactsAnalysisFileFilter
+				if(matches(changedFile, fileMatchers)){
+
+					// get directly impacted candidates first
+					if (props.verbose) println("     $changedFile ")
+
+					externalImpactReportingList.add(changedFile)
+				}
+				else {
+					if (props.verbose) println("*** Analysis and reporting has been skipped for changed file $changedFile due to build framework configuration (see configuration of build property reportExternalImpactsAnalysisFileFilter)")
+				}
+			}
+
+			if (externalImpactReportingList.size() != 0) {
+				(collectionImpactsSetMap, impactedFiles) = calculateLogicalImpactedFiles(externalImpactReportingList, changedFiles, collectionImpactsSetMap, "***", "buildSet")
+
+
+				// get impacted files of idenfied impacted files
+				if (props.reportExternalImpactsAnalysisDepths == "deep") {
+					if (props.verbose) println("**** Running external impact analysis for identified external impacted files as dependent files of the initial set. ")
+					impactedFiles.each{ impactedFile ->
+						if (props.verbose) println("     $impactedFile ")
+
+					}
+					def impactsBin
+					(collectionImpactsSetMap, impactsBin) = calculateLogicalImpactedFiles(new ArrayList(impactedFiles), changedFiles, collectionImpactsSetMap, "****", "impactSet")
+				}
+
+			}
+
+			// generate reports by collection / application
+			collectionImpactsSetMap.each{ entry ->
+				externalImpactList = entry.value
+				if (externalImpactList.size()!=0){
+					// write impactedFiles per application to build workspace
+					String impactListFileLoc = "${props.buildOutDir}/externalImpacts_${entry.key}.${props.buildListFileExt}"
+					if (props.verbose) println("*** Writing report of external impacts to file $impactListFileLoc")
+					File impactListFile = new File(impactListFileLoc)
+					String enc = props.logEncoding ?: 'IBM-1047'
+					impactListFile.withWriter(enc) { writer ->
+						externalImpactList.each { file ->
+							// if (props.verbose) println file
+							writer.write("$file\n")
+						}
+					}
+				}
+			}
+
+		}
+		else {
+			println("*! build property reportExternalImpactsAnalysisDepths has an invalid value : ${props.reportExternalImpactsAnaylsisDepths} , valid: simple | deep")
+		}
+
+	} catch (Exception e) {
+		println("*! (ReportingUtilities.reportExternalImpacts) Exception caught during reporting of external impacts. Build continues.")
+		println(e.getMessage())
+	}
+}
+
+/*
+ * Used to inspect dbb collections for potential impacts, sub-method to reportExternalImpacts
+ */
+
+def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFiles, Map<String,HashSet> collectionImpactsSetMap, String indentationMsg, String analysisMode) {
+	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
+
+	// local matchers to inspect files and collections
+	List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.reportExternalImpactsCollectionPatterns)
+
+	// local
+	List<LogicalDependency> logicalDependencies = new ArrayList()
+	
+	// will be returned
+	Set<String> impactedFiles = new HashSet<String>()
+
+	// creating a list logical dependencies
+	fileList.each{ file ->
+		// go after all the files passed in; assess the identified impacted files to skip analysis for files from an impactSet which are on the changed files
+		if(analysisMode.equals('buildSet') || (analysisMode.equals('impactSet') && !changedFiles.contains(file))){
+			String memberName = CopyToPDS.createMemberName(file)
+			def ldepFile = new LogicalDependency(memberName, null, null);
+			logicalDependencies.add(ldepFile)
+		}else {
+			// debug-output
+			// println("$indentationMsg!* Skipped redundant analysis. $file was already or will be procceed soon.")
+		}
+	}
+
+	if(logicalDependencies.size != 0) {
+
+		// iterate over collections
+		metadataStore.getCollections().each{ collection ->
+			String cName = collection.getName()
+			if(matchesPattern(cName,collectionMatcherPatterns)){ // find matching collection names
+
+				def Set<String> externalImpactList = collectionImpactsSetMap.get(cName) ?: new HashSet<String>()
+				// query dbb web app for files with all logicalDependencies
+				def logicalImpactedFiles = metadataStore.getImpactedFiles([cName], logicalDependencies);
+				
+				logicalImpactedFiles.each{ logicalFile ->
+					if (props.verbose) println("$indentationMsg Potential external impact found ${logicalFile.getLname()} (${logicalFile.getFile()}) in collection ${cName} ")
+					def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"
+					externalImpactList.add(impactRecord)
+					impactedFiles.add(logicalFile.getFile())
+				}
+				// adding updated record
+				collectionImpactsSetMap.put(cName, externalImpactList)
+
+			}
+			else{
+				// debug-output
+				//if (props.verbose) println("$cName does not match pattern: $collectionMatcherPatterns")
+			}
+		}
+	}
+	else {
+		// debug-output
+		//if (props.verbose) println("Empty fileList")
+	}
+
+
+	return [
+		collectionImpactsSetMap,
+		impactedFiles
+	]
+}
+
+// Methods for reporting concurrent changes
+
+/**
+ * Method to calculate and report the changes between the current configuration and concurrent configurations;
+ * leverages the existing infrastructure to calculateChangedFiles - in this case for concurrent configs.
+ *
+ * Invokes method generateConcurrentChangesReports to produce the reports
+ *
+ * @param buildSet
+ *
+ */
+def calculateConcurrentChanges(Set<String> buildSet) {
+	
+		// initialize patterns
+		List<Pattern> gitRefMatcherPatterns = createMatcherPatterns(props.reportConcurrentChangesGitBranchReferencePatterns)
+	
+		// obtain all current remote branches
+		// TODO: Handle / Exclude branches from other repositories
+		Set<String> remoteBranches = new HashSet<String>()
+		props.applicationSrcDirs.split(",").each { dir ->
+			dir = buildUtils.getAbsolutePath(dir)
+			remoteBranches.addAll(gitUtils.getRemoteGitBranches(dir))
+		}
+		
+		// Run analysis for each remoteBranch, which matches the configured criteria
+		remoteBranches.each { gitReference ->
+	
+			if (matchesPattern(gitReference,gitRefMatcherPatterns) && !gitReference.equals(props.applicationCurrentBranch)){
+	
+				Set<String> concurrentChangedFiles = new HashSet<String>()
+				Set<String> concurrentRenamedFiles = new HashSet<String>()
+				Set<String> concurrentDeletedFiles = new HashSet<String>()
+				Set<String> concurrentBuildProperties = new HashSet<String>()
+	
+				if (props.verbose) println "***  Analysing and validating changes for branch $gitReference ."
+	
+				(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, concurrentBuildProperties) = calculateChangedFiles(null, true, gitReference)
+	
+				// generate reports and verify for intersects
+				generateConcurrentChangesReports(buildSet, concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference)
+	
+			}
+		}
+	
+	}
+
+/*
+ * Method to generate the Concurrent Changes reports and validate if the current build list intersects with concurrent changes
+ */
+
+def generateConcurrentChangesReports(Set<String> buildList, Set<String> concurrentChangedFiles, Set<String> concurrentRenamedFiles, Set<String> concurrentDeletedFiles, String gitReference){
+	String concurrentChangesReportLoc = "${props.buildOutDir}/report_concurrentChanges.txt"
+
+	File concurrentChangesReportFile = new File(concurrentChangesReportLoc)
+	String enc = props.logEncoding ?: 'IBM-1047'
+	concurrentChangesReportFile.withWriterAppend(enc) { writer ->
+
+		if (!(concurrentChangedFiles.size() == 0 &&  concurrentRenamedFiles.size() == 0 && concurrentDeletedFiles.size() == 0)) {
+
+			if (props.verbose) println("** Writing report of concurrent changes to $concurrentChangesReportLoc for configuration $gitReference")
+
+			writer.write("\n=============================================== \n")
+			writer.write("** Report for configuration: $gitReference \n")
+			writer.write("========\n")
+
+			if (concurrentChangedFiles.size() != 0) {
+				writer.write("** Changed Files \n")
+				concurrentChangedFiles.each { file ->
+					if (props.verbose) println " Changed: ${file}"
+					if (buildList.contains(file)) {
+						writer.write("* $file is changed and intersects with the current build list.\n")
+						String msg = "*!! $file is changed on branch $gitReference and intersects with the current build list."
+						println msg
+						
+						// update build result
+						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
+							props.error = "true"
+							buildUtils.updateBuildResult(errorMsg:msg)
+						} else {
+							buildUtils.updateBuildResult(warningMsg:msg)
+						}
+					}
+					else
+						writer.write("  $file\n")
+				}
+			}
+
+			if (concurrentRenamedFiles.size() != 0) {
+				writer.write("** Renamed Files \n")
+				concurrentRenamedFiles.each { file ->
+					if (props.verbose) println " Renamed: ${file}"
+					if (buildList.contains(file)) {
+						writer.write("* $file got renamed and intersects with the current build list.\n")
+						String msg = "*!! $file is renamed on branch $gitReference and intersects with the current build list."
+						println msg
+						
+						// update build result
+						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
+							props.error = "true"
+							buildUtils.updateBuildResult(errorMsg:msg)
+						} else {
+							buildUtils.updateBuildResult(warningMsg:msg)
+						}
+					}
+					else
+						writer.write("  $file\n")
+				}
+			}
+
+			if (concurrentDeletedFiles.size() != 0) {
+				writer.write("** Deleted Files \n")
+				concurrentDeletedFiles.each { file ->
+					if (props.verbose) println " Deleted: ${file}"
+					if (buildList.contains(file)) {
+						writer.write("* $file is deleted and intersects with the current build list.\n")
+						String msg = "*!! $file is deleted on branch $gitReference and intersects with the current build list."
+						println msg
+						
+						// update build result
+						if (props.reportConcurrentChangesIntersectionFailsBuild && props.reportConcurrentChangesIntersectionFailsBuild.toBoolean()) {
+							props.error = "true"
+							buildUtils.updateBuildResult(errorMsg:msg)
+						} else {
+							buildUtils.updateBuildResult(warningMsg:msg)
+						}
+					}
+					else
+						writer.write("  $file\n")
+				}
+			}
+		}
+	}
+}
+
+// Internal matcher methods
+
+/**
+ * create List of Regex Patterns
+ */
+
+def createMatcherPatterns(String property) {
+	List<Pattern> patterns = new ArrayList<Pattern>()
+	if (property) {
+		property.split(',').each{ patternString ->
+			Pattern pattern = Pattern.compile(patternString);
+			patterns.add(pattern)
+		}
+	}
+	return patterns
+}
+
+/**
+* match a String against a list of patterns
+*/
+def matchesPattern(String name, List<Pattern> patterns) {
+   def result = patterns.any { pattern ->
+	   if (pattern.matcher(name).matches())
+	   {
+		   return true
+	   }
+   }
+   return result
+}

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -54,7 +54,7 @@ def reportExternalImpacts(Set<String> changedFiles){
 				List<PathMatcher> fileMatchers = buildUtils.createPathMatcherPattern(props.reportExternalImpactsAnalysisFileFilter)
 
 				// check that file is on reportExternalImpactsAnalysisFileFilter
-				if(matches(changedFile, fileMatchers)){
+				if(buildUtils.matches(changedFile, fileMatchers)){
 
 					// get directly impacted candidates first
 					if (props.verbose) println("     $changedFile ")

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -225,7 +225,7 @@ def calculateConcurrentChanges(Set<String> buildSet) {
 				Set<String> concurrentDeletedFiles = new HashSet<String>()
 				Set<String> concurrentBuildProperties = new HashSet<String>()
 	
-				if (props.verbose) println "***  Analysing and validating changes for branch $gitReference ."
+				if (props.verbose) println "***  Analysing and validating changes for branch : $gitReference"
 	
 				(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, concurrentBuildProperties) = impactUtils.calculateChangedFiles(null, true, gitReference)
 	

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -11,7 +11,7 @@ import java.net.URLEncoder
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def gitUtils= loadScript(new File("GitUtilities.groovy"))
 @Field def buildUtils= loadScript(new File("BuildUtilities.groovy"))
-@Field def impactUtils= loadScript(new File("utilities/ImpactUtilities.groovy"))
+@Field def impactUtils= loadScript(new File("ImpactUtilities.groovy"))
 
 /**
  * This utilities script is a collection of methods for the reporting 

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -42,7 +42,6 @@ def reportExternalImpacts(Set<String> changedFiles){
 
 	if (props.verbose) println("*** Running external impact analysis with file filter ${props.reportExternalImpactsAnalysisFileFilter} and collection patterns ${props.reportExternalImpactsCollectionPatterns} with analysis mode ${props.reportExternalImpactsAnalysisDepths}")
 
-
 	try {
 
 		if (props.reportExternalImpactsAnalysisDepths == "simple" || props.reportExternalImpactsAnalysisDepths == "deep"){
@@ -62,8 +61,7 @@ def reportExternalImpacts(Set<String> changedFiles){
 					if (props.verbose) println("     $changedFile ")
 					externalImpactReportingList.add(changedFile)
 					
-				}
-				else {
+				} else {
 					if (props.verbose) println("*** Analysis and reporting has been skipped for changed file $changedFile due to build framework configuration (see configuration of build property reportExternalImpactsAnalysisFileFilter)")
 				}
 			}
@@ -73,7 +71,6 @@ def reportExternalImpacts(Set<String> changedFiles){
 				// calculate impacted files and write the report
 				def List<Collection> logicalImpactedFilesCollections = calculateLogicalImpactedFiles(externalImpactReportingList, changedFiles, "buildSet")
 				writeExternalImpactReports(logicalImpactedFilesCollections, "***")
-				
 				
 				// calculate impacted files and write the report, this performs the second level of impact analysis 
 				if (props.reportExternalImpactsAnalysisDepths == "deep") {
@@ -91,9 +88,7 @@ def reportExternalImpacts(Set<String> changedFiles){
 					logicalImpactedFilesCollections = calculateLogicalImpactedFiles(externalImpactReportingList, changedFiles, "impactSet")
 					writeExternalImpactReports(logicalImpactedFilesCollections, "****")					
 				}
-
 			}
-
 		}
 		else {
 			println("*! build property reportExternalImpactsAnalysisDepths has an invalid value : ${props.reportExternalImpactsAnaylsisDepths} , valid: simple | deep")
@@ -135,9 +130,6 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
 			String memberName = CopyToPDS.createMemberName(file)
 			def ldepFile = new LogicalDependency(memberName, null, null);
 			logicalDependencies.add(ldepFile)
-		}else {
-			// debug-output
-			// println("$indentationMsg!* Skipped redundant analysis. $file was already or will be procceed soon.")
 		}
 	}
 
@@ -152,13 +144,7 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
 		
 		// run query
 		logicalImpactedFilesCollections = metadataStore.getImpactedFiles(selectedCollections, logicalDependencies);
-		
 	}
-	else {
-		// debug-output
-		//if (props.verbose) println("Empty fileList")
-	}
-
 	return logicalImpactedFilesCollections
 }
 
@@ -170,9 +156,7 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
  */
 def writeExternalImpactReports(List<Collection> logicalImpactedFilesCollections, String indentationMsg) {
 
-	
 	// generate reports by collection / application
-	
 	logicalImpactedFilesCollections.each{ collectionImpacts ->
 
 		def List<LogicalFile> logicalImpactedFiles = collectionImpacts.getLogicalFiles()

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -11,6 +11,7 @@ import java.net.URLEncoder
 @Field BuildProperties props = BuildProperties.getInstance()
 @Field def gitUtils= loadScript(new File("GitUtilities.groovy"))
 @Field def buildUtils= loadScript(new File("BuildUtilities.groovy"))
+@Field def impactUtils= loadScript(new File("utilities/ImpactUtilities.groovy"))
 
 /**
  * This utilities script is a collection of methods for the reporting 
@@ -226,7 +227,7 @@ def calculateConcurrentChanges(Set<String> buildSet) {
 	
 				if (props.verbose) println "***  Analysing and validating changes for branch $gitReference ."
 	
-				(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, concurrentBuildProperties) = calculateChangedFiles(null, true, gitReference)
+				(concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, concurrentBuildProperties) = impactUtils.calculateChangedFiles(null, true, gitReference)
 	
 				// generate reports and verify for intersects
 				generateConcurrentChangesReports(buildSet, concurrentChangedFiles, concurrentRenamedFiles, concurrentDeletedFiles, gitReference)

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -153,8 +153,8 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
 				// query dbb metadatastore for files with all logicalDependencies
 				def logicalImpactedFilesCollections = metadataStore.getImpactedFiles([cName], logicalDependencies);
 				
-				logicalImpactedFilesCollections.each { collection ->
-					List<LogicalFile> logicalImpactedFiles = collection.getLogicalFiles()
+				logicalImpactedFilesCollections.each{ collectionImpacts ->
+					List<LogicalFile> logicalImpactedFiles = collectionImpacts.getLogicalFiles()
 					logicalImpactedFiles.each{ logicalFile ->
 						if (props.verbose) println("$indentationMsg Potential external impact found ${logicalFile.getLname()} (${logicalFile.getFile()}) in collection ${cName} ")
 						def impactRecord = "${logicalFile.getLname()} \t ${logicalFile.getFile()} \t ${cName}"

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -3,6 +3,7 @@ import java.nio.file.PathMatcher
 import java.util.regex.*
 import com.ibm.dbb.build.*
 import com.ibm.dbb.dependency.*
+import com.ibm.dbb.metadata.*
 import groovy.transform.*
 
 // define script properties


### PR DESCRIPTION
Reporting capabilities in zAppBuild were previously managed in the ImpactUtilities script. While this is a feature of zAppBuild, it does not need to be part of the ImpactUtils script.

This PR is
* moving the the methods of the reporting capabilities to its dedicated utility script and addresses #340 .
* some helper methods got moved to the build utilities rather than having them in the impact utilities.
