### PR TITLE
Undefined variable in test script resetBuild

### DIFF
--- a/test/testScripts/resetBuild.groovy
+++ b/test/testScripts/resetBuild.groovy
@@ -4,6 +4,7 @@ import com.ibm.dbb.*
 import com.ibm.dbb.build.*
 
 @Field BuildProperties props = BuildProperties.getInstance()
+@Field def assertionList = []
 
 println "\n**************************************************************"
 println "** Executing test script ${this.class.getName()}.groovy"


### PR DESCRIPTION
The resetBuild script missed the declaration of the assertionList in the Exception clause. 