### PR TITLE
Document the zAppBuild and DBB Toolkit versions in build log and build result

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -98,8 +98,14 @@ def initializeBuildProcess(String[] args) {
 	def dbbToolkitVersion = VersionInfo.getInstance().getVersion()
 	props.dbbToolkitVersion = dbbToolkitVersion
 	def dbbToolkitBuildDate = VersionInfo.getInstance().getDate()
-	if (props.verbose) println "** zAppBuild running on DBB Toolkit Version ${dbbToolkitVersion} ${dbbToolkitBuildDate} "
 	
+	File versionFile = new File("${props.zAppBuildDir}/version.properties")
+	if (versionFile.exists()) {
+		props.load(versionFile)
+		if (props.zappbuild_version) println "** Running zAppBuild Version ${props.zappbuild_version} "
+	}
+	if (props.verbose) println "** Running DBB Toolkit Version ${dbbToolkitVersion} ${dbbToolkitBuildDate} "
+
 	// verify required dbb toolkit
 	buildUtils.assertDbbBuildToolkitVersion(props.dbbToolkitVersion, props.requiredDBBToolkitVersion)
 

--- a/build.groovy
+++ b/build.groovy
@@ -96,8 +96,9 @@ def initializeBuildProcess(String[] args) {
 	
 	// print and store property dbb toolkit version in use
 	def dbbToolkitVersion = VersionInfo.getInstance().getVersion()
-	props.dbbToolkitVersion = dbbToolkitVersion
 	def dbbToolkitBuildDate = VersionInfo.getInstance().getDate()
+	props.dbbToolkitVersion = dbbToolkitVersion
+	props.dbbToolkitBuildDate = dbbToolkitBuildDate
 	
 	File versionFile = new File("${props.zAppBuildDir}/version.properties")
 	if (versionFile.exists()) {
@@ -728,7 +729,10 @@ def finalizeBuildProcess(Map args) {
 		buildResult.setProperty("filesProcessed", String.valueOf(args.count))
 		buildResult.setState(buildResult.COMPLETE)
 
-
+		// add zAppBuild and DBB toolkit version info
+		if (props.zappbuild_version) buildResult.setProperty("zAppBuildVersion", props.zappbuild_version)
+		buildResult.setProperty("DBBToolkitVersion" , "${props.dbbToolkitVersion} ${props.dbbToolkitBuildDate}")
+		
 		// store build result properties in BuildReport.json
 		PropertiesRecord buildReportRecord = new PropertiesRecord("DBB.BuildResultProperties")
 		def buildResultProps = buildResult.getPropertyNames()

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,13 @@
-version=3.5.0
+# internal zAppbuild version number that is bumped up for each new release
+# delivered via the public github repository 
+# https://github.com/IBM/dbb-zappbuild.
+# Helps to understand from which version a copy was taken.
+zappbuild_baseVersion=3.6.0
+
+# use this property to add you own version suffix to indicate 
+# contributed enhancements and your own revisions
+zappbuild_customVersion=BASE
+
+# zappbuild version string that is  
+# combining the base and custom version properties 
+zappbuild_version=${zappbuild_baseVersion}-${zappbuild_customVersion}


### PR DESCRIPTION
Capture the zAppBuild and DBB Toolkit version in the build log and build result, to understand the state of the build framework that was used to build the binaries. 