### PR TITLE
DBB 202 Support - Metadata reorg & Build Map support

### DIFF
--- a/build-conf/Cobol.properties
+++ b/build-conf/Cobol.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of required build properties for Cobol.groovy
 cobol_requiredBuildProperties=cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,\
-  cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,\
+  cobol_compiler,cobol_linkEditor,cobol_tempOptions,\
   SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED, \
   cobol_dependencySearch
 

--- a/build-conf/Easytrieve.properties
+++ b/build-conf/Easytrieve.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of required build properties for easytrieve.groovy
 easytrieve_requiredBuildProperties=easytrieve_srcPDS,easytrieve_cpyPDS,easytrieve_objPDS,easytrieve_loadPDS,\
-easytrieve_compiler,easytrieve_linkEditor,easytrieve_tempOptions,applicationOutputsCollectionName,\
+easytrieve_compiler,easytrieve_linkEditor,easytrieve_tempOptions,\
 SCEELKED
 
 #

--- a/build-conf/LinkEdit.properties
+++ b/build-conf/LinkEdit.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of required build properties for LinkEdit.groovy
 linkedit_requiredBuildProperties=linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,\
-  linkedit_linkEditor,linkedit_tempOptions,applicationOutputsCollectionName,\
+  linkedit_linkEditor,linkedit_tempOptions,\
   SDFHLOAD,SCEELKED
 
 #

--- a/build-conf/PLI.properties
+++ b/build-conf/PLI.properties
@@ -3,7 +3,7 @@
 #
 # Comma separated list of required build properties for PLI.groovy
 pli_requiredBuildProperties=pli_srcPDS,pli_incPDS,pli_objPDS,pli_loadPDS,\
- pli_compiler,pli_linkEditor,pli_tempOptions,applicationOutputsCollectionName,\
+ pli_compiler,pli_linkEditor,pli_tempOptions,\
  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED, \
  pli_dependencySearch
 

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -110,7 +110,7 @@ createBuildOutputSubfolder=true
 #
 # Minimum required DBB ToolkitVersion to run this version of zAppBuild
 #  Build initialization process validates the DBB Toolkit Version in use and matches that against this setting
-requiredDBBToolkitVersion=2.0.0
+requiredDBBToolkitVersion=2.0.2
 
 #
 # Comma separated list of required build properties for zAppBuild/build.groovy

--- a/build-conf/build.properties
+++ b/build-conf/build.properties
@@ -110,7 +110,7 @@ createBuildOutputSubfolder=true
 #
 # Minimum required DBB ToolkitVersion to run this version of zAppBuild
 #  Build initialization process validates the DBB Toolkit Version in use and matches that against this setting
-requiredDBBToolkitVersion=2.0.2
+requiredDBBToolkitVersion=2.0.2.1
 
 #
 # Comma separated list of required build properties for zAppBuild/build.groovy

--- a/build.groovy
+++ b/build.groovy
@@ -551,11 +551,11 @@ def initMetadataArtifacts() {
 			if (props.topicBranchBuild && mds.buildGroupExists(mainBuildGroupName)) {
 				// create a topic branch build group (copy collections and last successful build result from mainBuildGroup)
 				buildGroup = mds.createTopicBuildGroup(mainBuildGroupName, props.applicationBuildGroup) 
-				if (props.verbose) println "** Created topic branch build group ${props.applicationBuildGroup} from $mainBuildGroupName"
+				println "** Created topic branch build group ${props.applicationBuildGroup} from $mainBuildGroupName"
 			}
 			else { 
 				buildGroup = mds.createBuildGroup(props.applicationBuildGroup)
-				if (props.verbose) println "** Created build group ${props.applicationBuildGroup}"
+				println "** Created build group ${props.applicationBuildGroup}"
 			}
 		}
 

--- a/build.groovy
+++ b/build.groovy
@@ -583,10 +583,10 @@ def initMetadataArtifacts() {
 			// check for legacy collection and copy to sources if it exists
 			if (mds.collectionExists(legacyOutputsCollectionName)) {
 				buildGroup.copyCollection(mds.getCollection(legacyOutputsCollectionName), "outputs")
-				println "** Migrated legacy outputs collection ${legacySourceCollectionName}"
+				println "** Migrated legacy outputs collection ${legacyOutputsCollectionName}"
 			} else if (props.topicBranchBuild && mds.collectionExists(legacyMainOutputsCollectionName)) {
 				buildGroup.copyCollection(mds.getCollection(legacyMainOutputsCollectionName), "outputs")
-				println "** Migrated legacy main branch outputs collection ${legacySourceCollectionName}"
+				println "** Migrated legacy main branch outputs collection ${legacyMainOutputsCollectionName}"
 			} else {
 				buildGroup.createCollection("outputs") 
 			}

--- a/build.groovy
+++ b/build.groovy
@@ -608,7 +608,7 @@ def initMetadataArtifacts() {
 		println("** Build result created for BuildGroup:${buildGroup.getName()} BuildLabel:${props.applicationBuildLabel}")
 
 		// Create build maps in language scripts
-		if (props.buildMapsEnabled && !props.topicBranchBuild) props.createBuildMaps = 'true'
+		if (props.buildMapsEnabled && props.buildMapsEnabled.toBoolean() && !props.topicBranchBuild) props.createBuildMaps = 'true'
 
 	}
 

--- a/build.groovy
+++ b/build.groovy
@@ -608,7 +608,8 @@ def initMetadataArtifacts() {
 		println("** Build result created for BuildGroup:${buildGroup.getName()} BuildLabel:${props.applicationBuildLabel}")
 
 		// Create build maps in language scripts
-		if (props.buildMapsEnabled && props.buildMapsEnabled.toBoolean() && !props.topicBranchBuild) props.createBuildMaps = 'true'
+		//if (props.buildMapsEnabled && props.buildMapsEnabled.toBoolean() && !props.topicBranchBuild) props.createBuildMaps = 'true'
+		props.createBuildMaps = 'true'
 
 	}
 

--- a/build.groovy
+++ b/build.groovy
@@ -1,4 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import com.ibm.dbb.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.metadata.*
 import com.ibm.dbb.build.*
@@ -550,7 +551,7 @@ def populateBuildProperties(def opts) {
 	if (props.verbose) {
 		println("java.version="+System.getProperty("java.runtime.version"))
 		println("java.home="+System.getProperty("java.home"))
-		println("user.dir="+System.getProperty("user.dir"))
+		println("user.dir="+EnvVars.getUserDir())
 		println ("** Build properties at start up:\n${props.list()}")
 	}
 

--- a/build.groovy
+++ b/build.groovy
@@ -522,6 +522,8 @@ def populateBuildProperties(def opts) {
 	
 	// Validate system datasets
 	if (props.checkDatasets && props.systemDatasets) validationUtils.validateSystemDatasets(props.systemDatasets, props.verbose)
+
+	props.createBuildMaps = 'true'
 	
 	// Print all build properties + some envionment variables 
 	if (props.verbose) {

--- a/build.groovy
+++ b/build.groovy
@@ -1,5 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.*
+import com.ibm.dbb.EnvVars
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.metadata.*
 import com.ibm.dbb.build.*

--- a/build.groovy
+++ b/build.groovy
@@ -523,7 +523,8 @@ def populateBuildProperties(def opts) {
 	// Validate system datasets
 	if (props.checkDatasets && props.systemDatasets) validationUtils.validateSystemDatasets(props.systemDatasets, props.verbose)
 
-	props.createBuildMaps = 'true'
+	// Create build maps in language scripts
+	if (props.buildMapsEnabled && !props.topicBranchBuild) props.createBuildMaps = 'true'
 	
 	// Print all build properties + some envionment variables 
 	if (props.verbose) {

--- a/build.groovy
+++ b/build.groovy
@@ -608,8 +608,7 @@ def initMetadataArtifacts() {
 		println("** Build result created for BuildGroup:${buildGroup.getName()} BuildLabel:${props.applicationBuildLabel}")
 
 		// Create build maps in language scripts
-		//if (props.buildMapsEnabled && props.buildMapsEnabled.toBoolean() && !props.topicBranchBuild) props.createBuildMaps = 'true'
-		props.createBuildMaps = 'true'
+		if (props.buildMapsEnabled && props.buildMapsEnabled.toBoolean() && !props.topicBranchBuild) props.createBuildMaps = 'true'
 
 	}
 

--- a/build.groovy
+++ b/build.groovy
@@ -522,9 +522,6 @@ def populateBuildProperties(def opts) {
 	
 	// Validate system datasets
 	if (props.checkDatasets && props.systemDatasets) validationUtils.validateSystemDatasets(props.systemDatasets, props.verbose)
-
-	// Create build maps in language scripts
-	if (props.buildMapsEnabled && !props.topicBranchBuild) props.createBuildMaps = 'true'
 	
 	// Print all build properties + some envionment variables 
 	if (props.verbose) {
@@ -609,6 +606,9 @@ def initMetadataArtifacts() {
 		
 		if (props.buildFile) buildResult.setProperty('buildFile', XmlUtil.escapeXml(props.buildFile))
 		println("** Build result created for BuildGroup:${buildGroup.getName()} BuildLabel:${props.applicationBuildLabel}")
+
+		// Create build maps in language scripts
+		if (props.buildMapsEnabled && !props.topicBranchBuild) props.createBuildMaps = 'true'
 
 	}
 

--- a/build.groovy
+++ b/build.groovy
@@ -548,7 +548,7 @@ def initMetadataArtifacts() {
 			String mainBuildGroupName = "${props.application}-${props.mainBuildBranch}"
 			if (props.topicBranchBuild && mds.buildGroupExists(mainBuildGroupName)) {
 				// create a topic branch build group (copy collections and last successful build result from mainBuildGroup)
-				buildGroup = mds.createTopicBranchBuildGroup(mainBuildGroupName, props.applicationBuildGroup) 
+				buildGroup = mds.createTopicBuildGroup(mainBuildGroupName, props.applicationBuildGroup) 
 				if (props.verbose) println "** Created topic branch build group ${props.applicationBuildGroup} from $mainBuildGroupName"
 			}
 			else { 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -311,7 +311,7 @@ user.dir=/ZT01/var/dbb
 MortgageApplication/cobol/epsnbrvl.cbl
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script
-required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COBOL
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COPY
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.OBJ
@@ -407,7 +407,7 @@ required props = bms_srcPDS,bms_cpyPDS,bms_loadPDS, bms_assembler,bms_linkEditor
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.LOAD
 *** Building file MortgageApplication/bms/epsmort.bms
 ** Building files mapped to Cobol.groovy script
-required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COBOL
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COPY
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.OBJ
@@ -576,7 +576,7 @@ required props = bms_srcPDS,bms_cpyPDS,bms_loadPDS, bms_assembler,bms_linkEditor
 *** Building file MortgageApplication/bms/epsmort.bms
 *** Building file MortgageApplication/bms/epsmlis.bms
 ** Building files mapped to Cobol.groovy script
-required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COBOL
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COPY
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.OBJ
@@ -657,7 +657,7 @@ Cobol compiler parms for MortgageApplication/cobol/epscsmrd.cbl = LIB,CICS
 *** Logical file =
 {"dli":false,"lname":"EPSCSMRD","file":"MortgageApplication\/cobol\/epscsmrd.cbl","mq":false,"cics":false,"language":"ZBND","sql":false}
 ** Building files mapped to LinkEdit.groovy script
-required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,applicationOutputsCollectionName,  SDFHLOAD,SCEELKED
+required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,  SDFHLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.LINK
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.OBJ
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.LOAD
@@ -765,7 +765,7 @@ MortgageApplication/cobol/epscmort.cbl
 MortgageApplication/link/epsmlist.lnk
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script
-required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COBOL
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COPY
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.OBJ
@@ -817,7 +817,7 @@ Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
 *** Logical file =
 {"dli":false,"lname":"EPSCMORT","file":"MortgageApplication\/cobol\/epscmort.cbl","mq":false,"cics":false,"logicalDependencies":[{"lname":"EPSNBRVL","library":"DBB.ZAPP.CLEAN.MASTER.OBJ","category":"LINK"}],"language":"ZBND","sql":false}
 ** Building files mapped to LinkEdit.groovy script
-required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,applicationOutputsCollectionName,  SDFHLOAD,SCEELKED
+required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,  SDFHLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.LINK
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.OBJ
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.LOAD
@@ -916,7 +916,7 @@ MortgageApplication/cobol/epsnbrvl.cbl
 MortgageApplication/cobol/epscmort.cbl
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script
-required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.FEAT.COBOL
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.FEAT.COPY
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.FEAT.OBJ
@@ -1066,7 +1066,7 @@ MortgageApplication/cobol/epscmort.cbl
 MortgageApplication/link/epsmlist.lnk
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script
-required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.REL.COBOL
 ** Creating / verifying build dataset DBB.ZAPP.REL.COPY
 ** Creating / verifying build dataset DBB.ZAPP.REL.OBJ
@@ -1101,7 +1101,7 @@ Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
 *** Logical file =
 {"dli":false,"lname":"EPSCMORT","file":"MortgageApplication\/cobol\/epscmort.cbl","mq":false,"cics":false,"logicalDependencies":[{"lname":"EPSNBRVL","library":"DBB.ZAPP.REL.OBJ","category":"LINK"}],"language":"ZBND","sql":false}
 ** Building files mapped to LinkEdit.groovy script
-required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,applicationOutputsCollectionName,  SDFHLOAD,SCEELKED
+required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,  SDFHLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.REL.LINK
 ** Creating / verifying build dataset DBB.ZAPP.REL.OBJ
 ** Creating / verifying build dataset DBB.ZAPP.REL.LOAD
@@ -1220,7 +1220,7 @@ MortgageApplication/cobol/epsmlist.cbl
 HTTP/1.1 200 OK
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script
-required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.COBOL
 ** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.COPY
 ** Creating / verifying build dataset DBB.ZAPP.MERGE.BUILD.OBJ
@@ -1472,7 +1472,7 @@ MortgageApplication/jcl/MYSAMP.jcl
 *!! MortgageApplication/cobol/epscmort.cbl is changed on branch main and intersects with the current build list.
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy,Transfer.groovy
 ** Building files mapped to Cobol.groovy script
-required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED,   cobol_dependencySearch
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED,   cobol_dependencySearch
 ** Creating / verifying build dataset DBEHM.DBB.BUILD.COBOL
 ** Creating / verifying build dataset DBEHM.DBB.BUILD.COPY
 ** Creating / verifying build dataset DBEHM.DBB.BUILD.OBJ
@@ -1559,7 +1559,7 @@ Link-Edit parms for MortgageApplication/cobol/epscmort.cbl = MAP,RENT,COMPAT(PM5
    "sql": false
 }
 ** Building files mapped to LinkEdit.groovy script
-required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,applicationOutputsCollectionName,  SDFHLOAD,SCEELKED
+required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,  SDFHLOAD,SCEELKED
 ** Creating / verifying build dataset DBEHM.DBB.BUILD.LINK
 ** Creating / verifying build dataset DBEHM.DBB.BUILD.OBJ
 ** Creating / verifying build dataset DBEHM.DBB.BUILD.LOAD
@@ -2018,7 +2018,7 @@ MortgageApplication/cobol/epscmort.cbl
 MortgageApplication/link/epsmlist.lnk
 ** Invoking build scripts according to build order: BMS.groovy,Cobol.groovy,LinkEdit.groovy
 ** Building files mapped to Cobol.groovy script
-required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,applicationOutputsCollectionName,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
+required props = cobol_srcPDS,cobol_cpyPDS,cobol_objPDS,cobol_loadPDS,cobol_compiler,cobol_linkEditor,cobol_tempOptions,  SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COBOL
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.COPY
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.OBJ
@@ -2070,7 +2070,7 @@ Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
 *** Logical file =
 {"dli":false,"lname":"EPSCMORT","file":"MortgageApplication\/cobol\/epscmort.cbl","mq":false,"cics":false,"logicalDependencies":[{"lname":"EPSNBRVL","library":"DBB.ZAPP.CLEAN.MASTER.OBJ","category":"LINK"}],"language":"ZBND","sql":false}
 ** Building files mapped to LinkEdit.groovy script
-required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,applicationOutputsCollectionName,  SDFHLOAD,SCEELKED
+required props = linkedit_srcPDS,linkedit_objPDS,linkedit_loadPDS,linkedit_linkEditor,linkedit_tempOptions,  SDFHLOAD,SCEELKED
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.LINK
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.OBJ
 ** Creating / verifying build dataset DBB.ZAPP.CLEAN.MASTER.LOAD

--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -160,7 +160,7 @@ sortedList.each { buildFile ->
 	// clean up passed DD statements
 	job.stop()
 
-	if (clean) { // all steps executed clean
+	if (clean) { // success
 		if (props.createBuildMaps) {
 			// create build map for each build file upon success
 			BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -54,7 +54,13 @@ sortedList.each { buildFile ->
 	else { // success
 		if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists()) {
 			// create build map for each build file upon success
-			BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
+			BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
+			if (group.buildMapExists(buildFile)) {
+				if (props.verbose) println("* Deleting build map for $buildFile as it already exists.")
+				group.deleteBuildMap(buildFile)
+			}
+
+			BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
 			
 			// populate outputs with IExecutes
 			buildMap.populateOutputs(mvsJob.getExecutables())

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -52,7 +52,7 @@ sortedList.each { buildFile ->
 		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else { // success
-		if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase) {
+		if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists()) {
 			// create build map for each build file upon success
 			BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
 			

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -56,7 +56,7 @@ sortedList.each { buildFile ->
 			// create build map for each build file upon success
 			BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
 			if (group.buildMapExists(buildFile)) {
-				if (props.verbose) println("* Deleting build map for $buildFile as it already exists.")
+				if (props.verbose) println("* Replacing existing build map for $buildFile")
 				group.deleteBuildMap(buildFile)
 			}
 

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -52,7 +52,7 @@ sortedList.each { buildFile ->
 		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else { // success
-		if (props.buildMapsEnabled && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
+		if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
 			// create build map for each build file upon success
 			BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
 			

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -52,7 +52,7 @@ sortedList.each { buildFile ->
 		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else { // success
-		if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
+		if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase) {
 			// create build map for each build file upon success
 			BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
 			

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -13,6 +13,7 @@ println("** Building ${argMap.buildList.size()} ${argMap.buildList.size() == 1 ?
 
 // verify required build properties
 buildUtils.assertBuildProperties(props.bms_requiredBuildProperties)
+if (props.createBuildMaps) assert props.bmsSearch : "*! Missing required build property for build map creation 'bmsSearch'" // verify required prop for build map generation
 
 def langQualifier = "bms"
 buildUtils.createLanguageDatasets(langQualifier)
@@ -52,21 +53,19 @@ sortedList.each { buildFile ->
 		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else { // success
-		if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists()) {
+		if (props.createBuildMaps) {
 			// create build map for each build file upon success
 			BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
 			if (group.buildMapExists(buildFile)) {
 				if (props.verbose) println("* Replacing existing build map for $buildFile")
 				group.deleteBuildMap(buildFile)
 			}
-
-			BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
 			
+			BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
 			// populate outputs with IExecutes
 			buildMap.populateOutputs(mvsJob.getExecutables())
-
 			// populate sources and inputs with git metadata
-			//buildMap.populateInputsFromGit(props.workspace, dependencySearch)
+			buildMap.populateInputsFromGit(props.workspace, props.bmsSearch)
 			// scan load module to populate binary inputs
 			buildMap.populateBinaryInputsFromGit(props.bms_loadPDS, member)
 		}

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -60,13 +60,13 @@ sortedList.each { buildFile ->
 				if (props.verbose) println("* Replacing existing build map for $buildFile")
 				group.deleteBuildMap(buildFile)
 			}
-			
+
 			BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
 			// populate outputs with IExecutes
 			buildMap.populateOutputs(mvsJob.getExecutables())
 			// populate sources and inputs with git metadata
 			buildMap.populateInputsFromGit(props.workspace, props.bmsSearch)
-			// scan load module to populate binary inputs
+			// populate binary inputs from load module
 			buildMap.populateBinaryInputsFromGit(props.bms_loadPDS, member)
 		}
 	}

--- a/languages/BMS.groovy
+++ b/languages/BMS.groovy
@@ -60,7 +60,7 @@ sortedList.each { buildFile ->
 			buildMap.populateOutputs(mvsJob.getExecutables())
 
 			// populate sources and inputs with git metadata
-			buildMap.populateInputsFromGit(props.workspace, dependencySearch)
+			//buildMap.populateInputsFromGit(props.workspace, dependencySearch)
 			// scan load module to populate binary inputs
 			buildMap.populateBinaryInputsFromGit(props.bms_loadPDS, member)
 		}

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -150,7 +150,6 @@ sortedList.each { buildFile ->
 			if (compile) execs.add(compile)
 			if (linkEdit) execs.add(linkEdit)
 			buildMap.populateOutputs(execs)
-
 			// populate inputs using dependency resolution
 			buildMap.populateInputsFromGit(props.workspace, dependencySearch)
 			// populate binary inputs from load module scanning

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -137,9 +137,8 @@ sortedList.each { buildFile ->
 
 	if (error) 
 		props.error = "true"
-
-	// create build map for each build file upon success
-	if (props.buildMapsEnabled && MetadataStoreFactory.metadataStoreExists() && !error && !isZUnitTestCase && !props.topicBranchBuild) {
+	else if (props.buildMapsEnabled && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
+		// create build map for each build file upon success
 		BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
 		
 		// populate outputs with IExecutes

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -77,10 +77,10 @@ sortedList.each { buildFile ->
 	int rc = compile.execute()
 	int maxRC = props.getFileProperty('cobol_compileMaxRC', buildFile).toInteger()
 
-	boolean error = false
+	boolean clean = true
 
 	if (rc > maxRC) {
-		error = true
+		clean = false
 		String errorMsg = "*! The compile return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
 		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
@@ -94,12 +94,12 @@ sortedList.each { buildFile ->
 			BuildReportFactory.getBuildReport().addRecord(db2BindInfoRecord)
 		}
 		
-		if (needsLinking.toBoolean()) {
+		if (linkEdit) {
 			rc = linkEdit.execute()
 			maxRC = props.getFileProperty('cobol_linkEditMaxRC', buildFile).toInteger()
 
 			if (rc > maxRC) {
-				error = true
+				clean = false
 				String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 				println(errorMsg)
 				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
@@ -116,7 +116,7 @@ sortedList.each { buildFile ->
 	}
 
 	//perform Db2 Bind only on User Build and perfromBindPackage property
-	if (props.userBuild && !error && logicalFile.isSQL() && props.bind_performBindPackage && props.bind_performBindPackage.toBoolean() ) {
+	if (props.userBuild && clean && logicalFile.isSQL() && props.bind_performBindPackage && props.bind_performBindPackage.toBoolean() ) {
 		int bindMaxRC = props.getFileProperty('bind_maxRC', buildFile).toInteger()
 
 		// if no  owner is set, use the user.name as package owner
@@ -125,7 +125,7 @@ sortedList.each { buildFile ->
 		def (bindRc, bindLogFile) = bindUtils.bindPackage(buildFile, props.cobol_dbrmPDS, props.buildOutDir, props.bind_runIspfConfDir,
 				props.bind_db2Location, props.bind_collectionID, owner, props.bind_qualifier, props.verbose && props.verbose.toBoolean());
 		if ( bindRc > bindMaxRC) {
-			error = true
+			clean = false
 			String errorMsg = "*! The bind package return code ($bindRc) for $buildFile exceeded the maximum return code allowed ($props.bind_maxRC)"
 			println(errorMsg)
 			buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}_bind.log":bindLogFile])
@@ -135,28 +135,34 @@ sortedList.each { buildFile ->
 	// clean up passed DD statements
 	job.stop()
 
-	if (error) 
-		props.error = "true"
-	else if (props.createBuildMaps && !isZUnitTestCase) {
-		// create build map for each build file upon success
-		BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
-		if (group.buildMapExists(buildFile)) {
-			if (props.verbose) println("* Replacing existing build map for $buildFile")
-			group.deleteBuildMap(buildFile)
+	if (clean) { // success
+		if (props.createBuildMaps && !isZUnitTestCase) {
+			// create build map for each build file upon success
+			BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
+			if (group.buildMapExists(buildFile)) {
+				if (props.verbose) println("* Replacing existing build map for $buildFile")
+				group.deleteBuildMap(buildFile)
+			}
+
+			BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
+			// populate outputs with IExecutes
+			List<IExecute> execs = new ArrayList<IExecute>()
+			if (compile) execs.add(compile)
+			if (linkEdit) execs.add(linkEdit)
+			buildMap.populateOutputs(execs)
+
+			// populate inputs using dependency resolution
+			buildMap.populateInputsFromGit(props.workspace, dependencySearch)
+			// populate binary inputs from load module scanning
+			if (linkEdit) { 
+				String scanLoadModule = props.getFileProperty('cobol_scanLoadModule', buildFile)
+				if (scanLoadModule && scanLoadModule.toBoolean())
+					buildMap.populateBinaryInputsFromGit(props.cobol_loadPDS, member)
+			}
 		}
-
-		BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
-		// populate outputs with IExecutes
-		List<IExecute> execs = new ArrayList<IExecute>()
-		if (compile != null) execs.add(compile)
-		if (linkEdit != null) execs.add(linkEdit)
-		buildMap.populateOutputs(execs)
-
-		// dependency resolution to populate sources and inputs with git metadata
-		buildMap.populateInputsFromGit(props.workspace, dependencySearch)
-
-		if (linkEdit != null) // scan load module to populate binary inputs
-			buildMap.populateBinaryInputsFromGit(props.cobol_loadPDS, member)
+	}
+	else { // error
+		props.error = "true"
 	}
 }
 

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -1,4 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import com.ibm.dbb.EnvVars
 import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
@@ -121,7 +122,7 @@ sortedList.each { buildFile ->
 		int bindMaxRC = props.getFileProperty('bind_maxRC', buildFile).toInteger()
 
 		// if no  owner is set, use the user.name as package owner
-		def owner = ( !props.bind_packageOwner ) ? System.getProperty("user.name") : props.bind_packageOwner
+		def owner = ( !props.bind_packageOwner ) ? EnvVars.getUserName() : props.bind_packageOwner
 
 		def (bindRc, bindLogFile) = bindUtils.bindPackage(buildFile, props.cobol_dbrmPDS, props.buildOutDir, props.bind_runIspfConfDir,
 				props.bind_db2Location, props.bind_collectionID, owner, props.bind_qualifier, props.verbose && props.verbose.toBoolean());

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -141,7 +141,7 @@ sortedList.each { buildFile ->
 		// create build map for each build file upon success
 		BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
 		if (group.buildMapExists(buildFile)) {
-			if (props.verbose) println("* Deleting build map for $buildFile as it already exists.")
+			if (props.verbose) println("* Replacing existing build map for $buildFile")
 			group.deleteBuildMap(buildFile)
 		}
 

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -137,7 +137,7 @@ sortedList.each { buildFile ->
 
 	if (error) 
 		props.error = "true"
-	else if (props.buildMapsEnabled && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
+	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
 		// create build map for each build file upon success
 		BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
 		

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -136,6 +136,21 @@ sortedList.each { buildFile ->
 
 	// clean up passed DD statements
 	job.stop()
+
+	// create build map for each build file upon success
+	if (props.buildMapsEnabled && MetadataStoreFactory.metadataStoreExists() && bindFlag && !isZUnitTestCase && !props.topicBranchBuild) {
+		BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
+		// populate outputs with IExecutes
+		List<IExecute> execs = new ArrayList<IExecute>()
+		if (compile != null) execs.add(compile)
+		if (linkEdit != null) execs.add(linkEdit)
+		buildMap.populateOutputs(execs)
+
+		// populate sources and inputs with git metadata
+		//buildMap.populateInputsFromGit()
+
+		// if link != null 
+	}
 }
 
 // end script

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -137,7 +137,7 @@ sortedList.each { buildFile ->
 
 	if (error) 
 		props.error = "true"
-	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
+	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase) {
 		// create build map for each build file upon success
 		BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
 		

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -139,7 +139,13 @@ sortedList.each { buildFile ->
 		props.error = "true"
 	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase) {
 		// create build map for each build file upon success
-		BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
+		BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
+		if (group.buildMapExists(buildFile)) {
+			if (props.verbose) println("* Deleting build map for $buildFile as it already exists.")
+			group.deleteBuildMap(buildFile)
+		}
+
+		BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
 		
 		// populate outputs with IExecutes
 		List<IExecute> execs = new ArrayList<IExecute>()

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -147,10 +147,10 @@ sortedList.each { buildFile ->
 		if (linkEdit != null) execs.add(linkEdit)
 		buildMap.populateOutputs(execs)
 
-		// populate sources and inputs with git metadata
+		// dependency resolution to populate sources and inputs with git metadata
 		buildMap.populateInputsFromGit(props.workspace, dependencySearch)
 
-		if (linkEdit != null) // populate binary inputs if program was linked
+		if (linkEdit != null) // scan load module to populate binary inputs
 			buildMap.populateBinaryInputsFromGit(props.cobol_loadPDS, member)
 	}
 }

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -137,7 +137,7 @@ sortedList.each { buildFile ->
 
 	if (error) 
 		props.error = "true"
-	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase) {
+	else if (props.createBuildMaps && !isZUnitTestCase) {
 		// create build map for each build file upon success
 		BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
 		if (group.buildMapExists(buildFile)) {
@@ -146,7 +146,6 @@ sortedList.each { buildFile ->
 		}
 
 		BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
-		
 		// populate outputs with IExecutes
 		List<IExecute> execs = new ArrayList<IExecute>()
 		if (compile != null) execs.add(compile)

--- a/languages/LinkEdit.groovy
+++ b/languages/LinkEdit.groovy
@@ -83,12 +83,12 @@ sortedList.each { buildFile ->
 			if (linkEdit) execs.add(linkEdit)
 			buildMap.populateOutputs(execs)
 			// populate inputs using dependency resolution
-			buildMap.populateInputsFromGit(props.workspace, props.bmsSearch)
+			buildMap.populateInputsFromGit(props.workspace, props.linkSearch)
 			// populate binary inputs from load module scanning
 			if (linkEdit) { 
 				String scanLoadModule = props.getFileProperty('linkedit_scanLoadModule', buildFile)
 				if (scanLoadModule && scanLoadModule.toBoolean())
-					buildMap.populateBinaryInputsFromGit(props.cobol_loadPDS, member)
+					buildMap.populateBinaryInputsFromGit(props.linkedit_loadPDS, member)
 			}
 		}
 	}

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -99,7 +99,7 @@ sortedList.each { buildFile ->
 
 	if (error)
 		props.error = "true"
-	else if (props.buildMapsEnabled && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
+	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
 		// create build map for each build file upon success
 		BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
 		

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -101,7 +101,13 @@ sortedList.each { buildFile ->
 		props.error = "true"
 	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase) {
 		// create build map for each build file upon success
-		BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
+		BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
+		if (group.buildMapExists(buildFile)) {
+			if (props.verbose) println("* Deleting build map for $buildFile as it already exists.")
+			group.deleteBuildMap(buildFile)
+		}
+
+		BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
 		
 		// populate outputs with IExecutes
 		List<IExecute> execs = new ArrayList<IExecute>()

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -103,7 +103,7 @@ sortedList.each { buildFile ->
 		// create build map for each build file upon success
 		BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
 		if (group.buildMapExists(buildFile)) {
-			if (props.verbose) println("* Deleting build map for $buildFile as it already exists.")
+			if (props.verbose) println("* Replacing existing build map for $buildFile")
 			group.deleteBuildMap(buildFile)
 		}
 

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -99,7 +99,7 @@ sortedList.each { buildFile ->
 
 	if (error)
 		props.error = "true"
-	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase && !props.topicBranchBuild) {
+	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase) {
 		// create build map for each build file upon success
 		BuildMap buildMap = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).createBuildMap(buildFile) // build map creation
 		

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -46,39 +46,37 @@ sortedList.each { buildFile ->
 	File logFile = new File( props.userBuild ? "${props.buildOutDir}/${member}.log" : "${props.buildOutDir}/${member}.REXX.log")
 	if (logFile.exists())
 		logFile.delete()
-	MVSExec compile = createCompileCommand(buildFile, logicalFile, member, logFile)
 	File linkEditLogFile = new File( props.userBuild ? "${props.buildOutDir}/${member}.LinkEdit.log" : "${props.buildOutDir}/${member}.REXX.LinkEdit.log")
 	if (linkEditLogFile.exists())
 		linkEditLogFile.delete()
+	MVSExec compile = createCompileCommand(buildFile, logicalFile, member, logFile)
 	MVSExec linkEdit
 	if (needsLinking.toBoolean()) linkEdit = createLinkEditCommand(buildFile, logicalFile, member, linkEditLogFile)
-
 
 	// execute mvs commands in a mvs job
 	MVSJob job = new MVSJob()
 	job.start()
+	boolean clean = true
 
 	// compile the cobol program
 	int rc = compile.execute()
 	int maxRC = props.getFileProperty('rexx_compileMaxRC', buildFile).toInteger()
 
-	boolean error = false
-
+	
 	if (rc > maxRC) {
-		error = true
+		clean = false
 		String errorMsg = "*! The compile return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 		println(errorMsg)
-		
 		buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
 	}
 	else {
 		// if this program needs to be link edited . . .
-		if (needsLinking.toBoolean()) {
+		if (linkEdit) {
 			rc = linkEdit.execute()
 			maxRC = props.getFileProperty('rexx_linkEditMaxRC', buildFile).toInteger()
 
 			if (rc > maxRC) {
-				error = true
+				clean = false
 				String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"
 				println(errorMsg)
 				buildUtils.updateBuildResult(errorMsg:errorMsg,logs:["${member}.log":logFile])
@@ -97,29 +95,34 @@ sortedList.each { buildFile ->
 	// clean up passed DD statements
 	job.stop()
 
-	if (error)
-		props.error = "true"
-	else if (props.createBuildMaps && MetadataStoreFactory.metadataStoreExists() && !isZUnitTestCase) {
-		// create build map for each build file upon success
-		BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
-		if (group.buildMapExists(buildFile)) {
-			if (props.verbose) println("* Replacing existing build map for $buildFile")
-			group.deleteBuildMap(buildFile)
+	if (clean) { // success
+		if (props.createBuildMaps) {
+			// create build map for each build file upon success
+			BuildGroup group = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
+			if (group.buildMapExists(buildFile)) {
+				if (props.verbose) println("* Replacing existing build map for $buildFile")
+				group.deleteBuildMap(buildFile)
+			}
+
+			BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
+			
+			// populate outputs with IExecutes
+			List<IExecute> execs = new ArrayList<IExecute>()
+			if (compile != null) execs.add(compile)
+			if (linkEdit != null) execs.add(linkEdit)
+			buildMap.populateOutputs(execs)
+			// populate inputs and sources using dependency resolution
+			buildMap.populateInputsFromGit(props.workspace, dependencySearch)
+			// populate binary inputs from load module scanning
+			if (linkEdit != null) {
+				String scanLoadModule = props.getFileProperty('rexx_scanLoadModule', buildFile)
+				if (scanLoadModule && scanLoadModule.toBoolean())
+					buildMap.populateBinaryInputsFromGit(props.rexx_loadPDS, member)
+			}
 		}
-
-		BuildMap buildMap = group.createBuildMap(buildFile) // build map creation
-		
-		// populate outputs with IExecutes
-		List<IExecute> execs = new ArrayList<IExecute>()
-		if (compile != null) execs.add(compile)
-		if (linkEdit != null) execs.add(linkEdit)
-		buildMap.populateOutputs(execs)
-
-		// populate sources and inputs with git metadata
-		buildMap.populateInputsFromGit(props.workspace, dependencySearch)
-
-		if (linkEdit != null) // populate binary inputs if program was linked
-			buildMap.populateBinaryInputsFromGit(props.rexx_loadPDS, member)
+	}
+	else { // failure
+		props.error = "true"
 	}
 }
 

--- a/languages/ZunitConfig.groovy
+++ b/languages/ZunitConfig.groovy
@@ -1,4 +1,5 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import com.ibm.dbb.EnvVars
 import com.ibm.dbb.metadata.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
@@ -129,7 +130,7 @@ zunitDebugParm = props.getFileProperty('zunit_userDebugSessionTestParm', buildFi
 """
 	if (props.verbose) println(jcl)
 
-	def dbbConf = System.getenv("DBB_CONF")
+	def dbbConf = EnvVars.getDBBConf()
 
 	// Create jclExec
 	def zUnitRunJCL = new JCLExec().text(jcl)

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -144,6 +144,3 @@ bmsSearch = search:${workspace}/?path=${application}/bms/*.bms
 #
 linkSearch = search:[:LINK]${workspace}/?path=${application}/cobol/*.cbl     
 
-
-createBuildMaps=true
-

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -44,6 +44,10 @@ excludeFileList=.*,**/.*,**/*.properties,**/*.xml,**/*.groovy,**/*.json,**/*.md,
 # sample: skipImpactCalculationList=**/epsmtout.cpy,**/centralCopybooks/*.cpy
 skipImpactCalculationList=
 
+#
+# Build map creation enabled for the main build branch
+buildMapsEnabled=false
+
 
 ###############################################################
 # Build Property management

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -142,5 +142,8 @@ bmsSearch = search:${workspace}/?path=${application}/bms/*.bms
 # the scanners detect a static call to the literal, which would need to turn into a new rule for CALL:
 # staticCallSearch = search:[:CALL]${workspace}/?path=${application}/cobol/*.cbl
 #
-linkSearch = search:[:LINK]${workspace}/?path=${application}/cobol/*.cbl         
+linkSearch = search:[:LINK]${workspace}/?path=${application}/cobol/*.cbl     
+
+
+createBuildMaps=true
 

--- a/test/testScripts/fullBuild.groovy
+++ b/test/testScripts/fullBuild.groovy
@@ -11,7 +11,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // Create full build command

--- a/test/testScripts/fullBuild_debug.groovy
+++ b/test/testScripts/fullBuild_debug.groovy
@@ -11,7 +11,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // Create full build command with debug option

--- a/test/testScripts/fullBuild_fileTruncation.groovy
+++ b/test/testScripts/fullBuild_fileTruncation.groovy
@@ -11,7 +11,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // Create full build command

--- a/test/testScripts/fullBuild_languageConfigurations.groovy
+++ b/test/testScripts/fullBuild_languageConfigurations.groovy
@@ -11,7 +11,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // Create full build command

--- a/test/testScripts/impactBuild.groovy
+++ b/test/testScripts/impactBuild.groovy
@@ -12,7 +12,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // create impact build command

--- a/test/testScripts/impactBuild_deletion.groovy
+++ b/test/testScripts/impactBuild_deletion.groovy
@@ -12,7 +12,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // create impact build command

--- a/test/testScripts/impactBuild_preview.groovy
+++ b/test/testScripts/impactBuild_preview.groovy
@@ -12,7 +12,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // create impact build command for preview

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -12,7 +12,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // create impact build command

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -12,7 +12,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // create impact build command

--- a/test/testScripts/mergeBuild.groovy
+++ b/test/testScripts/mergeBuild.groovy
@@ -12,7 +12,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // prepare properties file

--- a/test/testScripts/resetBuild.groovy
+++ b/test/testScripts/resetBuild.groovy
@@ -11,7 +11,7 @@ println "** Executing test script ${this.class.getName()}.groovy"
 println "**************************************************************"
 
 // Get the DBB_HOME location
-def dbbHome = EnvVars.getHome()
+def dbbHome = EnvVars.getDBBHome()
 if (props.verbose) println "** DBB_HOME = ${dbbHome}"
 
 // Create reset build command

--- a/test/utils/testUtilities.groovy
+++ b/test/utils/testUtilities.groovy
@@ -239,7 +239,7 @@ def runBaselineBuild(String testScriptPropFiles) {
 
 	println "\n** Running full build to set baseline"
 
-	def dbbHome = EnvVars.getHome()
+	def dbbHome = EnvVars.getDBBHome()
 				
 	def fullBuildCommand = []
 	fullBuildCommand << "${dbbHome}/bin/groovyz"

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -327,10 +327,11 @@ def sortBuildListAsMap(HashMap<String, String> buildMap, String rankPropertyName
  */
 def updateBuildResult(Map args) {
 	// args : errorMsg / warningMsg, logs[logName:logFile]
-	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
+	
 	// update build results only in non-userbuild scenarios
-	if (metadataStore && !props.userBuild) {
-		def buildResult = metadataStore.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
+	if (MetadataStoreFactory.metadataStoreExists() && !props.userBuild) {
+		MetadataStore mds = MetadataStoreFactory.getMetadataStore()
+		def buildResult = mds.getBuildGroup(props.applicationBuildGroup).getBuildResult(props.applicationBuildLabel)
 		if (!buildResult) {
 			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
 			return

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -331,7 +331,7 @@ def updateBuildResult(Map args) {
 	// update build results only in non-userbuild scenarios
 	if (MetadataStoreFactory.metadataStoreExists() && !props.userBuild) {
 		MetadataStore mds = MetadataStoreFactory.getMetadataStore()
-		def buildResult = mds.getBuildGroup(props.applicationBuildGroup).getBuildResult(props.applicationBuildLabel)
+		BuildResult buildResult = mds.getBuildGroup(props.applicationBuildGroup).getBuildResult(props.applicationBuildLabel)
 		if (!buildResult) {
 			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
 			return

--- a/utilities/BuildUtilities.groovy
+++ b/utilities/BuildUtilities.groovy
@@ -590,13 +590,14 @@ def getLangPrefix(String scriptName){
 def retrieveLastBuildResult(){
 	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 	// get the last build result
-	def lastBuildResult = metadataStore.getLastBuildResult(props.applicationBuildGroup, BuildResult.COMPLETE, BuildResult.CLEAN)
+	BuildResult lastBuildResult = metadataStore.getBuildGroup(props.applicationBuildGroup).getLastBuildResult(BuildResult.COMPLETE, BuildResult.CLEAN)
 
 	if (lastBuildResult == null && props.topicBranchBuild){
 		// if this is the first topic branch build get the main branch build result
 		String mainBranchBuildGroup = "${props.application}-${props.mainBuildBranch}"
 		if (props.verbose) println "** No previous successful topic branch build result. Retrieving last successful build result from the main build branch group (${mainBranchBuildGroup})."
-		lastBuildResult = metadataStore.getLastBuildResult(mainBranchBuildGroup, BuildResult.COMPLETE, BuildResult.CLEAN)
+		if (metadataStore.buildGroupExists(mainBranchBuildGroup))
+			lastBuildResult = metadataStore.getBuildGroup(mainBranchBuildGroup).getLastBuildResult(BuildResult.COMPLETE, BuildResult.CLEAN)
 	}
 
 	if (lastBuildResult == null) {

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -7,7 +7,6 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 @Field BuildProperties props = BuildProperties.getInstance()
-@Field MetadataStore metadataStore
 
 /*
  * Tests if directory is in a local git repository
@@ -414,12 +413,6 @@ def getChangedProperties(String gitDir, String baseline, String currentHash, Str
 
 /** helper methods **/
 
-def getMetadataStore() {
-	if (!metadataStore)
-		metadataStore = MetadataStoreFactory.getMetadataStore()
-	return metadataStore
-}
-
 /*
  * updateBuildResult - for git cmd related issues
  */
@@ -428,7 +421,7 @@ def updateBuildResult(Map args) {
 
 	// update build results only in non-userbuild scenarios
 	if (MetadataStoreFactory.metadataStoreExists() && !props.userBuild) {
-		def buildResult = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).getBuildResult(props.applicationBuildLabel)
+		BuildResult buildResult = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).getBuildResult(props.applicationBuildLabel)
 		if (!buildResult) {
 			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
 			return

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -425,11 +425,10 @@ def getMetadataStore() {
  */
 def updateBuildResult(Map args) {
 	// args : errorMsg / warningMsg
-	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
 
 	// update build results only in non-userbuild scenarios
-	if (metadataStore && !props.userBuild) {
-		def buildResult = metadataStore.getBuildResult(props.applicationBuildGroup, props.applicationBuildLabel)
+	if (MetadataStoreFactory.metadataStoreExists() && !props.userBuild) {
+		def buildResult = MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup).getBuildResult(props.applicationBuildLabel)
 		if (!buildResult) {
 			println "*! No build result found for BuildGroup '${props.applicationBuildGroup}' and BuildLabel '${props.applicationBuildLabel}'"
 			return

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -643,13 +643,17 @@ def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile log
 		LogicalFile scannerLogicalFile = scanner.scan(buildUtils.relativizePath(buildFile), loadPDS)
 		if (props.verbose) println "*** Logical file = \n$scannerLogicalFile"
 
-		// overwrite original logicalDependencies with load module dependencies
-		logicalFile.setLogicalDependencies(scannerLogicalFile.getLogicalDependencies())
+		// set language and submodule attributes based on provided logical file
+		scannerLogicalFile.setLanguage(logicalFile.getLanguage())
+		scannerLogicalFile.setCICS(logicalFile.isCICS())
+		scannerLogicalFile.setSQL(logicalFile.isSQL())
+		scannerLogicalFile.setDLI(logicalFile.isDLI())
+		scannerLogicalFile.setMQ(logicalFile.isMQ())
 
 		// Store logical file and indirect dependencies to the outputs collection
 		MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
 												.getCollection("outputs")
-												.addLogicalFile( logicalFile );
+												.addLogicalFile( scannerLogicalFile );
 	}
 }
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -650,7 +650,7 @@ def saveStaticLinkDependencies(String buildFile, String loadPDS, LogicalFile log
 
 		// Store logical file and indirect dependencies to the outputs collection
 		MetadataStoreFactory.getMetadataStore().getBuildGroup(props.applicationBuildGroup)
-												.getCollection("${props.applicationOutputsCollectionName}")
+												.getCollection("outputs")
 												.addLogicalFile( logicalFile );
 	}
 }

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -217,13 +217,13 @@ def createMergeBuildList(){
 def findImpactedFiles(String impactSearch, String changedFile) {
 	
 	List<String> collections = new ArrayList<String>()
-	collections.add(props.applicationCollectionName)
-	collections.add(props.applicationOutputsCollectionName)
+	collections.add("sources")
+	collections.add("outputs")
 	
 	if (props.verbose)
 		println ("*** Creating SearchPathImpactFinder with collections " + collections + " and impactSearch configuration " + impactSearch)
 	
-	def finder = new SearchPathImpactFinder(impactSearch, collections)
+	def finder = new SearchPathImpactFinder(impactSearch, props.applicationBuildGroup, collections)
 	
 	// Find all files impacted by the changed file
 	impacts = finder.findImpactedFiles(changedFile, props.workspace)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -515,8 +515,6 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 	List<LogicalFile> logicalFiles = new ArrayList<LogicalFile>()
 	List<PathMatcher> excludeMatchers = buildUtils.createPathMatcherPattern(props.excludeFileList)
 
-	verifyCollections()
-
 	// remove deleted files from collection
 	deletedFiles.each { file ->
 		// files in a collection are stored as relative paths from a source directory

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -137,13 +137,13 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
 
 		// get all collections which match pattern
 		List<String> selectedCollections = new ArrayList()
-		metadataStore.getCollections().each{ it ->
+		metadataStore.getBuildGroup(props.applicationBuildGroup).getCollections().each{ it ->
 			cName = it.getName()
 			if (matchesPattern(cName,collectionMatcherPatterns)) selectedCollections.add(cName)
 		}
 		
 		// run query
-		logicalImpactedFilesCollections = metadataStore.getImpactedFiles(selectedCollections, logicalDependencies);
+		logicalImpactedFilesCollections = metadataStore.getBuildGroup(props.applicationBuildGroup).getImpactedFiles(selectedCollections, logicalDependencies);
 	}
 	return logicalImpactedFilesCollections
 }

--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -110,6 +110,7 @@ def reportExternalImpacts(Set<String> changedFiles){
 
 def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFiles, String analysisMode) {
 	MetadataStore metadataStore = MetadataStoreFactory.getMetadataStore()
+	BuildGroup buildGroup = metadataStore.getBuildGroup(props.applicationBuildGroup)
 
 	// local matchers to inspect files and collections
 	List<Pattern> collectionMatcherPatterns = createMatcherPatterns(props.reportExternalImpactsCollectionPatterns)
@@ -137,13 +138,13 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
 
 		// get all collections which match pattern
 		List<String> selectedCollections = new ArrayList()
-		metadataStore.getBuildGroup(props.applicationBuildGroup).getCollections().each{ it ->
+		buildGroup.getCollections().each{ it ->
 			cName = it.getName()
 			if (matchesPattern(cName,collectionMatcherPatterns)) selectedCollections.add(cName)
 		}
 		
 		// run query
-		logicalImpactedFilesCollections = metadataStore.getBuildGroup(props.applicationBuildGroup).getImpactedFiles(selectedCollections, logicalDependencies);
+		logicalImpactedFilesCollections = buildGroup.getImpactedFiles(selectedCollections, logicalDependencies);
 	}
 	return logicalImpactedFilesCollections
 }


### PR DESCRIPTION
This PR provides refactoring & enhancements for DBB 2.0.2 support. Along with build map support, this PR also updates zAppBuild for the latest DBB metadata organization which uses build groups to contain both build results and collections. This PR also replaces any DBB API calls that are deprecated in DBB 2.0.2 with viable replacements as appropriate. 

See detailed list of changes below for additional information:

Changes Made:
- Use EnvVars for user property retrieval wherever possible 
- Use BuildGroup to house both build result **and** collections
  - Removed properties: `applicationCollectionName`, `applicationOutputsCollectionName` 
    - use build group name (`applicationBuildGroup`) as they exclusive identifier with similar naming convention to the previous collection names: `${props.application}-${props.applicationCurrentBranch}` 
    - use `sources` and `outputs` as the sources and outputs collections identifiers
  - Introduce `initMetadataArtifacts()` method in build.groovy to handle initialization of all metadata artifacts required for build
    - Handles migration from legacy collections if they exist
    - Uses new MDS build group creation APIs - `createBuildGroup()` and `createTopicBranchBuildGroup()` 
- BuildMap generation support:
  - Introduce `buildMapsEnabled` property in application.properties. Default = "false". Use as the main property to disable build map generation. However, setting the property to true will not always generate build maps. See behavior below:
    - Build Maps will not be generated if there is no metadatastore available (user-build) or if zAppBuild detects this is a topic branch build.  
  - Refactor and add build map support to the following language scripts, where DBB APIs are available to support the language script structure:
    - Assembler.groovy
    - BMS.groovy (*using impact searchpath for build map input population dependency resolution)
    - Cobol.groovy
    - Easytrieve.groovy
    - LinkEdit.groovy (*using impact searchpath for build map input population dependency resolution)
    - PLI.groovy
    - REXX.groovy
- Fixed defect in ImpactUtilities.saveStaticLinkDependencies where a cached live "sources" logical file was being edited and then reflected on the cache on subsequent calls to the SearchPathDependencyResolver. To resolve, used logical file returned from Link Edit Scanner and set language & subsystem attributes from sources logical file.
- **Update required DBB version from 2.0.0 -> 2.0.2.1**
 