### PR TITLE
Tolerate old dbb.scannerMapping configurations

### DIFF
--- a/utilities/DependencyScannerUtilities.groovy
+++ b/utilities/DependencyScannerUtilities.groovy
@@ -11,6 +11,9 @@ import groovy.json.JsonSlurper
 // define script properties
 @Field BuildProperties props = BuildProperties.getInstance()
 
+@Field def buildUtils = loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+
+
 /**
  * DependencyScannerUtilties
  * 
@@ -146,8 +149,13 @@ def parseConfigStringToMap(String configString) {
 		}
 	}
 	
-	// validate existance of scannerClass definition
-	assert scannerConfigMap.scannerClass != null
+	if (scannerConfigMap.scannerClass == null) {
+		String warningMsg = "*! The provided scanner mapping configuration ($configString) is not formed correctly and skipped."
+		println warningMsg 
+		println "*! Sample syntax: 'dbb.scannerMapping = \"scannerClass\":\"DependencyScanner\", \"languageHint\":\"COB\" :: cbl,cpy,cob'"
+		buildUtils.updateBuildResult(warningMsg:warningMsg)
+		return null
+	}
 	
 	return scannerConfigMap
 }


### PR DESCRIPTION
The development branch contains the enhancement #308, which implementation would stop a build, when a malformed `dbb.scannerMapping` configuration is detected due to the assertion exception.

The same property name was used previously to map to the ZUnitConfigScanner and is now extended to specify all the scanner mappings - see the defaults in build-conf/defaultzAppBuildConf.properties.

While we could meet some old application-confs with an old `dbb.scannerMapping`, this is now reported as a warning and skipped. It does not fail the build.