### PR TITLE
Link to changed files with user-provided baselineRef 

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -750,7 +750,7 @@ def finalizeBuildProcess(Map args) {
 					if (lastBuildResult){
 						String userBaselineRef = (props.baselineRef) ? buildUtils.getUserProvidedBaselineRef(dir) : null
 						String baselineHash = (userBaselineRef) ? userBaselineRef : lastBuildResult.getProperty(key)
-						String gitchangedfilesLink = props.gitRepositoryURL << "/" << props.gitRepositoryCompareService <<"/" << baselineHash << ".." << currenthash
+						String gitchangedfilesLink = props.gitRepositoryURL << "/" << props.gitRepositoryCompareService <<"/" << baselineHash << "..." << currenthash
 						String gitchangedfilesLinkUrl = new URI(gitchangedfilesLink).normalize().toString()
 						if (props.verbose) println "** Setting property $gitchangedfilesKey : $gitchangedfilesLinkUrl"
 						buildResult.setProperty(gitchangedfilesKey, gitchangedfilesLink)

--- a/build.groovy
+++ b/build.groovy
@@ -744,7 +744,8 @@ def finalizeBuildProcess(Map args) {
 					String gitchangedfilesKey = "$gitchangedfilesPrefix${buildUtils.relativizePath(dir)}"
 					def lastBuildResult= buildUtils.retrieveLastBuildResult()
 					if (lastBuildResult){
-						String baselineHash = lastBuildResult.getProperty(key)
+						String userBaselineRef = buildUtils.getUserProvidedBaselineRef(dir)
+						String baselineHash = (userBaselineRef) ? userBaselineRef : lastBuildResult.getProperty(key)
 						String gitchangedfilesLink = props.gitRepositoryURL << "/" << props.gitRepositoryCompareService <<"/" << baselineHash << ".." << currenthash
 						String gitchangedfilesLinkUrl = new URI(gitchangedfilesLink).normalize().toString()
 						if (props.verbose) println "** Setting property $gitchangedfilesKey : $gitchangedfilesLinkUrl"

--- a/build.groovy
+++ b/build.groovy
@@ -587,7 +587,7 @@ def createBuildList() {
 	// check if impact build
 	else if (props.impactBuild) {
 		if (props.baselineRef) {
-			println "** --impactBuild --baselineRef ${props.baselienRef} option selected. $action impacted programs for application ${props.application} "
+			println "** --impactBuild --baselineRef ${props.baselineRef} option selected. $action impacted programs for application ${props.application} "
 		} else {
 			println "** --impactBuild option selected. $action impacted programs for application ${props.application} "
 		}

--- a/build.groovy
+++ b/build.groovy
@@ -586,7 +586,11 @@ def createBuildList() {
 	}
 	// check if impact build
 	else if (props.impactBuild) {
-		println "** --impactBuild option selected. $action impacted programs for application ${props.application} "
+		if (props.baselineRef) {
+			println "** --impactBuild --baselineRef ${props.baselienRef} option selected. $action impacted programs for application ${props.application} "
+		} else {
+			println "** --impactBuild option selected. $action impacted programs for application ${props.application} "
+		}
 		if (metadataStore) {
 			(buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties) = impactUtils.createImpactBuildList()		}
 		else {

--- a/build.groovy
+++ b/build.groovy
@@ -744,7 +744,7 @@ def finalizeBuildProcess(Map args) {
 					String gitchangedfilesKey = "$gitchangedfilesPrefix${buildUtils.relativizePath(dir)}"
 					def lastBuildResult= buildUtils.retrieveLastBuildResult()
 					if (lastBuildResult){
-						String userBaselineRef = buildUtils.getUserProvidedBaselineRef(dir)
+						String userBaselineRef = (props.baselineRef) ? buildUtils.getUserProvidedBaselineRef(dir) : null
 						String baselineHash = (userBaselineRef) ? userBaselineRef : lastBuildResult.getProperty(key)
 						String gitchangedfilesLink = props.gitRepositoryURL << "/" << props.gitRepositoryCompareService <<"/" << baselineHash << ".." << currenthash
 						String gitchangedfilesLinkUrl = new URI(gitchangedfilesLink).normalize().toString()

--- a/build.groovy
+++ b/build.groovy
@@ -748,7 +748,7 @@ def finalizeBuildProcess(Map args) {
 					String gitchangedfilesKey = "$gitchangedfilesPrefix${buildUtils.relativizePath(dir)}"
 					def lastBuildResult= buildUtils.retrieveLastBuildResult()
 					if (lastBuildResult){
-						String userBaselineRef = (props.baselineRef) ? buildUtils.getUserProvidedBaselineRef(dir) : null
+						String userBaselineRef = (props.baselineRef) ? buildUtils.getUserProvidedBaselineRef(dir).replaceAll("origin/","") : null
 						String baselineHash = (userBaselineRef) ? userBaselineRef : lastBuildResult.getProperty(key)
 						String gitchangedfilesLink = props.gitRepositoryURL << "/" << props.gitRepositoryCompareService <<"/" << baselineHash << "..." << currenthash
 						String gitchangedfilesLinkUrl = new URI(gitchangedfilesLink).normalize().toString()

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -606,6 +606,39 @@ def retrieveLastBuildResult(){
 }
 
 /*
+ * Returns the user-provided baseline hash for configurations passed in with the baselineRef cli option
+ *   returns null if not defined
+ */
+
+def getUserProvidedBaselineRef(String dir) {
+	
+	String hash
+	String relDir = relativizePath(dir)
+	
+	String[] baselineMap = (props.baselineRef).split(",")
+	baselineMap.each{
+		// case: baselineRef (gitref)
+		if(it.split(":").size()==1 && relDir.equals(props.application)){
+			if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
+			hash = it
+		}
+		// case: baselineRef (folder:gitref)
+		else if(it.split(":").size()>1){
+			(appSrcDir, gitReference) = it.split(":")
+			if (appSrcDir.equals(relDir)){
+				if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
+				hash = gitReference
+			}
+		} else {
+			// No user-provided baseline ref found for dir
+		}
+	}
+	return hash
+}
+
+
+
+/*
  * returns the deployType for a logicalFile depending on the
  * isCICS, isIMS and isDLI setting
  */

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -611,28 +611,34 @@ def retrieveLastBuildResult(){
  */
 
 def getUserProvidedBaselineRef(String dir) {
-	
+
 	String hash
 	String relDir = relativizePath(dir)
-	
-	String[] baselineMap = (props.baselineRef).split(",")
-	baselineMap.each{
-		// case: baselineRef (gitref)
-		if(it.split(":").size()==1 && relDir.equals(props.application)){
-			if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
-			hash = it
-		}
-		// case: baselineRef (folder:gitref)
-		else if(it.split(":").size()>1){
-			(appSrcDir, gitReference) = it.split(":")
-			if (appSrcDir.equals(relDir)){
+
+	if (props.baselineRef) {
+
+		String[] baselineMap = (props.baselineRef).split(",")
+		baselineMap.each{
+			// case: baselineRef (gitref)
+			if(it.split(":").size()==1 && relDir.equals(props.application)){
 				if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
-				hash = gitReference
+				hash = it
 			}
-		} else {
-			// No user-provided baseline ref found for dir
+			// case: baselineRef (folder:gitref)
+			else if(it.split(":").size()>1){
+				(appSrcDir, gitReference) = it.split(":")
+				if (appSrcDir.equals(relDir)){
+					if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
+					hash = gitReference
+				}
+			} else {
+				// No user-provided baseline ref found for dir
+			}
 		}
+	} else {
+		// No baseline ref defined
 	}
+
 	return hash
 }
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -327,7 +327,8 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 
 			if (props.verbose) println "** Getting baseline hash for directory $dir"
 			String key = "$hashPrefix${buildUtils.relativizePath(dir)}"
-
+			String relDir = relativizePath(dir)
+			
 			String hash
 			// retrieve baseline reference overwrite if set
 			if (props.baselineRef){

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -324,28 +324,15 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 		// get the baseline hash for all build directories
 		directories.each { dir ->
 			dir = buildUtils.getAbsolutePath(dir)
+
 			if (props.verbose) println "** Getting baseline hash for directory $dir"
 			String key = "$hashPrefix${buildUtils.relativizePath(dir)}"
-			String relDir = buildUtils.relativizePath(dir)
+
 			String hash
 			// retrieve baseline reference overwrite if set
 			if (props.baselineRef){
-				String[] baselineMap = (props.baselineRef).split(",")
-				baselineMap.each{
-					// case: baselineRef (gitref)
-					if(it.split(":").size()==1 && relDir.equals(props.application)){
-						if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
-						hash = it
-					}
-					// case: baselineRef (folder:gitref)
-					else if(it.split(":").size()>1){
-						(appSrcDir, gitReference) = it.split(":")
-						if (appSrcDir.equals(relDir)){
-							if (props.verbose) println "*** Baseline hash for directory $relDir retrieved from overwrite."
-							hash = gitReference
-						}
-					}
-				}
+				// get user-provided baseline configuration from cli config 
+				hash = buildUtils.getUserProvidedBaselineRef(dir)
 				// for build directories which are not specified in baselineRef mapping, return the info from lastBuildResult
 				if (hash == null && lastBuildResult) {
 					hash = lastBuildResult.getProperty(key)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -327,7 +327,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 
 			if (props.verbose) println "** Getting baseline hash for directory $dir"
 			String key = "$hashPrefix${buildUtils.relativizePath(dir)}"
-			String relDir = relativizePath(dir)
+			String relDir = buildUtils.relativizePath(dir)
 			
 			String hash
 			// retrieve baseline reference overwrite if set


### PR DESCRIPTION
This is extending the existing capability of zAppBuild to provide a user-friendly link to the changed files at the Git provider when providing the `--impactBuild` with the `baselineRef` sub-option.

See the configuration parameters `gitRepositoryURL` in the application configuration and `gitRepositoryCompareService` in build-conf/defaultzAppBuildConf.properties.

The property `:gitchangedfiles:MortgageApplication` contains the correct link in impactBuilds with baselineRef https://github.com/dennis-behm/dbb-zappbuild/compare/main...5eb29f3eca6fbd2638f40c5a8f3f7944705af421

Verbose output log sample:

```
************* Creation and processing of the build list *************
** --impactBuild --baselineRef origin/main option selected. Building impacted programs for application MortgageApplication 
** Getting current hash for directory /u/dbehm/test-zapp/dbb-zappbuild/samples/MortgageApplication
** Storing MortgageApplication : 5eb29f3eca6fbd2638f40c5a8f3f7944705af421
** Getting baseline hash for directory /u/dbehm/test-zapp/dbb-zappbuild/samples/MortgageApplication
*** Baseline hash for directory MortgageApplication retrieved from overwrite.
** Storing MortgageApplication : origin/main
** Calculating changed files for directory /u/dbehm/test-zapp/dbb-zappbuild/samples/MortgageApplication
..
..
***************** Finalization of the build process *****************
*** Obtaining hash for directory /u/dbehm/test-zapp/dbb-zappbuild/samples/MortgageApplication
** Setting property :githash:MortgageApplication : 5eb29f3eca6fbd2638f40c5a8f3f7944705af421
** Setting property :giturl:MortgageApplication : https://github.com/dennis-behm/dbb-zappbuild.git
*** Baseline hash for directory MortgageApplication retrieved from overwrite.
** Setting property :gitchangedfiles:MortgageApplication : https://github.com/dennis-behm/dbb-zappbuild/compare/main...5eb29f3eca6fbd2638f40c5a8f3f7944705af421
```