### PR TITLE
Validate prerequisites of reporting capabilities

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -662,7 +662,8 @@ def createBuildList() {
 	}
 	
 	// Perform analysis and build report of external impacts
-	if (props.reportExternalImpacts && props.reportExternalImpacts.toBoolean()){
+	// Prereq: Metadatastore Connection
+	if (metadataStore && props.reportExternalImpacts && props.reportExternalImpacts.toBoolean()){
 		if (buildSet && changedFiles) {
 			println "** Perform analysis and reporting of external impacted files for the build list including changed files."
 			reportingUtils.reportExternalImpacts(buildSet.plus(changedFiles))
@@ -674,7 +675,8 @@ def createBuildList() {
 	}
 	
 	// Document and validate concurrent changes
-	if (props.reportConcurrentChanges && props.reportConcurrentChanges.toBoolean()){
+	// Prereq: Workspace containing git repos. Skipped for --userBuild build type
+	if (!props.userBuild && props.reportConcurrentChanges && props.reportConcurrentChanges.toBoolean()){
 		println "** Calculate and document concurrent changes."
 		reportingUtils.calculateConcurrentChanges(buildSet)
 	}

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -194,13 +194,15 @@ def calculateConcurrentChanges(Set<String> buildSet) {
 	
 		// initialize patterns
 		List<Pattern> gitRefMatcherPatterns = createMatcherPatterns(props.reportConcurrentChangesGitBranchReferencePatterns)
-	
+		
 		// obtain all current remote branches
 		// TODO: Handle / Exclude branches from other repositories
 		Set<String> remoteBranches = new HashSet<String>()
 		props.applicationSrcDirs.split(",").each { dir ->
 			dir = buildUtils.getAbsolutePath(dir)
-			remoteBranches.addAll(gitUtils.getRemoteGitBranches(dir))
+			if (gitUtils.isGitDir(dir)) {
+				remoteBranches.addAll(gitUtils.getRemoteGitBranches(dir))
+			}
 		}
 		
 		// Run analysis for each remoteBranch, which matches the configured criteria


### PR DESCRIPTION
This is implementing #455 and provides a more robust way when the build admin has centrally activated the reporting capabilities.

