### PR TITLE
GitUtils - fix variables in error message when multiple references are found

### DIFF
--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -78,7 +78,7 @@ def getCurrentGitDetachedBranch(String gitDir) {
 	// expecting references with "origin" as segment
 	def origin = "origin/"
 	if (gitBranchesArray.count {it.contains(origin)}  > 1 ) {
-		String warningMsg = "*! (GitUtils.getCurrentGitDetachedBranch) Warning obtaining branch name for ($dir). Multiple references point to the same commit. ($gitBranchArr)"
+		String warningMsg = "*! (GitUtils.getCurrentGitDetachedBranch) Warning obtaining branch name for ($gitDir). Multiple references point to the same commit. ($gitBranchString)"
 		println(warningMsg)
 		updateBuildResult(warningMsg:warningMsg)
 	}


### PR DESCRIPTION
This fixes the below exception in the condition that multiple references are found:

```
Caught: groovy.lang.MissingPropertyException: No such property: dir for class: GitUtilities
groovy.lang.MissingPropertyException: No such property: dir for class: GitUtilities
	at GitUtilities.getCurrentGitDetachedBranch(GitUtilities.groovy:81)
	at build.populateBuildProperties(build.groovy:522)
	at build.initializeBuildProcess(build.groovy:108)
	at build.run(build.groovy:36)
```