### PR TITLE
Correction of folder validation

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -354,15 +354,14 @@ def populateBuildProperties(def opts) {
 	// assert workspace
 	buildUtils.assertBuildProperties('workspace,outDir')
 
-	// validate tht workspace and outDir folders exist
-	[props.workspace, props.outDir].each { workDirectory ->
-		if (!(new File (workDirectory).exists())) {
-			println "!! The specified folder $workDirectory does not exist. Build exits."
-			System.exit(1)
-		}
+	// Validate that workspace exists 
+	if (!(new File (props.workspace).exists())) {
+		println "!! The specified workspace folder ${props.workspace} does not exist. Build exits."
+		System.exit(1)
 	}
 	
-	if (!(new File(props.outDir).canWrite())) {
+	// Check read/write permission of specified out/log dir if already existing 
+	if (new File (props.outDir).exists() && !(new File(props.outDir).canWrite())) {
 		println "!! User does not have WRITE permission to work output directory ${props.outDir}. Build exits."
 		System.exit(1)
 	}


### PR DESCRIPTION
Previous implementation was too rigid about the `outDir` for the log files. It was only tested on user builds with an existing out dir, but the build scripts will try to allocate the directory anyway later on.

