### PR TITLE
Fix condition evaluating generated test cases and zunit processing

### DIFF
--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -64,7 +64,7 @@ def createImpactBuildList() {
 			// if the changed file has a build script then add to build list
 			if (ScriptMappings.getScriptName(changedFile)) {
 				// skip adding generated test cases, when the testing is disabled 
-				if (buildUtils.isGeneratedzUnitTestCaseProgram(changedFile) || !(props.runzTests && props.runzTests.toBoolean())) {
+				if (buildUtils.isGeneratedzUnitTestCaseProgram(changedFile) && !(props.runzTests && props.runzTests.toBoolean())) {
 					if (props.verbose) println "** Identified $changedFile as a generated zunit test case program. Processing zUnit tests is not enabled for this build. Skip building this program."
 				} else {
 					buildSet.add(changedFile)
@@ -787,7 +787,7 @@ def boolean shouldCalculateImpacts(String changedFile){
 	if (onskipImpactCalculationList) return false
 	
 	// return false if the changed file is a generated test case program but testing is disabled
-	if (buildUtils.isGeneratedzUnitTestCaseProgram(changedFile) || !(props.runzTests && props.runzTests.toBoolean())) {
+	if (buildUtils.isGeneratedzUnitTestCaseProgram(changedFile) && !(props.runzTests && props.runzTests.toBoolean())) {
 		return false
 	}
 	


### PR DESCRIPTION
This is implementing #378 .

Test framework logs:

```
Revision: e57208290ef4879925cffe80c178cbed490819f4
Repository: https://github.com/dennis-behm/dbb-zappbuild.git

    origin/378_malformed_condition_to_skip_building_generated_test_cases
```

[dennis-behm-dbb-zappbuild-378_malformed_condition_to_skip_building_generated_test_cases.log](https://github.com/IBM/dbb-zappbuild/files/12015767/dennis-behm-dbb-zappbuild-378_malformed_condition_to_skip_building_generated_test_cases.log)
