### PR TITLE
Missing sortBuildMap function for language script zCEE2

### DIFF
--- a/build-conf/zCEE2.properties
+++ b/build-conf/zCEE2.properties
@@ -2,7 +2,7 @@
 
 #
 # Comma separated list of required build properties for zCEE3.groovy
-zcee2_requiredBuildProperties=zcee2_zconbtPath,zcee2_JAVA_HOME
+zcee2_requiredBuildProperties=zcee2_zconbtPath
 
 #
 # Absolute path to zconbt executable on z/OS UNIX System Services
@@ -12,6 +12,7 @@ zcee2_zconbtPath=
 #
 # Java installation used by the zconbt utility
 # for instance: /usr/lpp/java/J8.0_64
+# if not set, the value of the JAVA_HOME environment variable will be used
 zcee2_JAVA_HOME=
 
 #

--- a/languages/zCEE2.groovy
+++ b/languages/zCEE2.groovy
@@ -122,15 +122,15 @@ sortedList.each { buildFile, inputType ->
         StringBuffer shellOutput = new StringBuffer()
         StringBuffer shellError = new StringBuffer()
 
-        String JAVA_HOME = props.getFileProperty('zcee2_JAVA_HOME', buildFile)
-        if (!JAVA_HOME) {
-            JAVA_HOME = System.getenv("JAVA_HOME")
+        String javaHome = props.getFileProperty('zcee2_JAVA_HOME', buildFile)
+        if (!javaHome) {
+            javaHome = System.getenv("JAVA_HOME")
         }
 
         ProcessBuilder cmd = new ProcessBuilder(zconbtPath, parameters);
         Map<String, String> env = cmd.environment();
-        env.put("JAVA_HOME", JAVA_HOME);
-        env.put("PATH", JAVA_HOME + "/bin" + ":" + env.get("PATH"))
+        env.put("JAVA_HOME", javaHome);
+        env.put("PATH", javaHome + "/bin" + ":" + env.get("PATH"))
         Process process = cmd.start()
         process.consumeProcessOutput(shellOutput, shellError)
         process.waitFor()

--- a/languages/zCEE2.groovy
+++ b/languages/zCEE2.groovy
@@ -15,7 +15,7 @@ import java.nio.file.*;
 buildUtils.assertBuildProperties(props.zcee2_requiredBuildProperties)
 
 // create updated build map, removing duplicates in case of PROJECT input Type
-HashMap<String, String> updatedBuildMap = new HashMap<String, String>()
+HashMap<String, String> updatedBuildList = new HashMap<String, String>()
 
 println("** Streamlining the build list to remove duplicates")
 argMap.buildList.each { buildFile ->
@@ -36,27 +36,27 @@ argMap.buildList.each { buildFile ->
                 }
             }
             if (projectDirFound) {
-                updatedBuildMap.put(projectDir.getPath(), "PROJECT")
+                updatedBuildList.putIfAbsent(projectDir.getPath(), "PROJECT")
             } else {
                 if (props.verbose) println("!* No project directory found for file '${buildFile}'. Skipping...")
             }
         } else {
-            updatedBuildMap.put(buildFile, inputType);
+            updatedBuildList.put(buildFile, inputType);
         }
     } else {
         println("!* No Input Type mapping for file ${buildFile}, skipping it...")
     }
 }
 
-println("** Building ${updatedBuildMap.size()} API ${updatedBuildMap.size() == 1 ? 'definition' : 'definitions'} mapped to ${this.class.getName()}.groovy script")
+println("** Building ${updatedBuildList.size()} API ${updatedBuildList.size() == 1 ? 'definition' : 'definitions'} mapped to ${this.class.getName()}.groovy script")
 // sort the build list based on build file rank if provided
-HashMap<String, String> sortedMap = buildUtils.sortBuildMap(updatedBuildMap, 'zcee2_fileBuildRank')
+HashMap<String, String> sortedList = buildUtils.sortBuildListAsMap(updatedBuildList, 'zcee2_fileBuildRank')
 
 int currentBuildFileNumber = 1
 
 // iterate through build list
-sortedMap.each { buildFile, inputType ->
-    println "*** (${currentBuildFileNumber++}/${sortedMap.size()}) Building ${inputType == "PROJECT" ? 'project' : 'properties file'} $buildFile"
+sortedList.each { buildFile, inputType ->
+    println "*** (${currentBuildFileNumber++}/${sortedList.size()}) Building ${inputType == "PROJECT" ? 'project' : 'properties file'} $buildFile"
 
     String parameters = ""
     String outputDir = ""

--- a/languages/zCEE2.groovy
+++ b/languages/zCEE2.groovy
@@ -123,11 +123,14 @@ sortedList.each { buildFile, inputType ->
         StringBuffer shellError = new StringBuffer()
 
         String JAVA_HOME = props.getFileProperty('zcee2_JAVA_HOME', buildFile)
+        if (!JAVA_HOME) {
+            JAVA_HOME = System.getenv("JAVA_HOME")
+        }
 
         ProcessBuilder cmd = new ProcessBuilder(zconbtPath, parameters);
         Map<String, String> env = cmd.environment();
         env.put("JAVA_HOME", JAVA_HOME);
-        env.put("PATH", JAVA_HOME + "/bin" + ";" + env.get("PATH"))
+        env.put("PATH", JAVA_HOME + "/bin" + ":" + env.get("PATH"))
         Process process = cmd.start()
         process.consumeProcessOutput(shellOutput, shellError)
         process.waitFor()

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -286,9 +286,9 @@ def sortBuildList(List<String> buildList, String rankPropertyName) {
 }
 
 /*
- * sortBuildMap - sorts a build Map by rank property values
+ * sortBuildListAsMap - sorts a build List stored as Map by rank property values
  */
-def sortBuildMap(HashMap<String, String> buildMap, String rankPropertyName) {
+def sortBuildListAsMap(HashMap<String, String> buildMap, String rankPropertyName) {
 	HashMap<String, String> sortedMap = [:]
 	TreeMap<Integer,HashMap<String, String>> rankings = new TreeMap<Integer,HashMap<String, String>>()
 	HashMap<String, String> unranked = new HashMap<String, String>()

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -286,6 +286,43 @@ def sortBuildList(List<String> buildList, String rankPropertyName) {
 }
 
 /*
+ * sortBuildMap - sorts a build Map by rank property values
+ */
+def sortBuildMap(HashMap<String, String> buildMap, String rankPropertyName) {
+	HashMap<String, String> sortedMap = [:]
+	TreeMap<Integer,HashMap<String, String>> rankings = new TreeMap<Integer,HashMap<String, String>>()
+	HashMap<String, String> unranked = new HashMap<String, String>()
+
+	// sort buildFiles by rank
+	buildMap.each { buildFile, inputType ->
+		String rank = props.getFileProperty(rankPropertyName, buildFile)
+		if (rank) {
+			Integer rankNum = rank.toInteger()
+			HashMap<String, String> ranking = rankings.get(rankNum)
+			if (!ranking) {
+				ranking = new HashMap<String, String>()
+				rankings.put(rankNum, ranking)
+			}
+			ranking.put(buildFile, inputType)
+		} else {
+			unranked.put(buildFile, inputType)
+		}
+	}
+
+	// loop through rank keys adding sub lists (TreeMap automatically sorts keySet)
+	rankings.keySet().each { key ->
+		HashMap<String, String> ranking = rankings.get(key)
+		if (ranking)
+			sortedMap.putAll(ranking)
+	}
+
+	// finally add unranked buildFiles
+	sortedMap.putAll(unranked)
+
+	return sortedMap
+}
+
+/*
  * updateBuildResult - used by language scripts to update the build result after a build step
  */
 def updateBuildResult(Map args) {


### PR DESCRIPTION
Fixing the z/OS Connect EE 2 processing, where the sortBuildMap() function is used but is missing from the BuildUtilities.groovy script.