### PR TITLE
Add configuration options for IMS batch and online programs

### DIFF
--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -458,6 +458,9 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	if (buildUtils.isCICS(logicalFile))
 		linkedit.dd(new DDStatement().dsn(props.SDFHLOAD).options("shr"))
 
+	if (buildUtils.isIMS(logicalFile))
+		linkedit.dd(new DDStatement().dsn(props.SDFSRESL).options("shr"))
+		
 	if (buildUtils.isSQL(logicalFile))
 		linkedit.dd(new DDStatement().dsn(props.SDSNLOAD).options("shr"))
 

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -384,6 +384,9 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	if (buildUtils.isCICS(logicalFile))
 		linkedit.dd(new DDStatement().dsn(props.SDFHLOAD).options("shr"))
 	
+	if (buildUtils.isIMS(logicalFile))
+		linkedit.dd(new DDStatement().dsn(props.SDFSRESL).options("shr"))
+			
 	if (buildUtils.isSQL(logicalFile))
 		linkedit.dd(new DDStatement().dsn(props.SDSNLOAD).options("shr"))
 

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -109,13 +109,16 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 		linkedit.dd(new DDStatement().dsn(syslibDataset).options("shr"))
 	}
 	linkedit.dd(new DDStatement().dsn(props.SCEELKED).options("shr"))
-
+	
 	if (props.debug && props.SEQAMOD)
 		linkedit.dd(new DDStatement().dsn(props.SEQAMOD).options("shr"))
 
-	if (props.SDFHLOAD)
+	if (buildUtils.isCICS(logicalFile)
 		linkedit.dd(new DDStatement().dsn(props.SDFHLOAD).options("shr"))
-	
+
+	if (buildUtils.isIMS(logicalFile))
+		linkedit.dd(new DDStatement().dsn(props.SDFSRESL).options("shr"))
+			
 	if (props.SDSNLOAD)
 		linkedit.dd(new DDStatement().dsn(props.SDSNLOAD).options("shr"))
 

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -129,6 +129,7 @@ def createPLIParms(String buildFile, LogicalFile logicalFile) {
 	def parms = props.getFileProperty('pli_compileParms', buildFile) ?: ""
 	def cics = props.getFileProperty('pli_compileCICSParms', buildFile) ?: ""
 	def sql = props.getFileProperty('pli_compileSQLParms', buildFile) ?: ""
+	def ims = props.getFileProperty('pli_compileIMSParms', buildFile) ?: ""
 	def errPrefixOptions = props.getFileProperty('pli_compileErrorPrefixParms', buildFile) ?: ""
 	def compileDebugParms = props.getFileProperty('pli_compileDebugParms', buildFile)
 
@@ -142,6 +143,9 @@ def createPLIParms(String buildFile, LogicalFile logicalFile) {
 	if (props.errPrefix)
 		parms = "$parms,$errPrefixOptions"
 
+	if (buildUtils.isIMS(logicalFile))	
+		parms = "$parms,$ims"
+		
 	// add debug options
 	if (props.debug)  {
 		parms = "$parms,$compileDebugParms"

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -355,6 +355,9 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	if (buildUtils.isCICS(logicalFile))
 		linkedit.dd(new DDStatement().dsn(props.SDFHLOAD).options("shr"))
 
+	if (buildUtils.isIMS(logicalFile))
+		linkedit.dd(new DDStatement().dsn(props.SDFSRESL).options("shr"))
+		
 	if (buildUtils.isSQL(logicalFile))
 		linkedit.dd(new DDStatement().dsn(props.SDSNLOAD).options("shr"))
 

--- a/samples/application-conf/Assembler.properties
+++ b/samples/application-conf/Assembler.properties
@@ -79,6 +79,10 @@ assembler_deployTypeCICS=CICSLOAD
 assembler_deployTypeDLI=IMSLOAD
 
 #
+# deployType for build files with isIMS=true
+assembler_deployTypeIMS=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 assembler_scanLoadModule=true

--- a/samples/application-conf/Cobol.properties
+++ b/samples/application-conf/Cobol.properties
@@ -86,6 +86,10 @@ cobol_deployTypeCICS=CICSLOAD
 cobol_deployTypeDLI=IMSLOAD
 
 #
+# deployType for build files with isIMS=true
+cobol_deployTypeIMS=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 cobol_scanLoadModule=true

--- a/samples/application-conf/LinkEdit.properties
+++ b/samples/application-conf/LinkEdit.properties
@@ -44,6 +44,13 @@ linkedit_deployTypeCICS=CICSLOAD
 linkedit_deployTypeDLI=IMSLOAD
 
 #
+# deployType for build files with isIMS=true set in file properties
+#  DBB scanners cannot determine the file tags for linkcards automatically,
+#  requires the flag to be set via a file property
+#  e.q isIMS = true :: **/link/epsmlist.lnk
+linkedit_deployTypeIMS=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 linkedit_scanLoadModule=true

--- a/samples/application-conf/PLI.properties
+++ b/samples/application-conf/PLI.properties
@@ -35,6 +35,7 @@ pli_compileCICSParms=SYSTEM(CICS),PP(MACRO,CICS)
 pli_compileSQLParms=PP(SQL)
 pli_compileErrorPrefixParms=XINFO(XML)
 pli_compileDebugParms=TEST
+pli_compileIMSParms=SYSTEM(IMS)
 
 #
 # default LinkEdit parameters

--- a/samples/application-conf/PLI.properties
+++ b/samples/application-conf/PLI.properties
@@ -84,6 +84,10 @@ pli_deployTypeCICS=CICSLOAD
 pli_deployTypeDLI=IMSLOAD
 
 #
+# deployType for build files with isIMS=true
+pli_deployTypeIMS=IMSLOAD
+
+#
 # scan link edit load module for link dependencies
 # can be overridden by file properties
 pli_scanLoadModule=true

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -176,6 +176,7 @@ pli_compileParms | Default base compile parameters. | true
 pli_compileCICSParms | Default CICS compile parameters. Appended to base parameters if has value.| true
 pli_compileSQLParms | Default SQL compile parameters. Appended to base parameters if has value. | true
 pli_compileDebugParms | Default Debug compile parameters. Appended to base parameters if running with debug flag set. | true
+pli_compileIMSParms | Default IMS compile parameters. Appended to parms for file with `isIMS` flag turned on. | true
 pli_compileErrorPrefixParms | IDz user build parameters. Appended to base parameters if has value. | true
 pli_impactPropertyList | List of build properties causing programs to rebuild when changed | false
 pli_impactPropertyListCICS | List of CICS build properties causing programs to rebuild when changed | false

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -40,11 +40,19 @@ Property | Description
 --- | ---
 dbb.scriptMapping | DBB configuration file properties association build files to language scripts
 dbb.scannerMapping | zAppBuild configuration override/expansion to map files extensions to DBB dependency scanner configurations
-isSQL | File property overwrite to indicate that a file requires to include SQL parameters
-isCICS | File property overwrite to indicate that a file requires to include CICS parameters
-isMQ | File property overwrite to indicate that a file requires to include MQ parameters
-isDLI | File property overwrite to indicate that a file requires to include DLI parameters
 cobol_testcase | File property to indicate a generated zUnit cobol test case to use a different set of source and output libraries
+
+General file level overwrites to control the allocations of system datasets for compile and link steps or activation of preprocessing
+
+Property | Description
+--- | ---
+isSQL | File property overwrite to indicate that a file requires to include SQL preprocessing, and allocation of Db2 libraries for compile and link phase.
+isCICS | File property overwrite to indicate that a file requires to include CICS preprocessing, and allocation of CICS libraries for compile and link phase. Also used to indicate if a *batch* module is executed under CICS for pulling appropriate language interface modules for Db2 or MQ. 
+isMQ | File property overwrite to indicate that a file requires to include MQ libraries for compile and link phase.
+isDLI | File property overwrite to indicate that a file requires to include DLI 
+isIMS | File property flag to indicate IMS batch and online programs to allocate the IMS RESLIB library during link phase (Compared to the other 4 above flags, the isIMS flag is a pure file property, and not computed by the DBB scanners). 
+
+Please note that the above file property settings `isCICS` and `isIMS` are also used to control the allocations when processing link cards with `LinkEdit.groovy` to include the appropriate runtime specific language interfaces.
 
 ### reports.properties
 Properties used by the build framework to generate reports. Sample properties file to all application-conf to overwrite central build-conf configuration.

--- a/samples/application-conf/file.properties
+++ b/samples/application-conf/file.properties
@@ -37,13 +37,51 @@ dbb.scriptMapping = CRB.groovy :: **/crb/*.yaml
 # dbb.scannerMapping = "scannerClass":"DependencyScanner", "languageHint":"PLI" :: pli, inc
 # dbb.scannerMapping = "scannerClass":"ZUnitConfigScanner" :: bzucfg
 
-#
+####
 # General file level overwrites through DBB Build Properties
-# isCICS = true :: **/cobol/member.cbl
-# isSQL = true :: **/cobol/member.cbl
-# isMQ = true :: **/cobol/member.cbl
+# to control the allocations of system datasets for compile and link steps
+# or activation of preprocessing
 
+# isCICS - boolean flag indicating that the process for the module requires the
+# CICS libraries, source code needs preprocessing 
 #
+# flag is set by the DBB scanner if it detects EXEC CICS statements.
+# 
+# Override the flag for source code or linkcards that are executed in a CICS environment
+#  to enable proprocessing and to resolve appropriate language interface module
+#  
+isCICS = true :: **/cobol/member.cbl
+
+# isSQL - boolean flag indicating that the process for the module requires the
+# Db2 libraries, source code needs preprocessing 
+#
+# flag is set by the DBB scanner if it detects SQL statements.
+# 
+isSQL = true :: **/cobol/member.cbl
+
+# isMQ - boolean flag indicating that the process for the module requires the
+# MQ libraries got compile and link steps and to generate the
+# MQ stub instructions for the link phase based on the flags
+# isCICS, isDLI and isIMS (except the LinkEdit.groovy)
+#
+# flag is set by the DBB scanner if it detects MQ calls.
+#
+# Override the flag to force adding 
+#
+isMQ = true :: **/cobol/member.cbl
+
+# isIMS - indicating that the process for the module requires the
+# IMS libraries in the link phase. Applicable for
+#  DL/I batch programs
+#  IMS online programs 
+#
+# flag is NOT set by the DBB scanner.
+#
+# Set the flag for source code or link cards
+#  to resolve appropriate IMS language interface module (DFSLI000) 
+#  
+isIMS = true :: **/cobol/DLIBATCH.cbl
+
 # Please check for available file property overwrites within samples/application-conf/README.md
 
 #

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -411,6 +411,18 @@ def isMQ(LogicalFile logicalFile) {
 }
 
 /*
+ * isIMS - tests to see if the program is a DL/I program. If the logical file is false, then
+ * check to see if there is a file property.
+ */
+def isIMS(LogicalFile logicalFile) {
+	isIMS = false
+	String imsFlag = props.getFileProperty('isIMS', logicalFile.getFile())
+	if (imsFlag)
+		isIMS = imsFlag.toBoolean()
+	return isIMS
+}
+
+/*
  * getMqStubInstruction -
  *  returns include defintion for mq sub program for link edit
  */
@@ -421,7 +433,7 @@ def getMqStubInstruction(LogicalFile logicalFile) {
 		// https://www.ibm.com/docs/en/ibm-mq/9.3?topic=files-mq-zos-stub-programs
 		if (isCICS(logicalFile)) {
 			mqStubInstruction = "   INCLUDE SYSLIB(CSQCSTUB)\n"
-		} else if (isDLI(logicalFile)) {
+		} else if (isDLI(logicalFile) || isIMS(logicalFile)) {
 			mqStubInstruction = "   INCLUDE SYSLIB(CSQQSTUB)\n"
 		} else {
 			mqStubInstruction = "   INCLUDE SYSLIB(CSQBSTUB)\n"
@@ -558,6 +570,9 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 			} else if (isDLI(logicalFile)){
 				String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)
 				if (dliDeployType != null) deployType = dliDeployType
+			} if (isIMS(logicalFile)){
+				String imsDeployType = props.getFileProperty("${langQualifier}_deployTypeIMS", buildFile)
+				if (imsDeployType != null) deployType = imsDeployType
 			}
 		}
 	} else{

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -554,7 +554,8 @@ def retrieveLastBuildResult(){
 }
 
 /*
- * returns the deployType for a logicalFile depending on the isCICS, isDLI setting
+ * returns the deployType for a logicalFile depending on the
+ * isCICS, isIMS and isDLI setting
  */
 def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFile){
 	// getDefault
@@ -567,12 +568,12 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 			if(isCICS(logicalFile)){ // if CICS
 				String cicsDeployType = props.getFileProperty("${langQualifier}_deployTypeCICS", buildFile)
 				if (cicsDeployType != null) deployType = cicsDeployType
+			} else if (isIMS(logicalFile)){
+				String imsDeployType = props.getFileProperty("${langQualifier}_deployTypeIMS", buildFile)
+				if (imsDeployType != null) deployType = imsDeployType
 			} else if (isDLI(logicalFile)){
 				String dliDeployType = props.getFileProperty("${langQualifier}_deployTypeDLI", buildFile)
 				if (dliDeployType != null) deployType = dliDeployType
-			} if (isIMS(logicalFile)){
-				String imsDeployType = props.getFileProperty("${langQualifier}_deployTypeIMS", buildFile)
-				if (imsDeployType != null) deployType = imsDeployType
 			}
 		}
 	} else{


### PR DESCRIPTION
This PR is addressing #452 .

For IMS batch or online programs, the DBB scanners don't detect any file attributes.

This PR is adding

* a new file property `isIMS` that is used to control the allocation of the DFSRESL library in the SYLSIB for the link phase in Assembler, Cobol, PLI  and LinkEdit language processors from where the linkage editor will pick up the appropriate language/runtime interfaces modules for Db2, DLI calls (primarily DFSLI000).

* The deployTypes settings are extended to define the deployType for programs with the isIMS flag turned on.

* Explanations of the file flags extended.