### PR TITLE
Ability to maintain consistent metadata store for dependencies on generated zunit test case

### DIFF
--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -37,7 +37,7 @@ sortedList.each { buildFile ->
 	println "*** (${currentBuildFileNumber++}/${sortedList.size()}) Building file $buildFile"
 
 	// Check if this a testcase
-	isZUnitTestCase = (props.getFileProperty('cobol_testcase', buildFile).equals('true')) ? true : false
+	isZUnitTestCase = buildUtils.isGeneratedzUnitTestCaseProgram(buildFile)
 
 	// configure dependency resolution and create logical file	
 	String dependencySearch = props.getFileProperty('cobol_dependencySearch', buildFile)

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -35,7 +35,7 @@ sortedList.each { buildFile ->
 	println "*** (${currentBuildFileNumber++}/${sortedList.size()}) Building file $buildFile"
 
 	// Check if this a testcase
-	isZUnitTestCase = (props.getFileProperty('pli_testcase', buildFile).equals('true')) ? true : false
+	isZUnitTestCase = buildUtils.isGeneratedzUnitTestCaseProgram(buildFile)
 
 	// configure SearchPathDependencyResolver
 	String dependencySearch = props.getFileProperty('pli_dependencySearch', buildFile)

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -849,3 +849,15 @@ def printLogicalFileAttributes(LogicalFile logicalFile) {
 	
 }
 
+/**
+ * Validates if a buildFile is a zUnit generated test case program
+ * 
+ *  returns true / false
+ *  
+ */
+def isGeneratedzUnitTestCaseProgram(String buildFile) {
+	if (props.getFileProperty('cobol_testcase', buildFile).equals('true') || props.getFileProperty('pli_testcase', buildFile).equals('true')) {
+		return true
+	}
+	return false
+}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -62,8 +62,13 @@ def createImpactBuildList() {
 		changedFiles.each { changedFile ->
 			// if the changed file has a build script then add to build list
 			if (ScriptMappings.getScriptName(changedFile)) {
-				buildSet.add(changedFile)
-				if (props.verbose) println "** Found build script mapping for $changedFile. Adding to build list"
+				// skip adding generated test cases, when the testing is disabled 
+				if (buildUtils.isGeneratedzUnitTestCaseProgram(changedFile) || !(props.runzTests && props.runzTests.toBoolean())) {
+					if (props.verbose) println "** Identified $changedFile as a generated zunit test case program. Processing zUnit tests is not enabled for this build. Skip building this program."
+				} else {
+					buildSet.add(changedFile)
+					if (props.verbose) println "** Found build script mapping for $changedFile. Adding to build list"
+				}
 			}
 
 			// check if impact calculation should be performed, default true
@@ -773,6 +778,12 @@ def boolean shouldCalculateImpacts(String changedFile){
 
 	// return false if changedFile found in skipImpactCalculationList
 	if (onskipImpactCalculationList) return false
+	
+	// return false if the changed file is a generated test case program but testing is disabled
+	if (buildUtils.isGeneratedzUnitTestCaseProgram(changedFile) || !(props.runzTests && props.runzTests.toBoolean())) {
+		return false
+	}
+	
 	return true //default
 }
 


### PR DESCRIPTION
This is implementing the scenario outlined in #367 to allow users of zAppBuild to

* scan the generated zunit test case configuration,
* add the custom dependency via `createTestCaseDependency` configuration,
* but skip building the generated test case

to maintain consistent dependency information for zunit test setups for any feature/topic branch builds, which clone the dependency information to allow to automatically identify the generated test case via impact analysis, when the application program is changed. 