### PR TITLE
Display message on missing build script mapping

### DIFF
--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -109,8 +109,12 @@ def createImpactBuildList() {
 							// impactedFile found, but on Exclude List
 							//   Possible reasons: Exclude of file was defined after building the collection.
 							//   Rescan/Rebuild Collection to synchronize it with defined build scope.
-							if (props.verbose) println "!! $impactFile is impacted by changed file $changedFile, but is on Exlude List. Not added to build list."
+							if (props.verbose) println "*!* $impactFile is impacted by changed file $changedFile, but is on Exlude List. Not added to build list."
 						}
+					} else {
+						String warningMsg = "*!* $impactFile is impacted by changed file $changedFile, but is not added to build list, because it is not mapped to a language script."
+						buildUtils.updateBuildResult(warningMsg:warningMsg)
+						println(warningMsg)
 					}
 				}
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -109,10 +109,10 @@ def createImpactBuildList() {
 							// impactedFile found, but on Exclude List
 							//   Possible reasons: Exclude of file was defined after building the collection.
 							//   Rescan/Rebuild Collection to synchronize it with defined build scope.
-							if (props.verbose) println "*!* $impactFile is impacted by changed file $changedFile, but is on Exlude List. Not added to build list."
+							if (props.verbose) println "*! $impactFile is impacted by changed file $changedFile, but is on Exlude List. Not added to build list."
 						}
 					} else {
-						String warningMsg = "*!* $impactFile is impacted by changed file $changedFile, but is not added to build list, because it is not mapped to a language script."
+						String warningMsg = "*! $impactFile is impacted by changed file $changedFile, but is not added to build list, because it is not mapped to a language script."
 						buildUtils.updateBuildResult(warningMsg:warningMsg)
 						println(warningMsg)
 					}


### PR DESCRIPTION
This is providing a warning message to the console output independently of running in verbose logging mode, when during impact analysis an impacted file was detected, but is not mapped to a language script:

```
** Found impacted file retirementCalculator/testcase/TEBUD01.cbl
** retirementCalculator/testcase/TEBUD01.cbl is impacted by changed file retirementCalculator/cobol/EBUD01.cbl. Adding to build list.
** Found impacted file retirementCalculator/testcfg/EBUD01.bzucfg
*! retirementCalculator/testcfg/EBUD01.bzucfg is impacted by changed file retirementCalculator/cobol/EBUD01.cbl, but is not added to build list, because it is not mapped to a language script.
```

The msg is also added to the build result.