### PR TITLE
Transfer.groovy - specify the relative build file as key

### DIFF
--- a/languages/Transfer.groovy
+++ b/languages/Transfer.groovy
@@ -94,7 +94,7 @@ buildList.each { buildFile ->
 			String deployType = buildUtils.getDeployType("transfer", buildFile, null)
 
 			try {
-				int rc = new CopyToPDS().file(new File(buildUtils.getAbsolutePath(buildFile))).dataset(targetDataset).member(member).output(true).deployType(deployType).execute()
+				int rc = new CopyToPDS().key(buildFile).file(new File(buildUtils.getAbsolutePath(buildFile))).dataset(targetDataset).member(member).output(true).deployType(deployType).execute()
 				if (props.verbose) println "** Copied $buildFile to $targetDataset with deployType $deployType (rc = $rc)"
 
 				if (rc!=0){


### PR DESCRIPTION
This is implementing #344 .

With this little change, the build file will be reported nicely in the BuildReport as the file reference:

![image](https://github.com/IBM/dbb-zappbuild/assets/28918869/e2c04a59-9e76-4337-acf7-4839586b3550)
