### PR TITLE
Computation of the language prefix

### DIFF
--- a/languages/README.md
+++ b/languages/README.md
@@ -14,5 +14,11 @@ zAppBuild comes with a number of language specific build scripts.  These script 
 
 All language scripts both compile and optionally link-edit programs. The language build scripts are intended to be useful out of the box but depending on the complexity of your applications' build requirements, may require modifications to meet your development team's needs.  By following the examples used in the existing language build scripts of keeping all application specific references out of the build scripts and instead using configuration properties with strong default values, the zAppBuild sample can continue to be a generic build solution for all of your specific applications.
 
+## Convention for properties for language scripts
+
+Central properties files for languages scripts are managed in [build-conf](../build-conf/) referencing the name of the language script - such as `Cobol.properties`. These files contain dataset naming conventions and allocation options. Properties that may be application specific and may be overridden are managed as the group of application-conf properties files either centrally configured via the `applicationConfRootDir` property in [build-conf/build.properties](../build-conf/build.properties) or as part of the application repository - see [samples/application-conf/](../samples/application-conf/).  
+
+All properties for language scripts are defined by prefixing the property with a `language prefix` - e.q. `cobol_` to group and identify properties belonging to the Cobol.groovy languages script. The language prefix is computed based on the lower-case basename of the name of the language script, respectively until the first `_` character in the name of the language script. 
+
 ## Script Mappings
 Source files are mapped to language scripts via ***script mapping file properties***. Though script mappings can be defined at any level, zAppBuild relegates script mapping declarations to the application configuration folder (see [samples/application-conf/file.properties](../samples/application-conf/file.properties) allowing the application owner to determine what is best for the application. 

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -506,42 +506,14 @@ def createDatasets(String[] datasets, String options) {
 }
 
 /*
- * returns languagePrefix for language script name or null if not defined.
+ * returns languagePrefix from the name of the language script
+ * 
+ *  that is assumed to be the base name of the script, 
+ *  respectively the name until the first '_'
+ *  
  */
 def getLangPrefix(String scriptName){
-	def langPrefix = null
-	switch(scriptName) {
-		case "Cobol.groovy":
-			langPrefix = 'cobol'
-			break;
-		case "LinkEdit.groovy" :
-			langPrefix = 'linkedit'
-			break;
-		case "PLI.groovy":
-			langPrefix = 'pli'
-			break;
-		case "Assembler.groovy":
-			langPrefix = 'assembler'
-			break;
-		case "BMS.groovy":
-			langPrefix = 'bms'
-			break;
-		case "DBDgen.groovy":
-			langPrefix = 'dbdgen'
-			break;
-		case "MFS.groovy":
-			langPrefix = 'mfs'
-			break;
-		case "PSBgen.groovy":
-			langPrefix = 'psbgen'
-			break;
-		case "Transfer.groovy":
-			langPrefix = 'transfer'
-			break;
-		default:
-			if (props.verbose) println ("*** ! No language prefix defined for $scriptName.")
-			break;
-	}
+	langPrefix = scriptName.takeWhile{it != '.' && it != '_'}.toLowerCase()
 	return langPrefix
 }
 


### PR DESCRIPTION
This is implementing #396 to simplify to obtain the language prefix based on the name of a language script.

This is documenting the unwritten rule (but now it is written down), that properties of language script are prefix with the base name of the language script, respectively until the first `_`.

This will allow us in the future to proceed to simplify for instance the link phase of the various language script.