### PR TITLE
Improve calculation of branch name in detached head scenario

### DIFF
--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -73,20 +73,20 @@ def getCurrentGitDetachedBranch(String gitDir) {
 	}
 
 	String gitBranchString = gitBranch.toString()
-	def gitBranchArr = gitBranchString.split(',')
+	String[] gitBranchesArr = gitBranchString.split(',')
 	def solution = ""
 	// expecting references with "origin" as segment
 	def origin = "origin/"
-	if (gitBranchArr.count {it.contains(origin)}  > 1 ) {
+	if (gitBranchesArr.count {it.contains(origin)}  > 1 ) {
 		String warningMsg = "*! (GitUtils.getCurrentGitDetachedBranch) Warning obtaining branch name for ($dir). Multiple references point to the same commit. ($gitBranchArr)"
 		println(warningMsg)
 		updateBuildResult(warningMsg:warningMsg)
 	}
 
 	// substring the branch name
-	for (i = 0; i < gitBranchArr.length; i++) {
-		if (gitBranchArr[i].contains(origin)) {
-			solution = gitBranchArr[i].replaceAll(".*?${origin}", "").trim()
+	for (i = 0; i < gitBranchesArr.length; i++) {
+		if (gitBranchesArr[i].contains(origin)) {
+			solution = gitBranchesArr[i].replaceAll(".*?${origin}", "").trim()
 		}
 	}
 

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -73,20 +73,20 @@ def getCurrentGitDetachedBranch(String gitDir) {
 	}
 
 	String gitBranchString = gitBranch.toString()
-	String[] gitBranchesArr = gitBranchString.split(',')
+	String[] gitBranchesArray = gitBranchString.split(',')
 	def solution = ""
 	// expecting references with "origin" as segment
 	def origin = "origin/"
-	if (gitBranchesArr.count {it.contains(origin)}  > 1 ) {
+	if (gitBranchesArray.count {it.contains(origin)}  > 1 ) {
 		String warningMsg = "*! (GitUtils.getCurrentGitDetachedBranch) Warning obtaining branch name for ($dir). Multiple references point to the same commit. ($gitBranchArr)"
 		println(warningMsg)
 		updateBuildResult(warningMsg:warningMsg)
 	}
 
 	// substring the branch name
-	for (i = 0; i < gitBranchesArr.length; i++) {
-		if (gitBranchesArr[i].contains(origin)) {
-			solution = gitBranchesArr[i].replaceAll(".*?${origin}", "").trim()
+	for (i = 0; i < gitBranchesArray.length; i++) {
+		if (gitBranchesArray[i].contains(origin)) {
+			solution = gitBranchesArray[i].replaceAll(".*?${origin}", "").trim()
 		}
 	}
 

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -78,7 +78,7 @@ def getCurrentGitDetachedBranch(String gitDir) {
 	// expecting references with "origin" as segment
 	def origin = "origin/"
 	if (gitBranchArr.count {it.contains(origin)}  > 1 ) {
-		String warningMsg = "*? (GitUtils.getCurrentGitDetachedBranch) Warning obtaining branch name for ($dir). Multiple references point to the same commit. ($gitBranchArr)"
+		String warningMsg = "*! (GitUtils.getCurrentGitDetachedBranch) Warning obtaining branch name for ($dir). Multiple references point to the same commit. ($gitBranchArr)"
 		println(warningMsg)
 		updateBuildResult(warningMsg:warningMsg)
 	}
@@ -93,7 +93,7 @@ def getCurrentGitDetachedBranch(String gitDir) {
 	if (solution != "") { // return branch name
 		return solution
 	} else {
-		String errorMsg = "*! Error parsing branch name: $gitBranch"
+		String errorMsg = "*! (GitUtils.getCurrentGitDetachedBranch) Error extracting current branch name: $gitBranch. Expects a origin/ segment."
 		println(errorMsg)
 		props.error = "true"
 		updateBuildResult(errorMsg:errorMsg)

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -75,13 +75,29 @@ def getCurrentGitDetachedBranch(String gitDir) {
 	String gitBranchString = gitBranch.toString()
 	def gitBranchArr = gitBranchString.split(',')
 	def solution = ""
+	// expecting references with "origin" as segment
+	def origin = "origin/"
+	if (gitBranchArr.count {it.contains(origin)}  > 1 ) {
+		String warningMsg = "*? (GitUtils.getCurrentGitDetachedBranch) Warning obtaining branch name for ($dir). Multiple references point to the same commit. ($gitBranchArr)"
+		println(warningMsg)
+		updateBuildResult(warningMsg:warningMsg)
+	}
+
+	// substring the branch name
 	for (i = 0; i < gitBranchArr.length; i++) {
-		if (gitBranchArr[i].contains("origin/")) {
-			solution = gitBranchArr[i].replaceAll(".*?/", "").trim()
+		if (gitBranchArr[i].contains(origin)) {
+			solution = gitBranchArr[i].replaceAll(".*?${origin}", "").trim()
 		}
 	}
 
-	return (solution != "") ? solution : println("*! Error parsing branch name: $gitBranch")
+	if (solution != "") { // return branch name
+		return solution
+	} else {
+		String errorMsg = "*! Error parsing branch name: $gitBranch"
+		println(errorMsg)
+		props.error = "true"
+		updateBuildResult(errorMsg:errorMsg)
+	}
 }
 
 /*


### PR DESCRIPTION
This is addressing the reported issue #432 

Enhancement contains:

* Message a warning if multiple references are found #143
* Flag the build as `error` if the branch name could not be obtained.