### PR TITLE
Map build files to language configurations via DBB File property syntax

### DIFF
--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -4,8 +4,7 @@
 # Comma separated list of additional application property files to load
 # Supports both relative path (to ${application}/application-conf/) and absolute path
 applicationPropFiles=file.properties,BMS.properties,Cobol.properties,\
-LinkEdit.properties,languageConfigurationMapping.properties,\
-CRB.properties
+LinkEdit.properties,CRB.properties
 
 #
 # Comma separated list all source directories included in application build. Supports both absolute 

--- a/samples/MortgageApplication/application-conf/file.properties
+++ b/samples/MortgageApplication/application-conf/file.properties
@@ -42,3 +42,12 @@ loadFileLevelProperties = true :: **/cobol/epsmlist.cbl
 # Example 2: The following file path pattern looks for a language configuration properties file mapping for epsnbrvl.cbl and epsmpmt.cbl 
 # in the application-conf/languageconfigurationMapping.properties file:
 loadLanguageConfigurationProperties = true :: **/cobol/epsnbrvl.cbl, **/cobol/epsmpmt.cbl
+
+#
+# Properties mapping for assigning the language configuration to build files to specify the build configuration
+# Please see the detailed documentation on file property management at:
+# https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md
+# This option replaces the mapping of build files to language configuration in languageConfigurationMapping.properties file
+# 
+languageConfiguration = languageConfigProps01 :: **/cobol/epsnbrvl.cbl, **/cobol/epsmpmt.cbl
+languageConfiguration = languageConfigProps02 ::  **/cobol/epscmort.cbl

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -34,13 +34,22 @@ impactResolutionRules | Comma separated list of resolution rule properties used 
 impactSearch | Impact finder resolution search configuration leveraging the SearchPathImpactFinder API. Sample configurations are inlcuded below, next to the previous rule definitions. | true
 
 ### file.properties
-Location of file properties, script mappings and file-level property overrides. All file properties for the entire application, including source files in distributed repositories of the application need to be contained either in this file or in other property files in the `application-conf` directory. Look for the column 'Overridable' in the tables below for build properties that can have file-level property overrides. Additional file-level properties can be defined through individual artifact properties files in a separate directory of the repository. For more details, see [File Property Management](https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md).
+
+Location of file properties, script mappings and file-level property overrides. All file properties for the entire application, including source files in distributed repositories of the application need to be contained either in this file or in other property files in the `application-conf` directory. Look for the column 'Overridable' in the tables below for build properties that can have file-level property overrides. Please also read the section [Build properties](https://www.ibm.com/docs/en/dbb/2.0?topic=apis-build-properties) in the official DBB documentation.
+
+Additional file-level properties can be defined through **individual artifact properties files** in a separate directory of the repository or through **language configuration** files to configure the language scripts. For more details, see [File Property Management](https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md).
 
 Property | Description
 --- | ---
 dbb.scriptMapping | DBB configuration file properties association build files to language scripts
 dbb.scannerMapping | zAppBuild configuration override/expansion to map files extensions to DBB dependency scanner configurations
 cobol_testcase | File property to indicate a generated zUnit cobol test case to use a different set of source and output libraries
+
+Property | Description
+--- | ---
+loadFileLevelProperties | Flag to enable the zAppBuild capability to load individual artifact properties files for source files. See default configuration in [application.properties](#application.properties)
+loadLanguageConfigurationProperties | Flag to enable the zAppBuild capability to load language configuration properties files for source files. See default configuration in [application.properties](#application.properties)
+languageConfiguration | Properties mapping for assigning build files to language configuration to define the build configuration
 
 General file level overwrites to control the allocations of system datasets for compile and link steps or activation of preprocessing
 

--- a/samples/application-conf/file.properties
+++ b/samples/application-conf/file.properties
@@ -83,8 +83,50 @@ isMQ = true :: **/cobol/member.cbl
 #  
 isIMS = true :: **/cobol/DLIBATCH.cbl
 
-# Please check for available file property overwrites within samples/application-conf/README.md
 
+#########
+# Property File Management
+#
+# > Please check for available file property overwrites within samples/application-conf/README.md <
+# The tables indicate which build parameters can be overwritten for each build file to overwrite the default settings.
+# 
+# The subsequent section provides the configuration parameters to outline
+# - file level property overwrites by loading individual artifact properties files
+# - loading language configurations that define multiple build parameters for the mapped files
+#
+# Please see the detailed documentation on file property management at:
+# https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md
+#
+#########
+
+#
+# Flag to enable the zAppBuild capability to load individual artifact properties files for source files.
+# Example 1: The following file path pattern looks for an individual artifact properties file for epsmlist.cbl:
+# loadFileLevelProperties = true :: **/cobol/epsmlist.cbl 
+# Example 2: Enable individual artifact properties file for all COBOL files: loadFileLevelProperties=true :: **/cobol/*.cbl
+# loadFileLevelProperties = true :: **/cobol/*.cbl 
+
+#
+# Language Configuration properties management
+#
+# Flag to enable the zAppBuild capability to load language configuration properties files for source files.
+# Example 1: Enable language configuration mapping for all COBOL files: loadLanguageConfigurationProperties=true :: **/cobol/*.cbl
+# loadLanguageConfigurationProperties = true :: **/cobol/*.cbl
+# Example 2: The following file path pattern looks for a language configuration properties file mapping for epsnbrvl.cbl and epsmpmt.cbl 
+# in the application-conf/languageconfigurationMapping.properties file:
+# loadLanguageConfigurationProperties = true :: **/cobol/epsnbrvl.cbl, **/cobol/epsmpmt.cbl
+
+#
+# Properties mapping for assigning the language configuration to build files to specify the build configuration
+# This option is an alternative approach for mapping build files to the language configuration file
+# 
+# languageConfiguration = languageConfigProps01 :: **/cobol/epsnbrvl.cbl, **/cobol/epsmpmt.cbl
+# languageConfiguration = languageConfigProps02 ::  **/cobol/epscmort.cbl
+
+
+#########
+# zUnit Integration
+#########
 #
 # file mapping for generated zUnit Test case programs (Cobol) to use a seperate set of libraries
 # cobol_testcase = true :: **/testcase/*.cbl

--- a/samples/application-conf/languageConfigurationMapping.properties
+++ b/samples/application-conf/languageConfigurationMapping.properties
@@ -1,5 +1,8 @@
 # This file maps the program file with the corresponding language configuration properties file in the build-conf/language-conf folder.
 
+# Please see the detailed documentation on file property management at:
+# https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md
+
 # For example: As shown below, the programs `epsnbrvl.cbl` and `epsmpmt.cbl` will map to the language configuration file
 # build-conf/language-conf/languageConfigProps01.properties.
 # The program `epscmort.cbl` will map to the language configuration file build-conf/language-conf/languageConfigProps02.properties.

--- a/utilities/FilePropUtilities.groovy
+++ b/utilities/FilePropUtilities.groovy
@@ -22,28 +22,34 @@ def loadFileLevelPropertiesFromFile(List<String> buildList) {
 	     String member = new File(buildFile).getName()
 	     def filePropMap = [:]
 	        
-	     // check for language configuration group level overwrite
-	     loadLanguageConfigurationProperties = props.getFileProperty('loadLanguageConfigurationProperties', buildFile)
-	     if (loadLanguageConfigurationProperties && loadLanguageConfigurationProperties.toBoolean()) {
-	         String languageConfigurationPropertyFileName = props."$member"
-	         if (languageConfigurationPropertyFileName != null) {
-	                    
-	             // String languageConfigurationPropertyFilePath = buildUtils.getAbsolutePath(props.application) + "/${propertyFilePath}/${languageConfigurationPropertyFileName}.${propertyExtention}"                    
-	             String languageConfigurationPropertyFilePath = "${props.zAppBuildDir}/build-conf/language-conf/${languageConfigurationPropertyFileName}.${propertyExtention}"
+		// check for language configuration group level overwrite
+		loadLanguageConfigurationProperties = props.getFileProperty('loadLanguageConfigurationProperties', buildFile)
+		if (loadLanguageConfigurationProperties && loadLanguageConfigurationProperties.toBoolean()) {
 
-	             File languageConfigurationPropertyFile = new File(languageConfigurationPropertyFilePath)
+			// obtain the language configuration file name
+			String languageConfigurationPropertyFileName;
+			PropertyMappings languageConfigurationPropertyMapping = new PropertyMappings("languageConfiguration")
+			 // take language configuration from file property first
+			if (languageConfigurationPropertyMapping != null) languageConfigurationPropertyFileName = languageConfigurationPropertyMapping.getValue(buildFile)
+			// if not specified, check with settings in languageConfigurationMapping.properties
+			if (languageConfigurationPropertyFileName == null) languageConfigurationPropertyFileName = props."$member" 
 
-	             if (languageConfigurationPropertyFile.exists()) {
-	                 filePropMap = loadProgramTypeProperties(languageConfigurationPropertyFileName, languageConfigurationPropertyFilePath, buildFile)                            
-	             } else {
-	                 if (props.verbose) println "***! No language configuration properties file found for ${languageConfigurationPropertyFileName}.${propertyExtention}. Defaults or already defined file properties mapped to $buildFile."
-	             }
-	                   
-	         } else {
-	             if (props.verbose) println "***! No language configuration properties file defined for $buildFile"
-	         }                    
-	            
-	     }
+			if (languageConfigurationPropertyFileName != null) {
+
+				String languageConfigurationPropertyFilePath = "${props.zAppBuildDir}/build-conf/language-conf/${languageConfigurationPropertyFileName}.${propertyExtention}"
+
+				File languageConfigurationPropertyFile = new File(languageConfigurationPropertyFilePath)
+				if (languageConfigurationPropertyFile.exists()) {
+					filePropMap = loadProgramTypeProperties(languageConfigurationPropertyFileName, languageConfigurationPropertyFilePath, buildFile)
+				} else {
+					if (props.verbose) println "***! No language configuration properties file found for ${languageConfigurationPropertyFileName}.${propertyExtention}. Defaults or already defined file properties mapped to $buildFile."
+				}
+
+			} else {
+				if (props.verbose) println "***! No language configuration properties file defined for $buildFile"
+			}
+
+		}
 	    
 	     // check for file level overwrite
 	     loadFileLevelProperties = props.getFileProperty('loadFileLevelProperties', buildFile)


### PR DESCRIPTION
This is enhancing the existing language configuration approach in zAppBuild by allowing the user to map build files to the language configuration via the DBB file property syntax:

```properties
```