### PR TITLE
Fix NPE on build process finalization in catch clause

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -39,7 +39,7 @@ try {
 	println(errorMsg)
 	props.error = "true"
 	buildUtils.updateBuildResult(errorMsg:errorMsg)
-	finalizeBuildProcess(start:startTime, 0)
+	finalizeBuildProcess(start:startTime, count:0)
 }
 
 // create build list


### PR DESCRIPTION
Fix of the invocation of the finalizeBuildProcess in the catch block if an `AssertionError` is caught.