### PR TITLE
Binder control card lookup capability 

### DIFF
--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -24,6 +24,10 @@ cobol_dbrmPDS=${hlq}.DBRM
 cobol_BMS_PDS=${team}.BMS.COPY
 
 #
+# (Optional) Library to upload binder control cards
+cobol_bndPDS=${hlq}.BND
+
+#
 # COBOL load data sets
 cobol_loadPDS=${hlq}.LOAD
 

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -20,7 +20,7 @@ println("** Building ${argMap.buildList.size()} ${argMap.buildList.size() == 1 ?
 buildUtils.assertBuildProperties(props.cobol_requiredBuildProperties)
 
 // create language datasets
-def langQualifier = "cobol"
+@Field def langQualifier = "cobol"
 buildUtils.createLanguageDatasets(langQualifier)
 
 // sort the build list based on build file rank if provided
@@ -351,7 +351,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	if (sysin_linkEditInstream) linkedit.dd(new DDStatement().ddref("SYSIN"))
     
 	if (binderControlCardLookup && binderControlCardLookup.toBoolean()) {
-		
+		// lookup binder control member and upload it
 		binderControlLibrary = buildUtils.lookupBinderControlCard(langQualifier, buildFile)
 		if (binderControlLibrary != null) linkedit.dd(new DDStatement().dsn("${binderControlLibrary}(${member})").options('shr'))
 	}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -295,6 +295,7 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	String linker = props.getFileProperty('cobol_linkEditor', buildFile)
 	String linkEditStream = props.getFileProperty('cobol_linkEditStream', buildFile)
 	String linkDebugExit = props.getFileProperty('cobol_linkDebugExit', buildFile)
+	String binderControlCardLookup = props.getFileProperty('cobol_binderControlCardLookup', buildFile)
 
 	// obtain githash for buildfile
 	String cobol_storeSSI = props.getFileProperty('cobol_storeSSI', buildFile)
@@ -348,7 +349,12 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	// add SYSLIN along the reference to SYSIN if configured through sysin_linkEditInstream
 	linkedit.dd(new DDStatement().name("SYSLIN").dsn("${props.cobol_objPDS}($member)").options('shr'))
 	if (sysin_linkEditInstream) linkedit.dd(new DDStatement().ddref("SYSIN"))
-    linkedit.dd(new DDStatement().dsn("DBEHM.DBB.UB.LINK(LNKOPT)").options('shr'))
+    
+	if (binderControlCardLookup && binderControlCardLookup.toBoolean()) {
+		
+		binderControlLibrary = buildUtils.lookupBinderControlCard(langQualifier, buildFile)
+		if (binderControlLibrary != null) linkedit.dd(new DDStatement().dsn("${binderControlLibrary}(${member})").options('shr'))
+	}
 					
 	// add DD statements to the linkedit command
 	String deployType = buildUtils.getDeployType("cobol", buildFile, logicalFile)

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -353,7 +353,10 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	if (binderControlCardLookup && binderControlCardLookup.toBoolean()) {
 		// lookup binder control member and upload it
 		binderControlLibrary = buildUtils.lookupBinderControlCard(langQualifier, buildFile)
-		if (binderControlLibrary != null) linkedit.dd(new DDStatement().dsn("${binderControlLibrary}(${member})").options('shr'))
+		if (binderControlLibrary != null) {
+			if (props.verbose) println "*** Appending binder control card ${binderControlLibrary}(${member})"
+			linkedit.dd(new DDStatement().dsn("${binderControlLibrary}(${member})").options('shr'))
+		}
 	}
 					
 	// add DD statements to the linkedit command

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -348,7 +348,8 @@ def createLinkEditCommand(String buildFile, LogicalFile logicalFile, String memb
 	// add SYSLIN along the reference to SYSIN if configured through sysin_linkEditInstream
 	linkedit.dd(new DDStatement().name("SYSLIN").dsn("${props.cobol_objPDS}($member)").options('shr'))
 	if (sysin_linkEditInstream) linkedit.dd(new DDStatement().ddref("SYSIN"))
-			
+    linkedit.dd(new DDStatement().dsn("DBEHM.DBB.UB.LINK(LNKOPT)").options('shr'))
+					
 	// add DD statements to the linkedit command
 	String deployType = buildUtils.getDeployType("cobol", buildFile, logicalFile)
 	if(isZUnitTestCase){

--- a/samples/MortgageApplication/application-conf/Cobol.properties
+++ b/samples/MortgageApplication/application-conf/Cobol.properties
@@ -57,6 +57,15 @@ cobol_linkDebugExit=
 # can be overridden by file properties
 cobol_linkEdit=true
 
+# Flag indicating to lookup binder control cards for the linkage editor
+# that are managed within the repository
+# can be overridden by file properties
+# default: false
+cobol_binderControlCardLookup=true
+
+# Relative lookup path in the application repository to locate binder control files
+cobol_binderControlCardLookupPath=${application}/binderControlCards/@{member}.bnd
+
 #
 # store abbrev git hash in ssi field
 # available for buildTypes impactBuild, mergeBuild and fullBuild 

--- a/samples/MortgageApplication/binderControlCards/epscmort.bnd
+++ b/samples/MortgageApplication/binderControlCards/epscmort.bnd
@@ -1,0 +1,1 @@
+  ALIAS APSCMOR2

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -648,7 +648,7 @@ def lookupBinderControlCard(String langQualifier, String buildFile) {
 	// Locate binder control card
 	if (binderControlCardPath) {
 		fileName = buildFile.substring(buildFile.lastIndexOf("/") + 1, buildFile.lastIndexOf('.'))
-		def binderControlCard = replace("\\n","\n").replace('@{member}', fileName)
+		def binderControlCard = binderControlCardPath.replace("\\n","\n").replace('@{member}', fileName)
 		
 		File binderControlCardFile = new File(getAbsolutePath(binderControlCard))
 		if (binderControlCardFile.exists()) {

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -664,11 +664,11 @@ def lookupBinderControlCard(String langQualifier, String buildFile) {
 				new CopyToPDS().file(binderControlCardFile).dataset(binderControlCardLibrary).member(member).execute()
 				retval = binderControlCardLibrary
 			} else {
-				if (props.verbose) println "***! Binder Control Card Library name ($binderControlCardLibrary) or library options ($libraryOptions) not specified."
+				if (props.verbose) println "***! Binder control card library name ($binderControlCardLibrary) or library options ($libraryOptions) not specified."
 			}
 
 		} else {
-			if (props.verbose) println "***! Binder Control Card ($binderControlCardFile) for build file $buildFile not found."
+			if (props.verbose) println "*** No binder control card ($binderControlCardFile) found for build file $buildFile."
 		}
 
 	} else {

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -647,7 +647,7 @@ def lookupBinderControlCard(String langQualifier, String buildFile) {
 
 	// Locate binder control card
 	if (binderControlCardPath) {
-		fileName = buildFile.substring(buildFile.lastIndexOf("/") + 1).substring(buildFile.lastIndexOf('.'))
+		fileName = buildFile.substring(buildFile.lastIndexOf("/") + 1, buildFile.lastIndexOf('.'))
 		def binderControlCard = replace("\\n","\n").replace('@{member}', fileName)
 		
 		File binderControlCardFile = new File(getAbsolutePath(binderControlCard))

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -635,6 +635,50 @@ def getDeployType(String langQualifier, String buildFile, LogicalFile logicalFil
 }
 
 /*
+ * Lookup binder control card members
+ *  if found it will upload binder control card to target libary 
+ */
+
+def lookupBinderControlCard(String langQualifier, String buildFile) {
+
+	retval = null
+	
+	binderControlCardPath = props.getFileProperty("${langQualifier}_binderControlCardLookupPath", buildFile)
+
+	// Locate binder control card
+	if (binderControlCardPath) {
+		fileName = buildFile.substring(buildFile.lastIndexOf("/") + 1).substring(buildFile.lastIndexOf('.'))
+		def binderControlCard = replace("\\n","\n").replace('@{member}', fileName)
+		
+		File binderControlCardFile = new File(getAbsolutePath(binderControlCard))
+		if (binderControlCardFile.exists()) {
+
+			binderControlCardLibrary = props."${lang}_bndPDS"
+			libraryOptions = props."${langQualifier}_srcOptions"
+			if (binderControlCardLibrary && libraryOptions)	{
+				// create library
+				createDatasets(binderControlCardLibrary.split(","), libraryOptions)
+
+				// upload binder control card
+				String member = CopyToPDS.createMemberName(buildFile)
+				new CopyToPDS().file(binderControlCardFile).dataset(binderControlCardLibrary).member(member).execute()
+				retval = binderControlCardLibrary
+			} else {
+				if (props.verbose) println "***! Binder Control Card Library name ($binderControlCardLibrary) or library options ($libraryOptions) not specified."
+			}
+
+		} else {
+			if (props.verbose) println "***! Binder Control Card ($binderControlCardFile) for build file $buildFile not found."
+		}
+
+	} else {
+		// No Binder Control Card path specified
+	}
+
+	return retval
+}
+
+/*
  * Creates a Generic PropertyRecord with the provided db2 information in bind.properties
  */
 def generateDb2InfoRecord(String buildFile){

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -653,7 +653,7 @@ def lookupBinderControlCard(String langQualifier, String buildFile) {
 		File binderControlCardFile = new File(getAbsolutePath(binderControlCard))
 		if (binderControlCardFile.exists()) {
 
-			binderControlCardLibrary = props."${lang}_bndPDS"
+			binderControlCardLibrary = props."${langQualifier}_bndPDS"
 			libraryOptions = props."${langQualifier}_srcOptions"
 			if (binderControlCardLibrary && libraryOptions)	{
 				// create library


### PR DESCRIPTION
This is implementing the reported issue  #500 to locate existing binder control statement members within the repository.

if a binder control member is found, it will be added to the SYSLIN concatenation:

```
*** Link-Edit parms for MortgageApplication/cobol/epscmort.cbl = MAP,RENT,COMPAT(PM5),SSI=12d45452
*** Generated linkcard input stream: 
  IDENTIFY EPSCMORT('MortgageApplication/12d45452')
*** Appending binder control card DBEHM.DBB.BUILD.BND(EPSCMORT)
```

if no binder control member is found, we will print a message:

```
*** Link-Edit parms for MortgageApplication/cobol/epscsmrd.cbl = MAP,RENT,COMPAT(PM5),SSI=12d45452
*** Generated linkcard input stream: 
  IDENTIFY EPSCSMRD('MortgageApplication/12d45452')
*** No binder control card (/u/dbehm/test-zapp/dbb-zappbuild/samples/MortgageApplication/binderControlCards/epscsmrd.bnd) found for build file MortgageApplication/cobol/epscsmrd.cbl.
```

These are file properties, so the user can configure for which build files a binder control statement member should be looked up