### PR TITLE
Fix PL/I requiredBuildProperties property name

### DIFF
--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -2,7 +2,7 @@
 
 #
 # Comma separated list of required build properties for PLI.groovy
-pli_requiredBuildPropeties=pli_srcPDS,pli_incPDS,pli_objPDS,pli_loadPDS,\
+pli_requiredBuildProperties=pli_srcPDS,pli_incPDS,pli_objPDS,pli_loadPDS,\
  pli_compiler,pli_linkEditor,pli_tempOptions,applicationOutputsCollectionName,\
  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED, \
  pli_dependencySearch


### PR DESCRIPTION
Correct the property name for PL/I requiredBuildProperties so that it is applied when the [PL/I language script](https://github.com/IBM/dbb-zappbuild/blob/main/languages/PLI.groovy) runs.