### PR TITLE
Preview build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ zAppBuild supports a number of build scenarios:
 * **Merge Build** - Build only changed programs which will be merged back into the mainBuildBranch by using a triple-dot git diff. 
 * **Scan Source** - Skip the actual building and only scan source files to store dependency data in collection (migration scenario).
 * **Scan Source + Outputs** - Skip the actual building and only scan source files and existing load modules to dependency data in source and output collection (migration scenario with static linkage scenarios).
-* **Build Preview** - Supplemental build option. Process all phases of the supplied build option, but will not execute the commands. A build report and build result is generated.
+* **Build Preview** - Supplemental build option. Process all phases of the supplied build option, but will not execute the commands. A build report and a build result are generated with a specific status that excludes them in subsequent impact build calculations. 
+
 
 Instructions on invoking a zAppBuild is included in [docs/BUILD.md](docs/BUILD.md) as well as invocation samples for the above mentioned build scenarios including sample console logs.
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ zAppBuild supports a number of build scenarios:
 * **Merge Build** - Build only changed programs which will be merged back into the mainBuildBranch by using a triple-dot git diff. 
 * **Scan Source** - Skip the actual building and only scan source files to store dependency data in collection (migration scenario).
 * **Scan Source + Outputs** - Skip the actual building and only scan source files and existing load modules to dependency data in source and output collection (migration scenario with static linkage scenarios).
-* **Build Preview** - Supplemental build option. Process all phases of the supplied build option, but will not execute the commands and not create a build result.
+* **Build Preview** - Supplemental build option. Process all phases of the supplied build option, but will not execute the commands. A build report and build result is generated.
 
-
-Links to additional documentation is provided in the table below.  Instructions on invoking a zAppBuild is included in [docs/BUILD.md](docs/BUILD.md) as well as invocation samples for the above mentioned build scenarios including sample console logs.
+Instructions on invoking a zAppBuild is included in [docs/BUILD.md](docs/BUILD.md) as well as invocation samples for the above mentioned build scenarios including sample console logs.
 
 Application-level build properties such as compile and link options can be defined in various ways to set global defaults, application-level overrides or even file level (member-level) overrides. The various supported strategies are documented in [docs/FilePropertyManagement.md](docs/FilePropertyManagement.md).
 
 zAppBuild comes with a set of reporting features. It helps development teams to understand the impact of changed files across multiple applications. Another feature helps to identify conflicts due to concurrent development activities within their application. An overview of these features are documented in [docs/REPORTS.md](docs/REPORTS.md).
+
+Links to additional documentation is provided in the table below.  
 
 ## Repository Legend
 Folder/File | Description | Documentation Link

--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ zAppBuild supports a number of build scenarios:
 * **Merge Build** - Build only changed programs which will be merged back into the mainBuildBranch by using a triple-dot git diff. 
 * **Scan Source** - Skip the actual building and only scan source files to store dependency data in collection (migration scenario).
 * **Scan Source + Outputs** - Skip the actual building and only scan source files and existing load modules to dependency data in source and output collection (migration scenario with static linkage scenarios).
+* **Build Preview** - Supplemental build option. Process all phases of the supplied build option, but will not execute the commands and not create a build result.
 
 
-Links to additional documentation is provided in the table below.  Instructions on invoking a zAppBuild is included in [BUILD.md](BUILD.md) as well as invocation samples for the above mentioned build scenarios including sample console log.
+Links to additional documentation is provided in the table below.  Instructions on invoking a zAppBuild is included in [docs/BUILD.md](docs/BUILD.md) as well as invocation samples for the above mentioned build scenarios including sample console logs.
 
-zAppBuild comes with a set of reporting features. It helps development teams to understand the impact of changed files across multiple applications. Another feature helps to identify conflicts due to concurrent development activities within their application. An overview of these features are documented in [REPORT.md](REPORT.md).
+Application-level build properties such as compile and link options can be defined in various ways to set global defaults, application-level overrides or even file level (member-level) overrides. The various supported strategies are documented in [docs/FilePropertyManagement.md](docs/FilePropertyManagement.md).
+
+zAppBuild comes with a set of reporting features. It helps development teams to understand the impact of changed files across multiple applications. Another feature helps to identify conflicts due to concurrent development activities within their application. An overview of these features are documented in [docs/REPORTS.md](docs/REPORTS.md).
 
 ## Repository Legend
 Folder/File | Description | Documentation Link

--- a/build.groovy
+++ b/build.groovy
@@ -506,9 +506,13 @@ def createBuildList() {
 	Set<String> changedBuildProperties = new HashSet<String>() // not yet used for any post-processing
 	String action = (props.scanOnly) || (props.scanLoadmodules) ? 'Scanning' : 'Building'
 
+	// check if preview sub-option
+	if (props.preview) { println "** --preview cli option provided. Processing all phases of the supplied build option, but will not execute the commands." }
+			
 	// check if full build
 	if (props.fullBuild) {
 		println "** --fullBuild option selected. $action all programs for application ${props.application}"
+
 		buildSet = buildUtils.createFullBuildList()
 	}
 	// check if impact build
@@ -529,11 +533,7 @@ def createBuildList() {
 			println "*! Merge build requires a Filesystem or Db2 MetadataStore"
 		}
 	}
-	
-	if (props.preview) {
-		println "** --preview sub-option provided. Process all phases of the supplied build option, but will not execute the commands and not create a build result."
-	}
-	
+		
 	// if build file present add additional files to build list (mandatory build list)
 	if (props.buildFile) {
 
@@ -690,12 +690,7 @@ def finalizeBuildProcess(Map args) {
 
 		// add files processed and set state
 		buildResult.setProperty("filesProcessed", String.valueOf(args.count))
-		if (props.preview) {
-			buildResult.setState(4) // setting state to a none predefined state
-		} else { 
-			buildResult.setState(buildResult.COMPLETE)
-		}
-
+		buildResult.setState(buildResult.COMPLETE)
 
 
 		// store build result properties in BuildReport.json
@@ -741,7 +736,7 @@ def finalizeBuildProcess(Map args) {
 	def state = (props.error) ? "ERROR" : "CLEAN"
 	println("** Build ended at $endTime")
 	println("** Build State : $state")
-	if (props.preview) println("** Executed in Preview / ReportOnly mode.")
+	if (props.preview) println("** Build ran in preview mode.")
 	println("** Total files processed : ${args.count}")
 	println("** Total build time  : $duration\n")
 }

--- a/build.groovy
+++ b/build.groovy
@@ -204,8 +204,9 @@ def initializeBuildProcess(String[] args) {
 		if (props.fullBuild) buildResult.setProperty('fullBuild', 'true')
 		if (props.impactBuild) buildResult.setProperty('impactBuild', 'true')
 		if (props.topicBranchBuild) buildResult.setProperty('topicBranchBuild', 'true')
-		if (props.buildFile) buildResult.setProperty('buildFile', XmlUtil.escapeXml(props.buildFile))
 		if (props.preview) buildResult.setProperty('preview', 'true')
+		
+		if (props.buildFile) buildResult.setProperty('buildFile', XmlUtil.escapeXml(props.buildFile))
 				
 		println("** Build result created for BuildGroup:${props.applicationBuildGroup} BuildLabel:${props.applicationBuildLabel}")
 	}
@@ -241,7 +242,7 @@ options:
 	cli.m(longOpt:'mergeBuild', 'Flag indicating to build only changes which will be merged back to the mainBuildBranch.')	
 	cli.r(longOpt:'reset', 'Deletes the dependency collections and build result group from the MetadataStore')
 	cli.v(longOpt:'verbose', 'Flag to turn on script trace')
-	cli.pr(longOpt:'preview', 'Flag to run build in preview mode without processing any files.')
+	cli.pv(longOpt:'preview', 'Supplemental flag indicating to run build in preview mode without processing the execute commands')
 	
 	// scan options
 	cli.s(longOpt:'scanOnly', 'Flag indicating to only scan source files for application without building anything (deprecated use --scanSource)')

--- a/build.groovy
+++ b/build.groovy
@@ -405,7 +405,7 @@ def populateBuildProperties(def opts) {
 	if (opts.v) props.verbose = 'true'
 	if (opts.b) props.baselineRef = opts.b
 	if (opts.m) props.mergeBuild = 'true'
-	if (opts.pr) props.preview = 'true'
+	if (opts.pv) props.preview = 'true'
 		
 	// scan options
 	if (opts.s) props.scanOnly = 'true'
@@ -528,6 +528,10 @@ def createBuildList() {
 		else {
 			println "*! Merge build requires a Filesystem or Db2 MetadataStore"
 		}
+	}
+	
+	if (props.preview) {
+		println "** --preview sub-option provided. Process all phases of the supplied build option, but will not execute the commands and not create a build result."
 	}
 	
 	// if build file present add additional files to build list (mandatory build list)
@@ -686,7 +690,11 @@ def finalizeBuildProcess(Map args) {
 
 		// add files processed and set state
 		buildResult.setProperty("filesProcessed", String.valueOf(args.count))
-		buildResult.setState(buildResult.COMPLETE)
+		if (props.preview) {
+			buildResult.setState(4) // setting state to a none predefined state
+		} else { 
+			buildResult.setState(buildResult.COMPLETE)
+		}
 
 
 
@@ -733,6 +741,7 @@ def finalizeBuildProcess(Map args) {
 	def state = (props.error) ? "ERROR" : "CLEAN"
 	println("** Build ended at $endTime")
 	println("** Build State : $state")
+	if (props.preview) println("** Executed in Preview / ReportOnly mode.")
 	println("** Total files processed : ${args.count}")
 	println("** Total build time  : $duration\n")
 }

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -200,7 +200,9 @@ build options:
  -ss,--scanSource             Flag indicating to only scan source files for application without building anything
  -sl,--scanLoad               Flag indicating to only scan load modules for application without building anything
  -sa,--scanAll                Flag indicating to scan both source files and load modules for application without building anything
- 
+ -pv,--preview                Supplemental flag indicating to run build in preview mode without processing the execute commands
+
+
  -r,--reset                   Deletes the application's dependency collections 
                               and build result group from the DBB repository
  -v,--verbose                 Flag to turn on script trace

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1209,6 +1209,8 @@ Cobol compiler parms for MortgageApplication/cobol/epsmlist.cbl = LIB,CICS
 
 For instance, use the `--preview` flag with the `--impactBuild` option to obtain a preview of the impact build actions such as identified changed files, the calculated impacted files, the build list, the build flow, the applied build properties and option including the outputs which would be produced.
 
+Use the `--preview` flag with the `--fullBuild` option to produce the full bill of material (documented in a build report) for the artifacts that could be generated in the datasets pointed by the `hlq` parameter.
+
 The build will generate a build report, which, depending of the provided build option, will be stored in the build group. However, the build result status is set to `4` and does not impact the calculation of changed file of subsequent impact builds.  
 
 The below sample build log is documenting an `--impactBuild --preview` with the reporting capablities activated to what the build would do and any potential conflicts of concurrent development activities.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -252,6 +252,7 @@ utility options
 - [Perform Impact Build for topic branches](#perform-impact-build-for-topic-branches)
 - [Perform Impact Build by providing baseline reference for the analysis of changed files](#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files)
 - [Perform a Merge build](#perform-a-merge-build)
+- [Perform a Build in preview mode](#perform-a-build-in-preview-mode)
 - [Perform a Scan Source build](#perform-a-scan-source-build)
 - [Perform a Scan Source + Outputs build](#perform-a-scan-source--outputs-build)
 - [Dynamically Overwrite build properties](#dynamically-overwrite-build-properties)
@@ -1202,6 +1203,353 @@ Cobol compiler parms for MortgageApplication/cobol/epsmlist.cbl = LIB,CICS
 
 </details>
 
+### Perform a Build in Preview Mode
+
+`--preview` is a supplemental option to the various build types of zAppBuild. This supplemental option will let the build process run through all the build phases of the specified build option, but instead of executing the build commands such as copying the source files to the datasets or invoking the compile and link commands, it just documents what would be done and sets the return codes of these commands to 0. Please note, that file are scanned and, depending on the primary build option, dependency information is stored in the DBB Metadatastore.
+
+For instance, use the `--preview` flag with the `--impactBuild` option to obtain a preview of the impact build actions such as identified changed files, the calculated impacted files, the build list, the build flow, the applied build properties and option including the outputs which would be produced.
+
+The build will generate a build report, which, depending of the provided build option, will be stored in the build group. However, the build result status is set to `4` and does not impact the calculation of changed file of subsequent impact builds.  
+
+The below sample build log is documenting an `--impactBuild --preview` with the reporting capablities activated to what the build would do and any potential conflicts of concurrent development activities.
+
+```
+groovyz dbb-zappbuild/build.groovy --workspace /var/dbb/dbb-zappbuild/samples --hlq DBB.ZAPP.CLEAN.MASTER --workDir /var/dbb/out/MortgageApplication --application MortgageApplication --logEncoding UTF-8 --mergeBuild --verbose
+```
+<details>
+  <summary>Build log</summary>
+
+```
++ /usr/lpp/dbb/v2r0/bin/groovyz /var/dbb/dbb-zappbuild/build.groovy --sourceDir /var/dbb/dbb-zappbuild/samples --workDir /var/dbb/work/mortgageout --url jdbc:db2://10.3.20.201:4740/MOPDBC0 --id DB2ID --pwFile /var/dbb/config/db2-pwd-file.xml --hlq DBEHM.DBB.BUILD --application MortgageApplication --verbose --impactBuild --preview --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties
+
+** Build start at 20230425.040722.007
+** Input args = /var/dbb/dbb-zappbuild/samples --workDir /var/dbb/work/mortgageout --url jdbc:db2://10.3.20.201:4740/MOPDBC0 --id DB2ID --pwFile /var/dbb/config/db2-pwd-file.xml --hlq DBEHM.DBB.BUILD --application MortgageApplication --verbose --impactBuild --preview --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/dbehm.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/datasets.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/dependencyReport.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Assembler.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/MFS.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PSBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/DBDgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ACBgen.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/LinkEdit.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/PLI.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/REXX.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/ZunitConfig.properties
+** Loading property file /var/dbb/dbb-zappbuild/build-conf/Transfer.properties
+** appConf = /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/file.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/BMS.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/Cobol.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/LinkEdit.properties
+** Loading property file /var/dbb/dbb-zappbuild/samples/MortgageApplication/application-conf/languageConfigurationMapping.properties
+java.version=8.0.7.20 - pmz6480sr7fp20-20221020_01(SR7 FP20)
+java.home=/V2R4/usr/lpp/java/J8.0_64
+user.dir=/u/builduser
+** Build properties at start up:
+...
+preview=true
+...
+** zAppBuild running on DBB Toolkit Version 2.0.0 20-Mar-2023 10:36:28 
+required props = buildOrder,buildListFileExt
+** Running in reportOnly mode. Will process build options but not execute any steps.
+** Db2 MetadataStore initialized
+** Build output located at /var/dbb/work/mortgageout/build.20230425.160722.007
+** Build result created for BuildGroup:MortgageApplication-350_preview_builds BuildLabel:build.20230425.160722.007
+** --preview cli option provided. Processing all phases of the supplied build option, but will not execute the commands.
+** --impactBuild option selected. Building impacted programs for application MortgageApplication 
+** Getting current hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+** Storing MortgageApplication : 2b3add1e85a8124ff1d7af6ab1de2e5463325d7a
+** Getting baseline hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+** Storing MortgageApplication : cf6bc732bd717b404c5cf71a8f8d14458138a2d0
+** Calculating changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+** Diffing baseline cf6bc732bd717b404c5cf71a8f8d14458138a2d0 -> current 2b3add1e85a8124ff1d7af6ab1de2e5463325d7a
+*** Changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication :
+**** MortgageApplication/jcl/MYSAMP.jcl
+**** MortgageApplication/copybook/epsmtcom.cpy
+*** Deleted files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication :
+*** Renamed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication :
+** Updating collections MortgageApplication-350_preview_builds and MortgageApplication-350_preview_builds-outputs
+*** Sorted list of changed files: [MortgageApplication/jcl/MYSAMP.jcl, MortgageApplication/copybook/epsmtcom.cpy]
+*** Scanning file MortgageApplication/jcl/MYSAMP.jcl (/var/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/MYSAMP.jcl)
+*** Scanning file with the default scanner
+*** Logical file for MortgageApplication/copybook/MYSAMP.jcl =
+{
+   "cics": false,
+   "dli": false,
+   "file": "MortgageApplication\/jcl\/MYSAMP.jcl",
+   "language": "JCL",
+   "lname": "MYSAMP",
+   "logicalDependencies": [
+      {
+         "category": "COPY",
+         "library": "SYSLIB",
+         "lname": "EPSMTINP"
+      },
+      {
+         "category": "COPY",
+         "library": "SYSLIB",
+         "lname": "EPSMTOUT"
+      }
+   ],
+   "mq": false,
+   "sql": false
+}
+*** Scanning file MortgageApplication/copybook/epsmtcom.cpy (/var/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsmtcom.cpy)
+*** Scanning file with the default scanner
+*** Logical file for MortgageApplication/copybook/epsmtcom.cpy =
+{
+   "cics": false,
+   "dli": false,
+   "file": "MortgageApplication\/copybook\/epsmtcom.cpy",
+   "language": "COB",
+   "lname": "EPSMTCOM",
+   "logicalDependencies": [
+      {
+         "category": "COPY",
+         "library": "SYSLIB",
+         "lname": "EPSMTINP"
+      },
+      {
+         "category": "COPY",
+         "library": "SYSLIB",
+         "lname": "EPSMTOUT"
+      }
+   ],
+   "mq": false,
+   "sql": false
+}
+** Storing 2 logical files in MetadataStore collection 'MortgageApplication-350_preview_builds'
+*** Perform impacted analysis for changed files.
+** Found build script mapping for MortgageApplication/jcl/MYSAMP.jcl. Adding to build list
+** Performing impact analysis on changed file MortgageApplication/jcl/MYSAMP.jcl
+*** Creating SearchPathImpactFinder with collections [MortgageApplication-350_preview_builds, MortgageApplication-350_preview_builds-outputs] and impactSearch configuration search:/var/dbb/dbb-zappbuild/samples/?path=MortgageApplication/copybook/*.cpysearch:/var/dbb/dbb-zappbuild/samples/?path=MortgageApplication/bms/*.bmssearch:[:LINK]/var/dbb/dbb-zappbuild/samples/?path=MortgageApplication/cobol/*.cbl
+** Performing impact analysis on changed file MortgageApplication/copybook/epsmtcom.cpy
+*** Creating SearchPathImpactFinder with collections [MortgageApplication-350_preview_builds, MortgageApplication-350_preview_builds-outputs] and impactSearch configuration search:/var/dbb/dbb-zappbuild/samples/?path=MortgageApplication/copybook/*.cpysearch:/var/dbb/dbb-zappbuild/samples/?path=MortgageApplication/bms/*.bmssearch:[:LINK]/var/dbb/dbb-zappbuild/samples/?path=MortgageApplication/cobol/*.cbl
+** Found impacted file MortgageApplication/cobol/epscmort.cbl
+** MortgageApplication/cobol/epscmort.cbl is impacted by changed file MortgageApplication/copybook/epsmtcom.cpy. Adding to build list.
+** Found impacted file MortgageApplication/cobol/epscsmrt.cbl
+** MortgageApplication/cobol/epscsmrt.cbl is impacted by changed file MortgageApplication/copybook/epsmtcom.cpy. Adding to build list.
+** Found impacted file MortgageApplication/cobol/epsmlist.cbl
+** MortgageApplication/cobol/epsmlist.cbl is impacted by changed file MortgageApplication/copybook/epsmtcom.cpy. Adding to build list.
+** Found impacted file MortgageApplication/cobol/epscsmrt.cbl
+** MortgageApplication/cobol/epscsmrt.cbl is impacted by changed file MortgageApplication/copybook/epsmtcom.cpy. Adding to build list.
+** Found impacted file MortgageApplication/cobol/epscmort.cbl
+** MortgageApplication/cobol/epscmort.cbl is impacted by changed file MortgageApplication/copybook/epsmtcom.cpy. Adding to build list.
+** Found impacted file MortgageApplication/link/epsmlist.lnk
+** MortgageApplication/link/epsmlist.lnk is impacted by changed file MortgageApplication/copybook/epsmtcom.cpy. Adding to build list.
+** Calculation of impacted files by changed properties has been skipped due to configuration. 
+** Writing build list file to /var/dbb/work/mortgageout/build.20230425.160722.007/buildList.txt
+MortgageApplication/cobol/epsmlist.cbl
+MortgageApplication/cobol/epscsmrt.cbl
+MortgageApplication/cobol/epscmort.cbl
+MortgageApplication/link/epsmlist.lnk
+MortgageApplication/jcl/MYSAMP.jcl
+** Populating file level properties from individual artifact properties files.
+* Populating file level properties overrides.
+** Checking file property overrides for MortgageApplication/cobol/epsmlist.cbl 
+*** MortgageApplication/cobol/epsmlist.cbl has an individual artifact properties file defined in properties/epsmlist.cbl.properties
+    Found file property cobol_compileParms = ${cobol_compileParms},SOURCE
+*** Checking for existing file property overrides
+    Checking build property cobol_compileParms
+    Adding file property override cobol_compileParms = ${cobol_compileParms},SOURCE for MortgageApplication/cobol/epsmlist.cbl
+** Checking file property overrides for MortgageApplication/cobol/epscsmrt.cbl 
+*** Checking for existing file property overrides
+** Checking file property overrides for MortgageApplication/cobol/epscmort.cbl 
+*** Checking for existing file property overrides
+** Checking file property overrides for MortgageApplication/link/epsmlist.lnk 
+*** Checking for existing file property overrides
+** Checking file property overrides for MortgageApplication/jcl/MYSAMP.jcl 
+*** Checking for existing file property overrides
+** Perform analysis and reporting of external impacted files for the build list including changed files.
+*** Running external impact analysis with file filter **/* and collection patterns .*-main.* with analysis mode deep
+*** Running external impact analysis for files 
+     MortgageApplication/cobol/epscmort.cbl 
+     MortgageApplication/cobol/epsmlist.cbl 
+     MortgageApplication/link/epsmlist.lnk 
+     MortgageApplication/jcl/MYSAMP.jcl 
+     MortgageApplication/cobol/epscsmrt.cbl 
+     MortgageApplication/copybook/epsmtcom.cpy 
+*** Writing report of external impacts to file /var/dbb/work/mortgageout/build.20230425.160722.007/externalImpacts_MortgageApplication-main-outputs.log
+*** Potential external impact found EPSCSMRT (MortgageApplication/cobol/epscsmrt.cbl) in collection MortgageApplication-main-outputs 
+*** Potential external impact found EPSCMORT (MortgageApplication/cobol/epscmort.cbl) in collection MortgageApplication-main-outputs 
+*** Potential external impact found EPSMLIST (MortgageApplication/link/epsmlist.lnk) in collection MortgageApplication-main-outputs 
+*** Writing report of external impacts to file /var/dbb/work/mortgageout/build.20230425.160722.007/externalImpacts_MortgageApplication-main-patch.log
+*** Potential external impact found EPSCSMRT (MortgageApplication/cobol/epscsmrt.cbl) in collection MortgageApplication-main-patch 
+*** Potential external impact found EPSMLIST (MortgageApplication/cobol/epsmlist.cbl) in collection MortgageApplication-main-patch 
+*** Potential external impact found EPSCMORT (MortgageApplication/cobol/epscmort.cbl) in collection MortgageApplication-main-patch 
+*** Writing report of external impacts to file /var/dbb/work/mortgageout/build.20230425.160722.007/externalImpacts_MortgageApplication-main.log
+*** Potential external impact found EPSCSMRT (MortgageApplication/cobol/epscsmrt.cbl) in collection MortgageApplication-main 
+*** Potential external impact found EPSMLIST (MortgageApplication/cobol/epsmlist.cbl) in collection MortgageApplication-main 
+*** Potential external impact found EPSCMORT (MortgageApplication/cobol/epscmort.cbl) in collection MortgageApplication-main 
+*** Writing report of external impacts to file /var/dbb/work/mortgageout/build.20230425.160722.007/externalImpacts_MortgageApplication-main-patch-outputs.log
+*** Potential external impact found EPSMLIST (MortgageApplication/link/epsmlist.lnk) in collection MortgageApplication-main-patch-outputs 
+**** Running external impact analysis for identified external impacted files as dependent files of the initial set. 
+     MortgageApplication/cobol/epscsmrt.cbl 
+     MortgageApplication/cobol/epscmort.cbl 
+     MortgageApplication/link/epsmlist.lnk 
+     MortgageApplication/cobol/epscsmrt.cbl 
+     MortgageApplication/cobol/epsmlist.cbl 
+     MortgageApplication/cobol/epscmort.cbl 
+     MortgageApplication/cobol/epscsmrt.cbl 
+     MortgageApplication/cobol/epsmlist.cbl 
+     MortgageApplication/cobol/epscmort.cbl 
+     MortgageApplication/link/epsmlist.lnk 
+** Calculate and document concurrent changes.
+***  Analysing and validating changes for branch : main
+** Getting current hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+** Storing MortgageApplication : 2b3add1e85a8124ff1d7af6ab1de2e5463325d7a
+** Calculating changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+*** Changed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication in configuration main:
+**** MortgageApplication/cobol/epscmort.cbl
+*** Deleted files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication in configuration main:
+*** Renamed files for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication in configuration main:
+** Writing report of concurrent changes to /var/dbb/work/mortgageout/build.20230425.160722.007/report_concurrentChanges.txt for configuration main
+ Changed: MortgageApplication/cobol/epscmort.cbl
+*!! MortgageApplication/cobol/epscmort.cbl is changed on branch main and intersects with the current build list.
+** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy,Transfer.groovy
+** Building files mapped to Cobol.groovy script
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED,   cobol_dependencySearch
+** Creating / verifying build dataset DBEHM.DBB.BUILD.COBOL
+** Creating / verifying build dataset DBEHM.DBB.BUILD.COPY
+** Creating / verifying build dataset DBEHM.DBB.BUILD.OBJ
+** Creating / verifying build dataset DBEHM.DBB.BUILD.DBRM
+** Creating / verifying build dataset DBEHM.DBB.BUILD.LOAD
+*** Building file MortgageApplication/cobol/epsmlist.cbl
+*** Resolution rules for MortgageApplication/cobol/epsmlist.cbl:
+search:/var/dbb/dbb-zappbuild/samples/?path=MortgageApplication/copybook/*.cpy
+*** Physical dependencies for MortgageApplication/cobol/epsmlist.cbl:
+{"excluded":false,"lname":"DFHAID","library":"SYSLIB","category":"COPY","resolved":false}
+{"excluded":false,"lname":"EPSMLIS","library":"SYSLIB","category":"COPY","resolved":false}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMORTF","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmortf.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSNBRPM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","category":"COPY","resolved":true}
+Program attributes: CICS=true, SQL=false, DLI=false, MQ=false
+Cobol compiler parms for MortgageApplication/cobol/epsmlist.cbl = LIB,SOURCE,CICS
+Link-Edit parms for MortgageApplication/cobol/epsmlist.cbl = MAP,RENT,COMPAT(PM5),SSI=2b3add1e
+*** Building file MortgageApplication/cobol/epscsmrt.cbl
+*** Resolution rules for MortgageApplication/cobol/epscsmrt.cbl:
+search:/var/dbb/dbb-zappbuild/samples/?path=MortgageApplication/copybook/*.cpy
+*** Physical dependencies for MortgageApplication/cobol/epscsmrt.cbl:
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSPDATA","library":"SYSLIB","file":"MortgageApplication\/copybook\/epspdata.cpy","category":"COPY","resolved":true}
+Program attributes: CICS=true*, SQL=false, DLI=false, MQ=false
+Cobol compiler parms for MortgageApplication/cobol/epscsmrt.cbl = LIB,CICS
+Link-Edit parms for MortgageApplication/cobol/epscsmrt.cbl = MAP,RENT,COMPAT(PM5),SSI=2b3add1e
+*** Scanning load module for MortgageApplication/cobol/epscsmrt.cbl
+*** Logical file = 
+{
+   "cics": false,
+   "dli": false,
+   "file": "MortgageApplication\/cobol\/epscsmrt.cbl",
+   "language": "ZBND",
+   "lname": "EPSCSMRT",
+   "logicalDependencies": [
+      {
+         "category": "LINK",
+         "library": "DBEHM.DBB.BUILD.OBJ",
+         "lname": "EPSCSMRT"
+      }
+   ],
+   "mq": false,
+   "sql": false
+}
+*** Building file MortgageApplication/cobol/epscmort.cbl
+*** Resolution rules for MortgageApplication/cobol/epscmort.cbl:
+search:/var/dbb/dbb-zappbuild/samples/?path=MortgageApplication/copybook/*.cpy
+*** Physical dependencies for MortgageApplication/cobol/epscmort.cbl:
+{"excluded":false,"lname":"DFHAID","library":"SYSLIB","category":"COPY","resolved":false}
+{"excluded":false,"lname":"EPSMORT","library":"SYSLIB","category":"COPY","resolved":false}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMTCOM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtcom.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMTINP","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtinp.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSMTOUT","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsmtout.cpy","category":"COPY","resolved":true}
+{"excluded":false,"sourceDir":"\/u\/dbehm\/test-zapp\/dbb-zappbuild\/samples\/","lname":"EPSNBRPM","library":"SYSLIB","file":"MortgageApplication\/copybook\/epsnbrpm.cpy","category":"COPY","resolved":true}
+{"excluded":false,"lname":"SQLCA","library":"SYSLIB","category":"SQL INCLUDE","resolved":false}
+Program attributes: CICS=true, SQL=true, DLI=false, MQ=false
+Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
+Link-Edit parms for MortgageApplication/cobol/epscmort.cbl = MAP,RENT,COMPAT(PM5),SSI=2b3add1e
+*** Scanning load module for MortgageApplication/cobol/epscmort.cbl
+*** Logical file = 
+{
+   "cics": false,
+   "dli": false,
+   "file": "MortgageApplication\/cobol\/epscmort.cbl",
+   "language": "ZBND",
+   "lname": "EPSCMORT",
+   "logicalDependencies": [
+      {
+         "category": "LINK",
+         "library": "DBEHM.DBB.BUILD.OBJ",
+         "lname": "EPSCMORT"
+      },
+      {
+         "category": "LINK",
+         "library": "DBEHM.DBB.BUILD.OBJ",
+         "lname": "EPSNBRVL"
+      }
+   ],
+   "mq": false,
+   "sql": false
+}
+** Building files mapped to LinkEdit.groovy script
+required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,applicationOutputsCollectionName,  SDFHLOAD,SCEELKED
+** Creating / verifying build dataset DBEHM.DBB.BUILD.LINK
+** Creating / verifying build dataset DBEHM.DBB.BUILD.OBJ
+** Creating / verifying build dataset DBEHM.DBB.BUILD.LOAD
+*** Building file MortgageApplication/link/epsmlist.lnk
+Link-Edit parms for MortgageApplication/link/epsmlist.lnk = MAP,RENT,COMPAT(PM5),SSI=2b3add1e
+*** Scanning load module for MortgageApplication/link/epsmlist.lnk
+*** Logical file = 
+{
+   "cics": false,
+   "dli": false,
+   "file": "MortgageApplication\/link\/epsmlist.lnk",
+   "language": "ZBND",
+   "lname": "EPSMLIST",
+   "logicalDependencies": [
+      {
+         "category": "LINK",
+         "library": "DBEHM.DBB.BUILD.LOAD",
+         "lname": "EPSMPMT"
+      },
+      {
+         "category": "LINK",
+         "library": "DBEHM.DBB.BUILD.OBJ",
+         "lname": "EPSMLIST"
+      }
+   ],
+   "mq": false,
+   "sql": false
+}
+** Building files mapped to Transfer.groovy script
+required props = transfer_srcPDS,transfer_dsOptions,  transfer_deployType
+*** Transferring file MortgageApplication/jcl/MYSAMP.jcl
+** Creating / verifying build dataset DBEHM.DBB.BUILD.JCL
+** Copied MortgageApplication/jcl/MYSAMP.jcl to DBEHM.DBB.BUILD.JCL with deployType JCL (rc = 0)
+*** Obtaining hash for directory /var/dbb/dbb-zappbuild/samples/MortgageApplication
+** Setting property :githash:MortgageApplication : 2b3add1e85a8124ff1d7af6ab1de2e5463325d7a
+** Setting property :giturl:MortgageApplication : https://github.com/dennis-behm/dbb-zappbuild.git
+** Setting property :gitchangedfiles:MortgageApplication : https://github.com/ibm/dbb-zappbuild/compare/cf6bc732bd717b404c5cf71a8f8d14458138a2d0..2b3add1e85a8124ff1d7af6ab1de2e5463325d7a
+** Writing build report data to /var/dbb/work/mortgageout/build.20230425.160722.007/BuildReport.json
+** Writing build report to /var/dbb/work/mortgageout/build.20230425.160722.007/BuildReport.html
+** Updating build result BuildGroup:MortgageApplication-350_preview_builds BuildLabel:build.20230425.160722.007
+** Build ended at Tue Apr 25 16:07:34 GMT+01:00 2023
+** Build State : CLEAN
+** Build ran in preview mode.
+** Total files processed : 5
+** Total build time  : 12.204 seconds
+
+** Build finished
+```
+
+
+</details>
+
 ### Perform a Scan Source build
 
 `--fullBuild --scanSource` skips the actual building and only scan source files to store dependency data in the collection (migration scenario). Please be aware that it scans all programs including the copybooks, which is required to perform proper impact analysis.
@@ -1659,3 +2007,5 @@ required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkE
 ```
 
 </details>
+
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,5 @@ This folder contains supplemental documentation to help explain the implementati
 
 |File|Description|
 |-|-|
-|FilePropertyManagement|Documentation on managing default and overriding build properties for specific application files|
+|[Build Management](BUILD.md)|Documentation on managing default and overriding build properties for specific application files|
+|[Build Property Management](FilePropertyManagement.md)|Documentation on managing default and overriding build properties for specific application files|

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -14,6 +14,7 @@ impactBuild.groovy,\
 impactBuild_properties.groovy,\
 impactBuild_renaming.groovy,\
 impactBuild_deletion.groovy,\
+impactBuild_preview.groovy,\
 resetBuild.groovy
 
 ###############################
@@ -98,6 +99,20 @@ impactBuild_deletion_deleteFiles = cobol/epscmort.cbl
 impactBuild_deletion_deletedOutputs = LOAD(EPSCMORT) :: cobol/epscmort.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_deletion_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
+
+###############################
+# impactBuild_preview.groovy properties
+###############################
+#
+# list of changed source files to test impact builds
+impactBuild_preview_changedFiles = copybook/epsmtout.cpy
+#
+# list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
+impactBuild_preview_datasetsToCleanUp = BMS,COBOL,LINK
+#
+# Use file properties to associate expected files built to changed files
+impactBuild_preview_expectedFilesBuilt = epsmlist.cbl,epscsmrt.cbl,epscmort.cbl,epsmlist.lnk :: copybook/epsmtout.cpy
+
 
 #############################
 # fullBuild_languageConfigurations.groovy properties

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -11,10 +11,10 @@ mergeBuild.groovy,\
 fullBuild.groovy,\
 fullBuild_languageConfigurations.groovy,\
 impactBuild.groovy,\
+impactBuild_preview.groovy,\
 impactBuild_properties.groovy,\
 impactBuild_renaming.groovy,\
 impactBuild_deletion.groovy,\
-impactBuild_preview.groovy,\
 resetBuild.groovy
 
 ###############################

--- a/test/testScripts/impactBuild_preview.groovy
+++ b/test/testScripts/impactBuild_preview.groovy
@@ -1,0 +1,173 @@
+
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+import com.ibm.dbb.*
+import com.ibm.dbb.build.*
+import com.ibm.jzos.ZFile
+
+@Field BuildProperties props = BuildProperties.getInstance()
+println "\n** Executing test script impactBuild.groovy"
+
+// Get the DBB_HOME location
+def dbbHome = EnvVars.getHome()
+if (props.verbose) println "** DBB_HOME = ${dbbHome}"
+
+// Create full build command to set baseline
+def fullBuildCommand = []
+fullBuildCommand << "${dbbHome}/bin/groovyz"
+fullBuildCommand << "${props.zAppBuildDir}/build.groovy"
+fullBuildCommand << "--workspace ${props.workspace}"
+fullBuildCommand << "--application ${props.app}"
+fullBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+fullBuildCommand << "--hlq ${props.hlq}"
+fullBuildCommand << "--logEncoding UTF-8"
+fullBuildCommand << "--url ${props.url}"
+fullBuildCommand << "--id ${props.id}"
+fullBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+fullBuildCommand << (props.verbose ? "--verbose" : "")
+fullBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles}" : "")
+fullBuildCommand << "--fullBuild"
+
+// create impact build command for preview
+def impactBuildPreviewCommand = []
+impactBuildPreviewCommand << "${dbbHome}/bin/groovyz"
+impactBuildPreviewCommand << "${props.zAppBuildDir}/build.groovy"
+impactBuildPreviewCommand << "--workspace ${props.workspace}"
+impactBuildPreviewCommand << "--application ${props.app}"
+impactBuildPreviewCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+impactBuildPreviewCommand << "--hlq ${props.hlq}"
+impactBuildPreviewCommand << "--logEncoding UTF-8"
+impactBuildPreviewCommand << "--url ${props.url}"
+impactBuildPreviewCommand << "--id ${props.id}"
+impactBuildPreviewCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+impactBuildPreviewCommand << (props.verbose ? "--verbose" : "")
+impactBuildPreviewCommand << (props.propFiles ? "--propFiles ${props.propFiles}" : "")
+impactBuildPreviewCommand << "--impactBuild --preview" // this will run zAppBuild only in preview mode.
+
+// create impact build command
+def impactBuildCommand = []
+impactBuildCommand << "${dbbHome}/bin/groovyz"
+impactBuildCommand << "${props.zAppBuildDir}/build.groovy"
+impactBuildCommand << "--workspace ${props.workspace}"
+impactBuildCommand << "--application ${props.app}"
+impactBuildCommand << (props.outDir ? "--outDir ${props.outDir}" : "--outDir ${props.zAppBuildDir}/out")
+impactBuildCommand << "--hlq ${props.hlq}"
+impactBuildCommand << "--logEncoding UTF-8"
+impactBuildCommand << "--url ${props.url}"
+impactBuildCommand << "--id ${props.id}"
+impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "--pwFile ${props.pwFile}")
+impactBuildCommand << (props.verbose ? "--verbose" : "")
+impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles}" : "")
+impactBuildCommand << "--impactBuild"
+
+// iterate through change files to test impact build
+@Field def assertionList = []
+PropertyMappings filesBuiltMappings = new PropertyMappings('impactBuild_preview_expectedFilesBuilt')
+def changedFiles = props.impactBuild_changedFiles.split(',')
+println("** Processing changed files from impactBuild_changedFiles property : ${props.impactBuild_preview_changedFiles}")
+try {
+	
+	println "\n** Running full build to set baseline"
+	
+	// run impact build
+	println "** Executing ${fullBuildCommand.join(" ")}"
+	def outputStream = new StringBuffer()
+	def process = [
+		'bash',
+		'-c',
+		fullBuildCommand.join(" ")
+	].execute()
+	process.waitForProcessOutput(outputStream, System.err)
+	
+	changedFiles.each { changedFile ->
+		println "\n** Running IMPACT BUILD WITH PREVIEW TEST for changed file $changedFile"
+		
+		// update changed file in Git repo test branch
+		copyAndCommit(changedFile)
+		
+		// run impact build with preview
+		println "** Executing ${impactBuildPreviewCommand.join(" ")}"
+		outputStream = new StringBuffer()
+		process = ['bash', '-c', impactBuildPreviewCommand.join(" ")].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+		
+		validateImpactBuild(changedFile, filesBuiltMappings, outputStream)
+		
+		// run impact build
+		println "** Executing ${impactBuildCommand.join(" ")}"
+		outputStream = new StringBuffer()
+		process = ['bash', '-c', impactBuildCommand.join(" ")].execute()
+		process.waitForProcessOutput(outputStream, System.err)
+		
+		// validate build results
+		// still expecting the same files being impacted
+		validateImpactBuild(changedFile, filesBuiltMappings, outputStream)
+	}
+}
+finally {
+	cleanUpDatasets()
+	if (assertionList.size()>0) {
+        println "\n***"
+	println "**START OF FAILED IMPACT BUILD WITH PREVIEW TEST RESULTS**\n"
+	println "*FAILED IMPACT BUILD WITH PREVIEW TEST RESULTS*\n" + assertionList
+	println "\n**END OF FAILED IMPACT BUILD WITH PREVIEW TEST RESULTS**"
+	println "***"
+  }
+}
+// script end  
+
+//*************************************************************
+// Method Definitions
+//*************************************************************
+
+def copyAndCommit(String changedFile) {
+	println "** Copying and committing ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} to ${props.appLocation}/${changedFile}"
+	def commands = """
+    cp ${props.zAppBuildDir}/test/applications/${props.app}/${changedFile} ${props.appLocation}/${changedFile}
+    cd ${props.appLocation}/
+    git add .
+    git commit . -m "edited program file"
+"""
+	def task = ['bash', '-c', commands].execute()
+	def outputStream = new StringBuffer();
+	task.waitForProcessOutput(outputStream, System.err)
+}
+
+def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
+
+	println "** Validating impact build results"
+	def expectedFilesBuiltList = filesBuiltMappings.getValue(changedFile).split(',')
+	
+    try{
+	// Validate clean build
+	assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $changedFile\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected number of files built
+	def numImpactFiles = expectedFilesBuiltList.size()
+	assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FOR $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
+
+	// Validate expected built files in output stream
+	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FOR $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+	
+	println "**"
+	println "** IMPACT BUILD WITH PREVIEW TEST : PASSED FOR $changedFile **"
+	println "**"
+    }
+    catch(AssertionError e) {
+        def result = e.getMessage()
+        assertionList << result;
+		props.testsSucceeded = 'false'
+ }
+}
+def cleanUpDatasets() {
+	def segments = props.impactBuild_datasetsToCleanUp.split(',')
+	
+	println "Deleting impact build PDSEs ${segments}"
+	segments.each { segment ->
+	    def pds = "'${props.hlq}.${segment}'"
+	    if (ZFile.dsExists(pds)) {
+	       if (props.verbose) println "** Deleting ${pds}"
+	       ZFile.remove("//$pds")
+	    }
+	}
+}


### PR DESCRIPTION
This PR is proposing a new supplemental build option `--preview`.

The purpose of the enhancement is to run any build scenario (full builds, incremental builds) along with the `--preview` option to understand what the build will do without actually building anything.

It runs through all the phases of the build. For instance in an `impactBuild` scenario, it identifies the changed files, calculates the impacts, produces a build list and passes it also to the build script. However, none of the Execute commands (compile, link-edit) are processed, nor are the files being uploaded to the target libraries. The implementation leverages the DBB configuration property  `dbb.command.reportOnly`, which is part of the DBB product.

The PR includes:
* implementation of the supplemental cli option `--preview` 
* documentation of the feature
* a test script for the new option