### PR TITLE
Skip inspecting load modules when running in preview mode

### DIFF
--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -638,7 +638,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
  */
 def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile logicalFile) {
 	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
-	if (metadataStore && !props.error) {
+	if (metadataStore && !props.error && !props.preview) {
 		LinkEditScanner scanner = new LinkEditScanner()
 		if (props.verbose) println "*** Scanning load module for $buildFile"
 		LogicalFile scannerLogicalFile = scanner.scan(buildUtils.relativizePath(buildFile), loadPDS)


### PR DESCRIPTION
This fixing the defect reported in  #380.

When invoking the `saveStaticLinkDependencies()` , the script will now check if the preview flag was passed.

Test logs:

[dennis-behm-380_skip_inspecting_loadmodule_in_preview.log](https://github.com/IBM/dbb-zappbuild/files/12036185/dennis-behm-380_skip_inspecting_loadmodule_in_preview.log)
