### PR TITLE
Handle unknown cli parameters

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -251,7 +251,7 @@ If buildFile is a text file (*.txt) then it is assumed to be a build list file.
 options:
 	'''
 
-	def cli = new CliBuilder(usage:usage,header:header)
+	def cli = new CliBuilder(usage:usage,header:header,stopAtNonOption: false)
 	// required sandbox options
 	cli.w(longOpt:'workspace', args:1, 'Absolute path to workspace (root) directory containing all required source directories')
 	cli.a(longOpt:'application', args:1, required:true, 'Application directory name (relative to workspace)')


### PR DESCRIPTION
If a user is accidentally adding a wrong cli parameter, such as a simple typo `--userbuild` instead of `--userBuild` to the cli gets confused, and might pass in arguments as a build list.

With this change, the build will throw a below error message:

```
cd /u/dbehm/userBuild

$DBB_HOME/bin/groovyz /u/dbehm/userBuild/zAppBuild/build.groovy --sourceDir /u/dbehm/userBuild --workDir /u/dbehm/userBuild/work --hlq DBEHM.UB --application MortgageApplication --verbose --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/test.properties --propOverwrite formatConsoleOutput=false -re --fullbuild wrong opt --errPrefix U2291421 --userBuild  MortgageApplication/cobol/epsnbrvl.cbl
/u/dbehm/userBuild>



** Build start at 20240313.133416.980
**************** Initialization of the build process ****************

error: Unrecognized option: --fullbuild

usage: build.groovy [options] buildfile
buildFile (optional):  Path of the file to build. If buildFile is a text
file (*.txt) then it is assumed to be a build list file.
options:


 -a,--application <arg>           Application directory name (relative to
                                  workspace)
 -b,--baselineRef <arg>           Comma seperated list of git references
                                  to overwrite the baselineHash hash in an
                                  impactBuild scenario.
 -cc,--ccczUnit                   Flag to indicate to collect code
                                  coverage reports during zUnit step
 -cch,--cccHost <cccHost>         Headless Code Coverage Collector host
                                  (if not specified IDz will be used for
                                  reporting)
 -cco,--cccOptions <cccOptions>   Headless Code Coverage Collector Options
 -ccp,--cccPort <cccPort>         Headless Code Coverage Collector port
                                  (if not specified IDz will be used for
                                  reporting)
 -cd,--checkDatasets              Optional flag to validate the presense
                                  of the defined system datasets.
 -d,--debug                       Flag to indicate a build for debugging
 -df,--dependencyFile <arg>       Absolute or relative (from workspace)
                                  path to user build JSON file containing
                                  dependency information.
 -dz,--debugzUnitTestcase         Flag to indicate if zUnit Tests should
                                  launch a debug session
 -e,--errPrefix <arg>             Unique id used for IDz error message
                                  datasets
 -f,--fullBuild                   Flag indicating to build all programs
                                  for application
 -h,--hlq <arg>                   High level qualifier for partition data
                                  sets
 -help,--help                     Prints this message
 -i,--impactBuild                 Flag indicating to build only programs
                                  impacted by changed files since last
                                  successful build.
 -id,--id <arg>                   Db2 user id for the MetadataStore
 -l,--logEncoding <arg>           Encoding of output logs. Default is
                                  EBCDIC
 -m,--mergeBuild                  Flag indicating to build only changes
                                  which will be merged back to the
                                  mainBuildBranch.
 -o,--outDir <arg>                Absolute path to the build output root
                                  directory
 -p,--propFiles <arg>             Comma separated list of additional
                                  property files to load. Absolute paths
                                  or relative to workspace.
 -pf,--pwFile <arg>               Absolute or relative (from workspace)
                                  path to file containing Db2 password
 -po,--propOverwrites <arg>       Comma separated list of key=value pairs
                                  for set and overwrite build properties.
 -pv,--preview                    Supplemental flag indicating to run
                                  build in preview mode without processing
                                  the execute commands
 -pw,--pw <arg>                   Db2 password (encrypted with DBB
                                  Password Utility) for the MetadataStore
 -r,--reset                       Deletes the dependency collections and
                                  build result group from the
                                  MetadataStore
 -re,--reportExternalImpacts      Flag to activate analysis and report of
                                  external impacted files within DBB
                                  collections
 -s,--scanOnly                    Flag indicating to only scan source
                                  files for application without building
                                  anything (deprecated use --scanSource)
 -sa,--scanAll                    Flag indicating to scan both source
                                  files and load modules for application
                                  without building anything
 -sl,--scanLoad                   Flag indicating to only scan load
                                  modules for application without building
                                  anything
 -srcDir,--sourceDir <arg>        Absolute path to workspace (root)
                                  directory containing all required source
                                  directories for user build
 -ss,--scanSource                 Flag indicating to only scan source
                                  files for application without building
                                  anything
 -t,--team <hlq>                  Team build hlq for user build syslib
                                  concatenations
 -u,--userBuild                   Flag indicating running a user build
 -url,--url <arg>                 Db2 JDBC URL for the MetadataStore.
                                  Example: jdbc:db2:<Db2 server location>
 -v,--verbose                     Flag to turn on script trace
 -w,--workspace <arg>             Absolute path to workspace (root)
                                  directory containing all required source
                                  directories
 -wrkDir,--workDir <arg>          Absolute path to the build output root
                                  directory for user build
 -zTest,--runzTests               Specify if zUnit Tests should be
                                  executed
/u/dbehm/userBuild>
** Build finished
```