### PR TITLE
Add CopyMode property

### DIFF
--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -325,7 +325,6 @@ transfer_jclPDS | Sample dataset for JCL members
 transfer_xmlPDS | Sample dataset for xml members
 transfer_dsOptions | BPXWDYN creation options for creating 'source' type data sets
 transfer_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property. ** If used for multiple, use a file property to set transfer_outputDatasets
-transfer_copyMode | Copy Mode used during the copy to the target dataset  
 
 ### language-conf/languageConfigProps01.properties
 Sample language configuration properties file used by dbb-zappbuild/utilities/BuildUtilities.groovy.

--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -323,8 +323,9 @@ transfer_requiredBuildProperties | Comma separated list of required build proper
 transfer_srcPDS | Dataset of any type of source
 transfer_jclPDS | Sample dataset for JCL members
 transfer_xmlPDS | Sample dataset for xml members
-transfer_srcOptions | BPXWDYN creation options for creating 'source' type data sets
-transfer_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property. ** If used for multiple, use a file property to set transfer_outputDatasets 
+transfer_dsOptions | BPXWDYN creation options for creating 'source' type data sets
+transfer_outputDatasets | List of output datasets to document deletions ** Can be overridden by a file property. ** If used for multiple, use a file property to set transfer_outputDatasets
+transfer_copyMode | Copy Mode used during the copy to the target dataset  
 
 ### language-conf/languageConfigProps01.properties
 Sample language configuration properties file used by dbb-zappbuild/utilities/BuildUtilities.groovy.

--- a/build-conf/Transfer.properties
+++ b/build-conf/Transfer.properties
@@ -20,6 +20,13 @@ transfer_xmlPDS=${hlq}.XML
 #
 # This is using the DBB PropertyMapping syntax allowing multiple mappings of
 #  target source dataset definitions to the required options
-# 
+#
 transfer_dsOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_srcPDS, transfer_jclPDS
 transfer_dsOptions=cyl space(1,1) lrecl(144) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_xmlPDS
+
+#
+# Copy Mode used in during the transfer to target
+# Available modes are ASA_TEXT, BINARY, LOAD, and TEXT
+# Documentation: https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
+#
+transfer_copyMode=TEXT :: **/*jcl, **/xml/*.*

--- a/build-conf/Transfer.properties
+++ b/build-conf/Transfer.properties
@@ -23,10 +23,3 @@ transfer_xmlPDS=${hlq}.XML
 #
 transfer_dsOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_srcPDS, transfer_jclPDS
 transfer_dsOptions=cyl space(1,1) lrecl(144) dsorg(PO) recfm(F,B) dsntype(library) :: transfer_xmlPDS
-
-#
-# Copy Mode used in during the transfer to target
-# Available modes are ASA_TEXT, BINARY, LOAD, and TEXT
-# Documentation: https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
-#
-transfer_copyMode=TEXT :: **/*jcl, **/xml/*.*

--- a/languages/Transfer.groovy
+++ b/languages/Transfer.groovy
@@ -67,7 +67,6 @@ buildList.each { buildFile ->
 		// evaluate the datasetmapping, which maps build files to targetDataset defintions
 		PropertyMappings dsMapping = new PropertyMappings("transfer_datasetMapping")
 		PropertyMappings dsOptionsMapping = new PropertyMappings("transfer_dsOptions")
-        PropertyMappings copyModeMapping = new PropertyMappings("transfer_copyMode")		
 
 		// obtain the target dataset based on the mapped dataset key
 		mappedDatesetDef = dsMapping.getValue(buildFile)
@@ -86,7 +85,8 @@ buildList.each { buildFile ->
 			} 
 
             // get copy mode value from Property Mappings
-            def copyMode = copyModeMapping.getValue(buildFile)
+			def copyMode = props.getFileProperty('transfer_copyMode', buildFile)
+
             DBBConstants.CopyMode transferCopyMode
             if (copyMode != null) {
                 transferCopyMode = DBBConstants.CopyMode.valueOf(copyMode)

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -297,6 +297,7 @@ Application properties used by zAppBuild/language/Transfer.groovy
 Property | Description | Overridable
 --- | --- | ---
 transfer_deployType | deployType | true
+transfer_copyMode | Copy mode used during the copy to the target data set | true
 
 ### languageConfigurationMapping.properties
 Sample language configuration mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy.

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -291,7 +291,7 @@ rexx_cexec_deployType | default deployType CEXEC | true
 rexx_compileSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during compile step | true
 rexx_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
-### nonBuildable.properties
+### Transfer.properties
 Application properties used by zAppBuild/language/Transfer.groovy
 
 Property | Description | Overridable

--- a/samples/application-conf/Transfer.properties
+++ b/samples/application-conf/Transfer.properties
@@ -2,4 +2,4 @@
 
 #
 # default deployType
-transfer_deployType=TRANSFER
+transfer_deployType=TRANSFER :: **/*jcl, **/xml/*.*

--- a/samples/application-conf/Transfer.properties
+++ b/samples/application-conf/Transfer.properties
@@ -2,4 +2,10 @@
 
 #
 # default deployType
-transfer_deployType=TRANSFER :: **/*jcl, **/xml/*.*
+transfer_deployType=TRANSFER
+
+#
+# Default copy mode to transfer the file to the target library
+# Available modes are ASA_TEXT, BINARY, LOAD, and TEXT
+# Documentation: https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
+transfer_copyMode=TEXT

--- a/samples/application-conf/file.properties
+++ b/samples/application-conf/file.properties
@@ -70,3 +70,9 @@ dbb.scriptMapping = CRB.groovy :: **/crb/*.yaml
 #
 # transfer_deployType = JCL :: **/*.jcl
 # transfer_deployType = XML :: **/xml/*.*
+
+#
+# Override of the default copy mode to transfer the file to the target library
+# Available modes are ASA_TEXT, BINARY, LOAD, and TEXT
+# Documentation: https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
+# transfer_copyMode=BINARY :: **/*.object


### PR DESCRIPTION
Collaboration with @M-DLB to implement a `transfer_copyMode` property that can be used to specify the [CopyMode](https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html) during `Transfer.groovy`. Documentation is updated accordingly.

(Original work is located on the [transfer-copymode](https://github.com/lauren-li/dbb-zappbuild/tree/transfer-copymode) branch.)