### PR TITLE
Added documentation of object decks with deployType

### DIFF
--- a/languages/Assembler.groovy
+++ b/languages/Assembler.groovy
@@ -314,7 +314,7 @@ def createAssemblerCommand(String buildFile, LogicalFile logicalFile, String mem
 	assembler.dd(new DDStatement().name("SYSUT1").options(props.assembler_tempOptions))
 
 	// define object dataset allocation
-	assembler.dd(new DDStatement().name("SYSLIN").dsn("${props.assembler_objPDS}($member)").options('shr').output(true))
+	assembler.dd(new DDStatement().name("SYSLIN").dsn("${props.assembler_objPDS}($member)").options('shr').output(true).deployType("OBJ"))
 
 	// create a SYSLIB concatenation with optional MACLIB and MODGEN
 	assembler.dd(new DDStatement().name("SYSLIB").dsn(props.assembler_macroPDS).options("shr"))

--- a/languages/Cobol.groovy
+++ b/languages/Cobol.groovy
@@ -196,11 +196,9 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 
 	// add DD statements to the compile command
 	
-	if (isZUnitTestCase){
+	if (isZUnitTestCase) {
 	compile.dd(new DDStatement().name("SYSIN").dsn("${props.cobol_testcase_srcPDS}($member)").options('shr').report(true))
-	}
-	else
-	{
+	} else {
 		compile.dd(new DDStatement().name("SYSIN").dsn("${props.cobol_srcPDS}($member)").options('shr').report(true))
 	}
 	
@@ -211,7 +209,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	}
 
 	// define object dataset allocation
-	compile.dd(new DDStatement().name("SYSLIN").dsn("${props.cobol_objPDS}($member)").options('shr').output(true))
+	compile.dd(new DDStatement().name("SYSLIN").dsn("${props.cobol_objPDS}($member)").options('shr').output(true).deployType("OBJ"))
 
 	// add a syslib to the compile command with optional bms output copybook and CICS concatenation
 	compile.dd(new DDStatement().name("SYSLIB").dsn(props.cobol_cpyPDS).options("shr"))

--- a/languages/Easytrieve.groovy
+++ b/languages/Easytrieve.groovy
@@ -143,7 +143,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	}
 	
 	// define object dataset allocation
-	compile.dd(new DDStatement().name("SYSLIN").dsn("${props.easytrieve_objPDS}($member)").options('shr').output(true))
+	compile.dd(new DDStatement().name("SYSLIN").dsn("${props.easytrieve_objPDS}($member)").options('shr').output(true).deployType("OBJ"))
 		
 	// add a syslib to the compile command
 	compile.dd(new DDStatement().name("PANDD").dsn(props.easytrieve_cpyPDS).options("shr"))

--- a/languages/PLI.groovy
+++ b/languages/PLI.groovy
@@ -184,7 +184,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	}
 
 	// define object dataset allocation
-	compile.dd(new DDStatement().name("SYSLIN").dsn("${props.pli_objPDS}($member)").options('shr').output(true))
+	compile.dd(new DDStatement().name("SYSLIN").dsn("${props.pli_objPDS}($member)").options('shr').output(true).deployType("OBJ"))
 
 	// add a syslib to the compile command with optional bms output copybook and CICS concatenation
 	compile.dd(new DDStatement().name("SYSLIB").dsn(props.pli_incPDS).options("shr"))

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -124,7 +124,7 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	String linkEditStream = props.getFileProperty('rexx_linkEditStream', buildFile)
 	String linkDebugExit = props.getFileProperty('rexx_linkDebugExit', buildFile)
 
-	compile.dd(new DDStatement().name("SYSPUNCH").dsn("${props.rexx_objPDS}($member)").options('shr').output(true))
+	compile.dd(new DDStatement().name("SYSPUNCH").dsn("${props.rexx_objPDS}($member)").options('shr').output(true).deployType("OBJ"))
 	String deployType = buildUtils.getDeployType("rexx_cexec", buildFile, null)
 	compile.dd(new DDStatement().name("SYSCEXEC").dsn("${props.rexx_cexecPDS}($member)").options('shr').output(true).deployType(deployType))
 	


### PR DESCRIPTION
This PR adds a "deploy type" to all Object decks generated during the build process. Object decks are now documented in the DBB Build Report, with an object type "OBJ". Object decks can be then processed and potentially integrated in the archive.