### PR TITLE
Fix for REXX properties

### DIFF
--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -78,7 +78,6 @@ sortedList.each { buildFile ->
 		String needsLinking = props.getFileProperty('rexx_linkEdit', buildFile)
 		if (needsLinking && needsLinking.toBoolean()) {
 			rc = linkEdit.execute()
-			maxRC = props.getFileProperty('rexx_linkEditMaxRC', buildFile).toInteger()
 			if (props.getFileProperty('rexx_linkEditMaxRC', buildFile)) {
 				maxRC = props.getFileProperty('rexx_linkEditMaxRC', buildFile).toInteger()
 			} else {

--- a/languages/REXX.groovy
+++ b/languages/REXX.groovy
@@ -57,8 +57,13 @@ sortedList.each { buildFile ->
 
 	// compile the cobol program
 	int rc = compile.execute()
-	int maxRC = props.getFileProperty('rexx_compileMaxRC', buildFile).toInteger()
-
+	int maxRC
+	if (props.getFileProperty('rexx_compileMaxRC', buildFile)) {
+		maxRC = props.getFileProperty('rexx_compileMaxRC', buildFile).toInteger()
+	} else {
+		maxRC = 4
+	}
+	
 	boolean bindFlag = true
 
 	if (rc > maxRC) {
@@ -71,9 +76,14 @@ sortedList.each { buildFile ->
 	else {
 		// if this program needs to be link edited . . .
 		String needsLinking = props.getFileProperty('rexx_linkEdit', buildFile)
-		if (needsLinking.toBoolean()) {
+		if (needsLinking && needsLinking.toBoolean()) {
 			rc = linkEdit.execute()
 			maxRC = props.getFileProperty('rexx_linkEditMaxRC', buildFile).toInteger()
+			if (props.getFileProperty('rexx_linkEditMaxRC', buildFile)) {
+				maxRC = props.getFileProperty('rexx_linkEditMaxRC', buildFile).toInteger()
+			} else {
+				maxRC = 4
+			}
 
 			if (rc > maxRC) {
 				String errorMsg = "*! The link edit return code ($rc) for $buildFile exceeded the maximum return code allowed ($maxRC)"


### PR DESCRIPTION
Fixing issue #548 
The PR adds some checks and use defaults values if these properties are not set. They are set by default in the REXX.properties file of application-conf folder.