### PR TITLE
Fix sorting of build list when creating test case dependency programatically

### DIFF
--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -531,7 +531,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 	}
 
 	if (props.createTestcaseDependency && props.createTestcaseDependency.toBoolean() && changedFiles && changedFiles.size() > 1) {
-		sortFileList(changedFiles);
+		changedFiles = sortFileList(changedFiles);
 		if (props.verbose) println "*** Sorted list of changed files: $changedFiles"
 	}
 
@@ -827,7 +827,7 @@ def addBuildPropertyDependencies(String buildProperties, LogicalFile logicalFile
  */
 def sortFileList(list) {
 	
-	list.sort{s1, s2 ->
+	return list.sort{s1, s2 ->
 		if (isMappedAsZUnitConfigFile(s1)) {
 			if (isMappedAsZUnitConfigFile(s2)) {
 				return 0;


### PR DESCRIPTION
This is resolving #362 . Previously the sorting was not correctly implemented.