### PR TITLE
Support for zCEE2

### DIFF
--- a/build-conf/README.md
+++ b/build-conf/README.md
@@ -300,6 +300,16 @@ zcee3_shellEnvironment | Shell environment used to run the gradle command
 zcee3_gradlePath | Path to gradle executable
 zcee3_gradle_JAVA_OPTS | JAVA Options used with gradle
 
+### zCEE2.properties
+Application properties used by zAppBuild/language/zCEE2.groovy
+
+Property | Description
+--- | ---
+zcee2_zconbtPath | Absolute path to zconbt executable on z/OS UNIX System Services
+zcee2_JAVA_HOME | Java installation used by the zconbt utility
+zcee2_inputType | Mapping of input files with types of files
+zcee2_ARA_PackageArtifacts | Flag to indicate if artifacts produced for the ARA processing should be packaged
+
 ### CRB.properties
 Application properties used by zAppBuild/language/CRB.groovy
 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -19,7 +19,7 @@
 buildPropFiles=datasets.properties,dependencyReport.properties,Assembler.properties,BMS.properties,\
 MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,\
 LinkEdit.properties,PLI.properties,REXX.properties,ZunitConfig.properties,Transfer.properties,\
-CRB.properties,zCEE3.properties
+CRB.properties,zCEE3.properties,zCEE2.properties
 
 #
 # Comma separated list of default application configuration property files to load

--- a/build-conf/zCEE2.properties
+++ b/build-conf/zCEE2.properties
@@ -1,0 +1,28 @@
+# Releng properties used by language/zCEE2.groovy
+
+#
+# Comma separated list of required build properties for zCEE3.groovy
+zcee2_requiredBuildProperties=zcee2_zconbtPath,zcee2_JAVA_HOME
+
+#
+# Absolute path to zconbt executable on z/OS UNIX System Services
+# for instance: /var/zosconnect/v359/bin/zconbt.zos
+zcee2_zconbtPath=
+
+#
+# Java installation used by the zconbt utility
+# for instance: /usr/lpp/java/J8.0_64
+zcee2_JAVA_HOME=
+
+#
+# Mapping of input files with types of files
+# PROJECT can be used for SAR and AAR projects
+# SAR and ARA can be used for SAR Properties files and ARA properties files
+# Can be overridden by file-level properties
+zcee2_inputType=PROJECT
+
+#
+# Flag to indicate if artifacts produced for the ARA processing should be packaged (generated copybooks, API information copybook and logs)
+# When set to true, the artifacts are located based on the dataStructuresLocation, apiInfoFileLocation and logFileDirectory properties of the ARA properties files
+# When not defined, the default value is false and artifacts are packaged
+zcee2_ARA_PackageArtifacts=true

--- a/languages/zCEE2.groovy
+++ b/languages/zCEE2.groovy
@@ -1,0 +1,219 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import com.ibm.dbb.dependency.*
+import com.ibm.dbb.build.*
+import groovy.transform.*
+import com.ibm.dbb.build.report.*
+import com.ibm.dbb.build.report.records.*
+import java.nio.file.*;
+
+
+// define script properties
+@Field BuildProperties props = BuildProperties.getInstance()
+@Field def buildUtils= loadScript(new File("${props.zAppBuildDir}/utilities/BuildUtilities.groovy"))
+
+// verify required build properties
+buildUtils.assertBuildProperties(props.zcee2_requiredBuildProperties)
+
+// create updated build map, removing duplicates in case of PROJECT input Type
+HashMap<String, String> updatedBuildMap = new HashMap<String, String>()
+
+println("** Streamlining the build list to remove duplicates")
+argMap.buildList.each { buildFile ->
+    PropertyMappings inputTypeMappings = new PropertyMappings("zcee2_inputType")
+    inputType = inputTypeMappings.getValue(buildFile)
+
+    if (inputType) {
+        if (inputType == "PROJECT") {
+            File changedBuildFile = new File(buildFile);
+            File projectDir = changedBuildFile.getParentFile()
+            boolean projectDirFound = false
+            while (projectDir != null && !projectDirFound) {
+                File projectFile = new File(projectDir.getPath() + '/.project')
+                if (projectFile.exists()) {
+                    projectDirFound = true
+                } else {
+                    projectDir = projectDir.getParentFile()
+                }
+            }
+            if (projectDirFound) {
+                updatedBuildMap.put(projectDir.getPath(), "PROJECT")
+            } else {
+                if (props.verbose) println("!* No project directory found for file '${buildFile}'. Skipping...")
+            }
+        } else {
+            updatedBuildMap.put(buildFile, inputType);
+        }
+    } else {
+        println("!* No Input Type mapping for file ${buildFile}, skipping it...")
+    }
+}
+
+println("** Building ${updatedBuildMap.size()} API ${updatedBuildMap.size() == 1 ? 'definition' : 'definitions'} mapped to ${this.class.getName()}.groovy script")
+// sort the build list based on build file rank if provided
+HashMap<String, String> sortedMap = buildUtils.sortBuildMap(updatedBuildMap, 'zcee2_fileBuildRank')
+
+int currentBuildFileNumber = 1
+
+// iterate through build list
+sortedMap.each { buildFile, inputType ->
+    println "*** (${currentBuildFileNumber++}/${sortedMap.size()}) Building ${inputType == "PROJECT" ? 'project' : 'properties file'} $buildFile"
+
+    String parameters = ""
+    String outputDir = ""
+    String outputFile = ""
+    if (inputType == "PROJECT") {
+        outputDir = "${props.buildOutDir}/zCEE2/$buildFile"
+        parameters = "-od $outputDir -pd $buildFile"
+    } else {
+        File changedBuildFile = new File(buildFile);
+        String outputFileName = changedBuildFile.getName().split("\\.")[0] + "." + inputType.toLowerCase()
+        File projectDir = changedBuildFile.getParentFile()
+        outputFile = "${props.buildOutDir}/zCEE2/${projectDir.getPath()}/${outputFileName}"
+        outputDir = "${props.buildOutDir}/zCEE2/${projectDir.getPath()}"
+        parameters = "-f $outputFile -p $buildFile"
+    }
+    File outputDirectory = new File(outputDir)
+    outputDirectory.mkdirs()
+
+
+    Properties ARAproperties = new Properties()
+    File dataStructuresLocation
+    File apiInfoFileLocation
+    File logFileDirectory
+    if (inputType == "ARA") {
+        File ARApropertiesFile = new File(buildFile)
+        ARApropertiesFile.withInputStream {
+            ARAproperties.load(it)
+        }
+        println("*** dataStructuresLocation: ${ARAproperties.dataStructuresLocation}")
+        println("*** apiInfoFileLocation: ${ARAproperties.apiInfoFileLocation}")
+        println("*** logFileDirectory: ${ARAproperties.logFileDirectory}")
+        dataStructuresLocation = new File(ARAproperties.dataStructuresLocation)
+        dataStructuresLocation.mkdirs()
+        apiInfoFileLocation = new File(ARAproperties.apiInfoFileLocation)
+        apiInfoFileLocation.mkdirs()
+        logFileDirectory = new File(ARAproperties.logFileDirectory)
+        logFileDirectory.mkdirs()            
+    }
+
+
+    // log file - Changing slashes with dots to avoid conflicts
+    String logFilePath = buildFile.replace("/", ".")
+    File logFile = new File("${props.buildOutDir}/${logFilePath}.zCEE2.log")
+    if (logFile.exists())
+        logFile.delete()
+    
+    String zconbtPath = props.getFileProperty('zcee2_zconbtPath', buildFile)
+
+    File zconbt = new File(zconbtPath)
+    if (!zconbt.exists()) {
+        def errorMsg = "*! zconbt wasn't find at location '$zconbtPath'" 
+        println(errorMsg)
+        props.error = "true"
+        buildUtils.updateBuildResult(errorMsg:errorMsg)
+    } else {
+        String[] command;
+
+        command = [zconbtPath, parameters]
+        String commandString = command.join(" ")
+        if (props.verbose)
+            println("** Executing command '${commandString}'...")
+
+        StringBuffer shellOutput = new StringBuffer()
+        StringBuffer shellError = new StringBuffer()
+
+        String JAVA_HOME = props.getFileProperty('zcee2_JAVA_HOME', buildFile)
+
+        ProcessBuilder cmd = new ProcessBuilder(zconbtPath, parameters);
+        Map<String, String> env = cmd.environment();
+        env.put("JAVA_HOME", JAVA_HOME);
+        env.put("PATH", JAVA_HOME + "/bin" + ";" + env.get("PATH"))
+        Process process = cmd.start()
+        process.consumeProcessOutput(shellOutput, shellError)
+        process.waitFor()
+        if (props.verbose)
+            println("** Exit value for the zconbt process: ${process.exitValue()}");
+            
+        // write outputs to log file
+        String enc = props.logEncoding ?: 'IBM-1047'
+        logFile.withWriter(enc) { writer ->
+            writer.append(shellOutput)
+            writer.append(shellError)
+        }
+        
+        if (process.exitValue() != 0) {
+            def errorMsg = "*! Error during the zconbt process" 
+            println(errorMsg)
+            if (props.verbose)
+                println("*! zconbt error message:\n${shellError}")
+            props.error = "true"
+            buildUtils.updateBuildResult(errorMsg:errorMsg)
+        } else {
+            if (props.verbose)
+                println("** zconbt output:\n${shellOutput}")
+
+            ArrayList<String> outputProperty = []
+            Path outputDirectoryPath = Paths.get(props.buildOutDir)
+            if (inputType == "PROJECT") {
+                String[] outputFiles = outputDirectory.list()
+                for (int i=0; i<outputFiles.length; i++) {
+                    Path outputFilePath = Paths.get(outputDir + "/" + outputFiles[i])
+                    Path relativeOutputFilePath = outputDirectoryPath.relativize(outputFilePath)
+                    outputProperty.add("[${props.buildOutDir}, ${relativeOutputFilePath.toString()}, zCEE2]")
+                }
+            } else {
+                Path outputFilePath = Paths.get(outputFile)
+                Path relativeOutputFilePath = outputDirectoryPath.relativize(outputFilePath)
+                outputProperty.add("[${props.buildOutDir}, ${relativeOutputFilePath.toString()}, zCEE2]")
+
+                if (inputType == "ARA") {
+                    def ARA_PackageArtifacts = props.getFileProperty('zcee2_ARA_PackageArtifacts', buildFile)
+                    if (ARA_PackageArtifacts && ARA_PackageArtifacts.toBoolean()) {
+
+                        String[] outputFiles
+                        Path finalOutputFilePath
+
+                        outputFiles = dataStructuresLocation.list()
+                        File dataStructuresLocationDir = new File("${props.buildOutDir}/zCEE2/dataStructures")
+                        dataStructuresLocationDir.mkdirs()
+                        for (int i=0; i<outputFiles.length; i++) {
+                            outputFilePath = Paths.get(dataStructuresLocation.getPath() + "/" + outputFiles[i])
+                            finalOutputFilePath = Paths.get(dataStructuresLocationDir.getPath() + "/" + outputFiles[i])
+                            Files.copy(outputFilePath, finalOutputFilePath, StandardCopyOption.COPY_ATTRIBUTES);
+                            relativeOutputFilePath = outputDirectoryPath.relativize(finalOutputFilePath)
+                            outputProperty.add("[${props.buildOutDir}, ${relativeOutputFilePath.toString()}, zCEE2-Copy]")
+                        }
+                        outputFiles = apiInfoFileLocation.list()
+                        File apiInfoFileLocationDir = new File("${props.buildOutDir}/zCEE2/apiInfoFiles")
+                        apiInfoFileLocationDir.mkdirs()
+                        for (int i=0; i<outputFiles.length; i++) {
+                            outputFilePath = Paths.get(apiInfoFileLocation.getPath() + "/" + outputFiles[i])
+                            finalOutputFilePath = Paths.get(apiInfoFileLocationDir.getPath() + "/" + outputFiles[i])
+                            Files.copy(outputFilePath, finalOutputFilePath, StandardCopyOption.COPY_ATTRIBUTES);
+                            relativeOutputFilePath = outputDirectoryPath.relativize(finalOutputFilePath)
+                            outputProperty.add("[${props.buildOutDir}, ${relativeOutputFilePath.toString()}, zCEE2-Info]")
+                        }
+                        outputFiles = logFileDirectory.list()
+                        File logFileDirectoryDir = new File("${props.buildOutDir}/zCEE2/logs")
+                        logFileDirectoryDir.mkdirs()
+                        for (int i=0; i<outputFiles.length; i++) {
+                            if (outputFiles[i].endsWith(".log")) {
+                                outputFilePath = Paths.get(logFileDirectory.getPath() + "/" + outputFiles[i])
+                                finalOutputFilePath = Paths.get(logFileDirectoryDir.getPath() + "/" + outputFiles[i])
+                                Files.copy(outputFilePath, finalOutputFilePath, StandardCopyOption.COPY_ATTRIBUTES);
+                                relativeOutputFilePath = outputDirectoryPath.relativize(finalOutputFilePath)
+                                outputProperty.add("[${props.buildOutDir}, ${relativeOutputFilePath.toString()}, zCEE2-Log]")
+                            }
+                        }
+                    }
+                }
+            }
+            AnyTypeRecord zCEEWARRecord = new AnyTypeRecord("USS_RECORD")
+            zCEEWARRecord.setAttribute("file", buildFile)
+            zCEEWARRecord.setAttribute("label", "z/OS Connect EE OpenAPI 2 definition")
+            zCEEWARRecord.setAttribute("outputs", outputProperty.join(";"))
+            zCEEWARRecord.setAttribute("command", commandString);
+            BuildReportFactory.getBuildReport().addRecord(zCEEWARRecord)
+        }
+    }
+}

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -24,7 +24,7 @@ applicationSrcDirs=${application}
 #
 # Comma separated list of the build script processing order
 buildOrder=BMS.groovy,MFS.groovy,Cobol.groovy,Assembler.groovy,PLI.groovy,\
-LinkEdit.groovy,DBDgen.groovy,PSBgen.groovy,Transfer.groovy,CRB.groovy
+LinkEdit.groovy,DBDgen.groovy,PSBgen.groovy,Transfer.groovy,CRB.groovy,zCEE2.groovy
 
 #
 # Comma seperated list of the test script processing order
@@ -42,14 +42,14 @@ testOrder=ZunitConfig.groovy
 mainBuildBranch=master
 
 #
-# The git repository URL of the application repository to establish links to the changed files 
-# in the build result properties 
+# The git repository URL of the application repository to establish links to the changed files
+# in the build result properties
 # ex: for GitHub: https://github.com/ibm/dbb-zappbuild/
 gitRepositoryURL=
 
 #
 # exclude list used when scanning or running full build
-excludeFileList=.*,**/.*,**/*.properties,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/application-conf/*.*
+excludeFileList=.*,**/.*,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/application-conf/*.*
 
 #
 # comma-separated list of file patterns for which impact calculation should be skipped. Uses glob file patterns
@@ -70,15 +70,15 @@ jobCard=
 
 # ### Properties to enable and configure build property overrides using individual artifact properties files
 
-# flag to enable the zAppBuild capability to load individual artifact properties files for all individual source files. 
+# flag to enable the zAppBuild capability to load individual artifact properties files for all individual source files.
 # Note: To only activate loadFileLevelProperties for a group of files, it is recommended to use DBB's file property path
 # syntax in application-conf/file.properties instead.
 # default: false
 loadFileLevelProperties=false
 
-# Property to enable/disable and configure build property overrides using language configuration mapping 
+# Property to enable/disable and configure build property overrides using language configuration mapping
 # file - languageConfigurationMapping.properties
-# If loadFileLevelProperties is set as true above, the properties from the individual artifact properties files will override the 
+# If loadFileLevelProperties is set as true above, the properties from the individual artifact properties files will override the
 # properties from language configuration properties file.
 # Note: To only activate loadLanguageConfigurationProperties for a group of files, it is recommended to use DBB's file property path
 # syntax in application-conf/file.properties instead.
@@ -99,28 +99,28 @@ propertyFileExtension=properties
 #
 # boolean flag to configure the SearchPathDependencyResolver to evaluate if resolved dependencies impact
 #  the file flags isCICS, isSQL, isDLI, isMQ when creating the LogicalFile
-# 
-#  default:false 
+#
+#  default:false
 resolveSubsystems=false
 
 #
 # SearchPathImpactFinder resolution searchPath configuration
-#  list of multiple search path configurations which are defined below 
+#  list of multiple search path configurations which are defined below
 #
 # this configuration is used when running zAppBuild with the --impactBuild option
 #  to calculate impacted files based on the identified changed files
 impactSearch=${copybookSearch}${pliincludeSearch}${bmsSearch}${linkSearch}${rexxCopySearch}${zunitTestConfigSearch}${zunitTestcasePgmSearch}
 
 #
-# copybookSearch 
-# searchPath to locate Cobol copybooks 
+# copybookSearch
+# searchPath to locate Cobol copybooks
 # used in dependency resolution and impact analysis
-# 
+#
 # Please be as specific as possible when configuring the searchPath.
-# Alternate configurations: 
+# Alternate configurations:
 #
 # dependency resolution from multiple repositories / multiple root folders:
-# copybookSearch = search:${workspace}/?path=**/copybook/*.cpy 
+# copybookSearch = search:${workspace}/?path=**/copybook/*.cpy
 #
 # dependency resolution across all directories in build workspace, but filtering on the file extension cpy:
 # copybookSearch = search:${workspace}/?path=**/*.cpy
@@ -129,28 +129,28 @@ impactSearch=${copybookSearch}${pliincludeSearch}${bmsSearch}${linkSearch}${rexx
 #
 # dependency resolution in the application directory and a shared common copybook location:
 # copybookSearch = search:${workspace}/?path=${application}/copybook/*.cpy;/u/build/common/copybooks/*.cpy
-# 
-# More samples can be found along with the syntax for the search path configurations at: 
+#
+# More samples can be found along with the syntax for the search path configurations at:
 # https://www.ibm.com/docs/en/dbb/2.0.0?topic=apis-dependency-impact-resolution#6-resolving-logical-build-dependencies-to-local-physical-files
 #
-copybookSearch = search:${workspace}/?path=${application}/copybook/*.cpy  
+copybookSearch = search:${workspace}/?path=${application}/copybook/*.cpy
 
 #
-# pliincludeSearch 
-# searchPath to locate PLI include files 
-# used in dependency resolution and impact analysis               
-pliincludeSearch = search:${workspace}/?path=${application}/plinc/*.cpy 
+# pliincludeSearch
+# searchPath to locate PLI include files
+# used in dependency resolution and impact analysis
+pliincludeSearch = search:${workspace}/?path=${application}/plinc/*.cpy
 
-# asmMacroSearch 
-# searchPath to locate Assembler macro files 
+# asmMacroSearch
+# searchPath to locate Assembler macro files
 # use category filters on what you want to include during the scan (i.e. excludes macro-def keyword)
-# used in dependency resolution and impact analysis   
-asmMacroSearch = search:[SYSLIB:MACRO]${workspace}/?path=${application}/maclib/*.mac 
+# used in dependency resolution and impact analysis
+asmMacroSearch = search:[SYSLIB:MACRO]${workspace}/?path=${application}/maclib/*.mac
 
-# asmCopySearch 
-# searchPath to locate Assembler copy files 
-# used in dependency resolution and impact analysis   
-asmCopySearch = search:[SYSLIB:COPY]${workspace}/?path=${application}/maclib/*.mac 
+# asmCopySearch
+# searchPath to locate Assembler copy files
+# used in dependency resolution and impact analysis
+asmCopySearch = search:[SYSLIB:COPY]${workspace}/?path=${application}/maclib/*.mac
 
 #
 # bmsSearch
@@ -161,7 +161,7 @@ bmsSearch = search:${workspace}/?path=${application}/bms/*.bms
 #
 # rexxCopySearch
 # searchPath to locate rexx copy - defaults to the local rexx folder in the main application folder
-# used in dependency resolution and impact analysis   
+# used in dependency resolution and impact analysis
 rexxCopySearch = search:[SYSLIB:COPY]${workspace}/?path=${application}/rexx/*.rexx
 
 #
@@ -170,7 +170,7 @@ rexxCopySearch = search:[SYSLIB:COPY]${workspace}/?path=${application}/rexx/*.re
 # searchPath to locate impacted linkcards or main programs after an included submodule is changed
 # leverages the output collection, which has the dependency info from the executable
 # category LINK only; used only in impact analysis
-# 
+#
 # Additional samples:
 #
 # impact resolution across all directories in build workspace, but filtering on the file extension cbl:
@@ -179,7 +179,7 @@ rexxCopySearch = search:[SYSLIB:COPY]${workspace}/?path=${application}/rexx/*.re
 # impact resolution across all directories in build workspace, but filtering on the file extension cbl and pli (for cobol and pli submodules):
 # staticLinkSearch = search:[:LINK]${workspace}/?path=**/*.cbl,**/*.pli
 #
-# More samples can be found along with the syntax for the search path configurations at: 
+# More samples can be found along with the syntax for the search path configurations at:
 # https://www.ibm.com/docs/en/dbb/2.0.0?topic=apis-dependency-impact-resolution#6-resolving-logical-build-dependencies-to-local-physical-files
 #
 # Special case with Dependency Scanner Transfer Control Statement capturing turned on (default is off)
@@ -188,15 +188,15 @@ rexxCopySearch = search:[SYSLIB:COPY]${workspace}/?path=${application}/rexx/*.re
 #
 linkSearch = search:[:LINK]${workspace}/?path=${application}/cobol/*.cbl
 
-# zunitTestConfigSearch 
-# searchPath to locate zunit config files 
-# used in impact analysis 
+# zunitTestConfigSearch
+# searchPath to locate zunit config files
+# used in impact analysis
 zunitTestConfigSearch = search:[:ZUNITINC]${workspace}/?path=${application}/cobol/*.cbl;${application}/pli/*.pli;${application}/testcase/*.cbl;${application}/testcase/*.pli
 
 #
 # zunitPlayfileSearch
 # searchPath to locate zunit playback files
-# used in dependency resolution   
+# used in dependency resolution
 zunitPlayfileSearch = search:[SYSPLAY:]${workspace}/?path=${application}/testplayfiles/*.bzuplay
 
 #

--- a/samples/application-conf/file.properties
+++ b/samples/application-conf/file.properties
@@ -14,6 +14,7 @@ dbb.scriptMapping = ZunitConfig.groovy :: **/*.bzucfg
 dbb.scriptMapping = Transfer.groovy :: **/*.jcl, **/*.xml
 dbb.scriptMapping = zCEE3.groovy :: **/openapi.yaml
 dbb.scriptMapping = CRB.groovy :: **/crb/*.yaml
+dbb.scriptMapping = zCEE2.groovy :: **/zosconnect_artefacts/**/*.*
 
 #
 # dbb.scannerMapping to map files extensions to DBB dependency scanner configurations
@@ -76,3 +77,23 @@ dbb.scriptMapping = CRB.groovy :: **/crb/*.yaml
 # Available modes are ASA_TEXT, BINARY, LOAD, and TEXT
 # Documentation: https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
 # transfer_copyMode=BINARY :: **/*.object
+
+
+#########
+# Configuration for zCEE2.groovy to specify file-level overrides
+#########
+
+#
+# Mapping of input files with types of files
+# PROJECT can be used for SAR and AAR projects
+# SAR and ARA can be used for SAR Properties files and ARA properties files
+#
+# zcee2_inputType=PROJECT :: **/zosconnect_artefacts/apis/**/*.*, **/zosconnect_artefacts/services/**/*.*
+# zcee2_inputType=SAR :: **/zosconnect_artefacts/SAR/*.properties
+# zcee2_inputType=ARA :: **/zosconnect_artefacts/requester/**/*.properties
+
+#
+# Build Rank for zCEE2 artifacts
+#
+#zcee2_fileBuildRank=1 :: **/zosconnect_artefacts/services/**
+#zcee2_fileBuildRank=2 :: **/zosconnect_artefacts/requester/**/*.properties


### PR DESCRIPTION
The purpose of this PR is to collect feedback on the proposed integration of zCEE2 artifacts as part of the pipeline.
The requisites is to install the *zconbt* utility (on USS) and customize accordingly the zCEE2.properties in the` build-conf` directory.
The mapping defined in `application-conf/file.properties` for the *zcee2_inputType* helps you define the type of artifacts you're working with (either PROJECT for Service ARchive (SAR) or API ARchive (AAR) projects, SAR for Service ARchive (SAR) properties files, ARA for API Requester Archive (ARA) properties files).