### PR TITLE
Adds CICS Resource builder build capability to zAppbuild

### DIFF
--- a/build-conf/CRB.properties
+++ b/build-conf/CRB.properties
@@ -1,0 +1,21 @@
+# Releng properties used by language/Cicsyml.groovy
+
+#The properties required to build using the CICS resource builder tool
+# Comma separated list of required build properties for Cicsyml.groovy
+crb_requiredBuildProperties=crb_zrbLocation,crb_resourceModelFile
+
+#
+# Cics Resource Builder path 
+crb_zrbLocation=/var/crb-1.0.3/cics-resource-builder/bin/zrb
+
+#
+# Cics Resource builder max acceptable exit/return code
+crb_maxRC=
+
+#
+# CRB model yaml file
+crb_resourceModelFile=""
+
+#
+# CRB aplication restriction yaml file
+crb_applicationConstraintsFile=""

--- a/languages/CRB.groovy
+++ b/languages/CRB.groovy
@@ -1,0 +1,88 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import com.ibm.dbb.metadata.*
+import com.ibm.dbb.dependency.*
+import com.ibm.dbb.build.*
+import com.ibm.dbb.build.report.records.*
+import com.ibm.dbb.build.report.*
+import groovy.transform.*
+
+/*
+The language script is for running the CICS tool (zrb) on CICS definitions in YML (yaml)
+format.
+The crb.properties file should provide 
+ - the zrb location on the host
+ - the path to the Model file 
+ - the application constraints file
+The script will get the resource CICS yml file names from the buildlist and proceed to execute 
+the zrb executable on them. This will create a CSD formatted file, which can be stored as an artifact 
+or can be run on Z/OS through DFHCSDUP or CicsDef.groovy script
+*/
+
+@Field BuildProperties props = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+
+// verify required build properties
+buildUtils.assertBuildProperties(props.crb_requiredBuildProperties)
+
+List<String> buildList = argMap.buildList
+
+println("** Processing files mapped to ${this.class.getName()}.groovy script")
+
+// iterate through build list
+buildList.each { buildFile ->
+	println("*** Building file $buildFile")
+
+    // Get the path to the zrb executable
+    String zrbPath = props.getFileProperty('crb_zrbLocation', buildFile)
+    // Set the model and appl constraint paths
+    String resourceModelFile = props.getFileProperty('crb_resourceModelFile', buildFile)
+    String applicationConstraintsFile = props.getFileProperty('crb_applicationConstraintsFile', buildFile)
+    // If maxRc is null or blank, set a default maxRC of 4
+    int maxRC = (props.getFileProperty('crb_maxRC', buildFile) ?: "4").toInteger()
+
+
+    File zrbExe = new File(zrbPath)
+    if (!zrbExe.exists()) {
+        String errorMsg = "*! The zrb utility was not found at $zrbPath."
+        println(errorMsg)
+        props.error = "true"
+        buildUtils.updateBuildResult(errorMsg:errorMsg)
+    }
+
+    // Generate the file name for the CSD formatted file
+    def extIndex = buildFile.lastIndexOf('.')
+    def slashIndex = buildFile.lastIndexOf('/')
+    if (slashIndex < 0) slashIndex = 0
+	def outputFile = buildFile.substring(slashIndex + 1, extIndex) + ".csd"
+
+    println("*** Output file is ${props.buildOutDir}/$outputFile.")
+    // Build the shell command to execute
+    def applicationParm = ""
+    if (applicationConstraintsFile) 
+        applicationParm = "--application $applicationConstraintsFile"
+    def zrb_cmd = zrbPath + " build --model $resourceModelFile $applicationParm --resources ${props.workspace}/${buildFile} --output ${props.buildOutDir}/$outputFile"
+
+    // Execute the command and save the console output in sout & serr
+    def process = zrb_cmd.execute()
+    process.waitForProcessOutput(System.out, System.err)
+    def returnCode = process.exitValue()
+    if (returnCode > maxRC) {
+			props.error = "true"
+            println("*! Error executing zrb: $returnCode")
+    } else {
+        if (props.verbose)
+            println("*** zrb return code: $returnCode")
+        // Create a new record of type AnyTypeRecord
+        AnyTypeRecord ussRecord = new AnyTypeRecord("USS_RECORD")
+        // Set attributes
+        ussRecord.setAttribute("file", buildFile)
+        ussRecord.setAttribute("label", "CICS Resource Builder YAML file")
+        ussRecord.setAttribute("outputFile", "${props.buildOutDir}/$outputFile")
+        ussRecord.setAttribute("deployType", "CSD")
+
+        // Add new record to build report
+        if (props.verbose) 
+            println("*** Adding USS_RECORD for $buildFile")
+        BuildReportFactory.getBuildReport().addRecord(ussRecord)
+    }
+}

--- a/languages/README.md
+++ b/languages/README.md
@@ -11,6 +11,7 @@ zAppBuild comes with a number of language specific build scripts.  These script 
 * PSBgen.groovy
 * MFS.groovy
 * ZunitConfig.groovy
+* CRB.groovy
 
 All language scripts both compile and optionally link-edit programs. The language build scripts are intended to be useful out of the box but depending on the complexity of your applications' build requirements, may require modifications to meet your development team's needs.  By following the examples used in the existing language build scripts of keeping all application specific references out of the build scripts and instead using configuration properties with strong default values, the zAppBuild sample can continue to be a generic build solution for all of your specific applications.
 

--- a/samples/MortgageApplication/application-conf/CRB.properties
+++ b/samples/MortgageApplication/application-conf/CRB.properties
@@ -1,0 +1,21 @@
+# Releng properties used by language/Cicsyml.groovy
+
+#The properties required to build using the CICS resource builder tool
+# Comma separated list of required build properties for Cicsyml.groovy
+crb_requiredBuildProperties=crb_zrbLocation,crb_resourceModelFile
+
+#
+# Cics Resource Builder path 
+crb_zrbLocation=/var/crb-1.0.3/cics-resource-builder/bin/zrb
+
+#
+# Cics Resource builder max acceptable exit/return code
+crb_maxRC=4
+
+#
+# CRB model yaml file
+crb_resourceModelFile=/var/crb-1.0.3/resourcesModel.yml
+
+#
+# CRB aplication restriction yaml file
+crb_applicationConstraintsFile=/var/crb-1.0.3/applicationConstraints.yml

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of additional application property files to load
 # Supports both relative path (to ${application}/application-conf/) and absolute path
-applicationPropFiles=file.properties,BMS.properties,Cobol.properties,LinkEdit.properties
+applicationPropFiles=file.properties,BMS.properties,Cobol.properties,LinkEdit.properties,CRB.properties
 
 #
 # Comma separated list all source directories included in application build. Supports both absolute 

--- a/samples/MortgageApplication/application-conf/file.properties
+++ b/samples/MortgageApplication/application-conf/file.properties
@@ -7,6 +7,7 @@ dbb.scriptMapping = BMS.groovy :: **/*.bms
 dbb.scriptMapping = Cobol.groovy :: **/*.cbl
 dbb.scriptMapping = LinkEdit.groovy :: **/*.lnk
 dbb.scriptMapping = PLI.groovy :: **/*.pli
+dbb.scriptMapping = CRB.groovy :: **/*.yml, **/*.yaml
 
 #
 # Need to build epsnbrvl.cbl first during cobol builds

--- a/samples/application-conf/CRB.properties
+++ b/samples/application-conf/CRB.properties
@@ -1,0 +1,21 @@
+# Releng properties used by language/Cicsyml.groovy
+
+#The properties required to build using the CICS resource builder tool
+# Comma separated list of required build properties for Cicsyml.groovy
+crb_requiredBuildProperties=crb_zrbLocation,crb_resourceModelFile
+
+#
+# Cics Resource Builder path 
+crb_zrbLocation=/var/crb-1.0.3/cics-resource-builder/bin/zrb
+
+#
+# Cics Resource builder max acceptable exit/return code
+crb_maxRC=
+
+#
+# CRB model yaml file
+crb_resourceModelFile=/var/crb-1.0.3/resourcesModel.yml
+
+#
+# CRB aplication restriction yaml file
+crb_applicationConstraintsFile=/var/crb-1.0.3/applicationConstraints.yml

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -8,7 +8,7 @@
 #
 # Comma separated list of additional application property files to load
 # Supports both relative path (to ${application}/application-conf/) and absolute path
-applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,REXX.properties,ZunitConfig.properties,Transfer.properties,reports.properties
+applicationPropFiles=file.properties,bind.properties,Assembler.properties,BMS.properties,Cobol.properties,LinkEdit.properties,bind.properties,PLI.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,REXX.properties,ZunitConfig.properties,Transfer.properties,reports.properties,CRB.properties
 
 #
 # Comma separated list all source directories included in application build. Supports both absolute

--- a/samples/application-conf/file.properties
+++ b/samples/application-conf/file.properties
@@ -12,6 +12,7 @@ dbb.scriptMapping = LinkEdit.groovy :: **/*.lnk
 dbb.scriptMapping = PLI.groovy :: **/*.pli
 dbb.scriptMapping = ZunitConfig.groovy :: **/*.bzucfg
 dbb.scriptMapping = Transfer.groovy :: **/*.jcl, **/*.xml
+dbb.scriptMapping = CRB.groovy :: **/*.yml, **/*.yaml
 
 #
 # Scanner mappings for application programs that require a custom scanner


### PR DESCRIPTION
This request extends the functionality of the build by allowing users to build CICS resource definitions in yaml format. The changes will allow the CICS yaml formatted file to be build by the CICS Resource builder tool. It will generate an artefact which will be in the legacy CSD format. This artefact can then be used in a DFHCSDUP job to apply the changes to the CICS region. The PR is a part of the Infrastructure as code effort. 
The PR consists of CRB. groovy file for doing the build and its corresponding properties files CRB.properties