### PR TITLE
Implement Syntax rules for really long IDENTIFY statements

### DIFF
--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -898,7 +898,6 @@ def generateIdentifyStatement(String buildFile, String dsProperty) {
 		String shortGitHash = getShortGitHash(buildFile)
 
 		if (shortGitHash != null) {
-
 			String identifyString = props.application + "/" + shortGitHash
 			//   IDENTIFY EPSCSMRT('MortgageApplication/abcabcabc')
 			identifyStmt = "  " + "IDENTIFY ${member}(\'$identifyString\')"
@@ -909,6 +908,12 @@ def generateIdentifyStatement(String buildFile, String dsProperty) {
 				updateBuildResult(errorMsg:errorMsg)
 				return null
 			} else {
+				// Split IDENTIFY after col 71
+				// See syntax rules: https://www.ibm.com/docs/en/zos/3.1.0?topic=reference-identify-statement
+				identifyString = " IDENTIFY EPSCSMRT('MortgageApplicationMortgageApplicationMortgageApp/abcabcabc')"
+				if (identifyString.length() > 71) {
+					identifyString = identifyString.substring(0,71) + "\n " + identifyString.substring(71,identifyString.length())
+				}
 				return identifyStmt
 			}
 		} else {

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -900,20 +900,19 @@ def generateIdentifyStatement(String buildFile, String dsProperty) {
 		if (shortGitHash != null) {
 			String identifyString = props.application + "/" + shortGitHash
 			//   IDENTIFY EPSCSMRT('MortgageApplication/abcabcabc')
-			identifyStmt = "  " + "IDENTIFY ${member}(\'$identifyString\')"
+			identifyStmt = " " + "IDENTIFY ${member}(\'$identifyString\')"
 			if (identifyString.length() > maxRecordLength) {
 				String errorMsg = "*!* BuildUtilities.generateIdentifyStatement() - Identify string exceeds $maxRecordLength chars: identifyStmt=$identifyStmt"
 				println(errorMsg)
 				props.error = "true"
 				updateBuildResult(errorMsg:errorMsg)
 				return null
-			} else {
-				// Split IDENTIFY after col 71
-				// See syntax rules: https://www.ibm.com/docs/en/zos/3.1.0?topic=reference-identify-statement
-				identifyStmt = " IDENTIFY EPSCSMRT('MortgageApplicationMortgageApplicationMortgageApp/abcabcabc')"
-				if (identifyStmt.length() > 71) {
+			} else { 
+				if (identifyStmt.length() > 71) { // Split IDENTIFY after col 71
+					// See syntax rules: https://www.ibm.com/docs/en/zos/3.1.0?topic=reference-identify-statement
 					identifyStmt = identifyStmt.substring(0,71) + "\n " + identifyStmt.substring(71,identifyStmt.length())
 				}
+				// return generated IDENTIFY statement
 				return identifyStmt
 			}
 		} else {

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -910,9 +910,9 @@ def generateIdentifyStatement(String buildFile, String dsProperty) {
 			} else {
 				// Split IDENTIFY after col 71
 				// See syntax rules: https://www.ibm.com/docs/en/zos/3.1.0?topic=reference-identify-statement
-				identifyString = " IDENTIFY EPSCSMRT('MortgageApplicationMortgageApplicationMortgageApp/abcabcabc')"
-				if (identifyString.length() > 71) {
-					identifyString = identifyString.substring(0,71) + "\n " + identifyString.substring(71,identifyString.length())
+				identifyStmt = " IDENTIFY EPSCSMRT('MortgageApplicationMortgageApplicationMortgageApp/abcabcabc')"
+				if (identifyStmt.length() > 71) {
+					identifyStmt = identifyStmt.substring(0,71) + "\n " + identifyStmt.substring(71,identifyStmt.length())
 				}
 				return identifyStmt
 			}


### PR DESCRIPTION
This is implementing #479 for really long identify statements.

The generated IDENTIFY statement is split after column 71. Here is a sample output:
```
Return code 4
1z/OS V2 R5 BINDER     13:20:34 WEDNESDAY MARCH  6, 2024
 BATCH EMULATOR  JOB(DBEHM7  ) STEP(*OMVSEX ) PGM= IEWBLINK
 IEW2278I B352 INVOCATION PARAMETERS - MAP,RENT,COMPAT(PM5),SSI=9efa35a4
 IEW2322I 1220  1    IDENTIFY EPSCSMRT('MortgageApplicationMortgageApplicationMortgageApp/a
 IEW2322I 1220  2    bcabcabc')
```