### PR TITLE
Ability to print file attributes and including their overrides

### DIFF
--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -37,6 +37,9 @@ sortedList.each { buildFile ->
 	// Create logical file
 	LogicalFile logicalFile = buildUtils.createLogicalFile(dependencyResolver, buildFile)
 
+	// print logicalFile details and overrides
+	if (props.verbose) buildUtils.printLogicalFileAttributes(logicalFile)
+	
 	// create mvs commands
 	String member = CopyToPDS.createMemberName(buildFile)
 	File logFile = new File( props.userBuild ? "${props.buildOutDir}/${member}.log" : "${props.buildOutDir}/${member}.asm.log")

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -52,6 +52,9 @@ sortedList.each { buildFile ->
 	// Get logical file
 	LogicalFile logicalFile = buildUtils.createLogicalFile(dependencyResolver, buildFile)
 
+	// print logicalFile details and overrides
+	if (props.verbose) buildUtils.printLogicalFileAttributes(logicalFile)
+	
 	// create mvs commands
 	String member = CopyToPDS.createMemberName(buildFile)
 	File logFile = new File( props.userBuild ? "${props.buildOutDir}/${member}.log" : "${props.buildOutDir}/${member}.cobol.log")

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -51,6 +51,9 @@ sortedList.each { buildFile ->
 	// Get logical file
 	LogicalFile logicalFile = buildUtils.createLogicalFile(dependencyResolver, buildFile)
 
+	// print logicalFile details and overrides
+	if (props.verbose) buildUtils.printLogicalFileAttributes(logicalFile)
+	
 	// create mvs commands
 	String member = CopyToPDS.createMemberName(buildFile)
 	File logFile = new File( props.userBuild ? "${props.buildOutDir}/${member}.log" : "${props.buildOutDir}/${member}.pli.log")

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -796,7 +796,7 @@ def getShortGitHash(String buildFile) {
  * and indicating if an attribute is overridden through a property definition.
  * 
  * sample output:
- * File attributes: CICS=Yes, SQL=Yes*, DLI=No, MQ=No
+ * Program attributes: CICS=true, SQL=true*, DLI=false, MQ=false
  * 
  * additional notes:
  * An suffixed asterisk (*) of the value for an attribute is indicating if a property definition 
@@ -814,7 +814,7 @@ def printLogicalFileAttributes(LogicalFile logicalFile) {
 	String dliFlag = (logicalFile.isDLI() == isDLI(logicalFile)) ? "${logicalFile.isDLI()}" : "${isDLI(logicalFile)}*"
 	String mqFlag = (logicalFile.isMQ() == isMQ(logicalFile)) ? "${logicalFile.isMQ()}" : "${isMQ(logicalFile)}*"
 	
-	println "File attributes: CICS=$cicsFlag, SQL=$sqlFlag, DLI=$dliFlag, MQ=$mqFlag"
+	println "Program attributes: CICS=$cicsFlag, SQL=$sqlFlag, DLI=$dliFlag, MQ=$mqFlag"
 	
 }
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -792,10 +792,16 @@ def getShortGitHash(String buildFile) {
 }
 
 /**
- * print the logicalFile attributes and indicates if attributes are overriden
- * by file property overrides.
+ * method to print the logicalFile attributes (CICS, SQL, DLI, MQ) of a scanned file 
+ * and indicating if an attribute is overridden through a property definition.
  * 
- * //File attributes: CICS=Yes, SQL=Yes*, DLI=No, MQ=No
+ * sample output:
+ * File attributes: CICS=Yes, SQL=Yes*, DLI=No, MQ=No
+ * 
+ * additional notes:
+ * An suffixed asterisk (*) of the value for an attribute is indicating if a property definition 
+ * is overriding the value. When the values are identical, no asterisk is presented, even when 
+ * a property is setting the same value.
  * 
  * This is implementing 
  * https://github.com/IBM/dbb-zappbuild/issues/339
@@ -808,7 +814,7 @@ def printLogicalFileAttributes(LogicalFile logicalFile) {
 	String dliFlag = (logicalFile.isDLI() == isDLI(logicalFile)) ? "${logicalFile.isDLI()}" : "${isDLI(logicalFile)}*"
 	String mqFlag = (logicalFile.isMQ() == isMQ(logicalFile)) ? "${logicalFile.isMQ()}" : "${isMQ(logicalFile)}*"
 	
-	println "DBB File attributes: CICS=$cicsFlag, SQL=$sqlFlag, DLI=$dliFlag, MQ=$mqFlag"
+	println "File attributes: CICS=$cicsFlag, SQL=$sqlFlag, DLI=$dliFlag, MQ=$mqFlag"
 	
 }
 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -790,3 +790,25 @@ def getShortGitHash(String buildFile) {
 	if (props.verbose) println "*! Could not obtain abbreviated githash for buildFile $buildFile"
 	return null
 }
+
+/**
+ * print the logicalFile attributes and indicates if attributes are overriden
+ * by file property overrides.
+ * 
+ * //File attributes: CICS=Yes, SQL=Yes*, DLI=No, MQ=No
+ * 
+ * This is implementing 
+ * https://github.com/IBM/dbb-zappbuild/issues/339
+ *  
+*/
+
+def printLogicalFileAttributes(LogicalFile logicalFile) {
+	String cicsFlag = (logicalFile.isCICS() == isCICS(logicalFile)) ? "${logicalFile.isCICS()}" : "${isCICS(logicalFile)}*"
+	String sqlFlag = (logicalFile.isSQL() == isSQL(logicalFile)) ? "${logicalFile.isSQL()}" : "${isSQL(logicalFile)}*"
+	String dliFlag = (logicalFile.isDLI() == isDLI(logicalFile)) ? "${logicalFile.isDLI()}" : "${isDLI(logicalFile)}*"
+	String mqFlag = (logicalFile.isMQ() == isMQ(logicalFile)) ? "${logicalFile.isMQ()}" : "${isMQ(logicalFile)}*"
+	
+	println "DBB File attributes: CICS=$cicsFlag, SQL=$sqlFlag, DLI=$dliFlag, MQ=$mqFlag"
+	
+}
+


### PR DESCRIPTION
This PR is enhancing zAppBuild to print file attributes of the build file in verbose output mode of zAppBuild and implements #339.

It provides insights to developers if a file property is overriding the default attribute when scanning the build file with the DBB dependency scanner. 

An asterisk (*) is indicating if an override is changing the flag. When values are identical, no asterisk is presented:
```
DBB File attributes: CICS=true*, SQL=false, DLI=false, MQ=false
```
The feature is available for build files mapped to Cobol.groovy, PLI.groovy and Assembler.groovy. 

Sample output for `MortgageApplication/cobol/epscsmrt.cbl`
```
*** Building file MortgageApplication/cobol/epscsmrt.cbl
*** Resolution rules for MortgageApplication/cobol/epscsmrt.cbl:
search:/u/dbehm/userBuild/?path=MortgageApplication/copybook/*.cpy
/u/dbehm/userBuild>
*** Physical dependencies for MortgageApplication/cobol/epscsmrt.cbl:
{"excluded":false,"sourceDir":"\/u\/dbehm\/userBuild\/","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
{"excluded":false,"sourceDir":"\/u\/dbehm\/userBuild\/","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
{"excluded":false,"sourceDir":"\/u\/dbehm\/userBuild\/","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
{"excluded":false,"sourceDir":"\/u\/dbehm\/userBuild\/","lname":"EPSPDATA","library":"SYSLIB","file":"MortgageApplication\/copybook\/epspdata.cpy","category":"COPY","resolved":true}
DBB File attributes: CICS=true*, SQL=false, DLI=false, MQ=false
Cobol compiler parms for MortgageApplication/cobol/epscsmrt.cbl = LIB,CICS,ADATA,EX(ADX(ELAXMGUX))
Link-Edit parms for MortgageApplication/cobol/epscsmrt.cbl = MAP,RENT,COMPAT(PM5)
** Generated linkcard input stream: 
```