### PR TITLE
REXX properties as required

### DIFF
--- a/build-conf/REXX.properties
+++ b/build-conf/REXX.properties
@@ -4,8 +4,8 @@
 # Comma separated list of required build properties for REXX.groovy
 rexx_requiredBuildProperties=rexx_srcPDS,rexx_objPDS,rexx_loadPDS,\
   rexx_cexecPDS, rexx_compiler,rexx_linkEditor,rexx_tempOptions, \
-  SFANLMD, \
-  rexx_dependencySearch
+  SFANLMD, rexx_dependencySearch, \
+  rexx_compileMaxRC, rexx_linkEditMaxRC, rexx_linkEdit
 
 #
 # rexx compiler name
@@ -53,5 +53,5 @@ rexx_outputDatasets=${rexx_cexecPDS},${rexx_loadPDS}
 #   rexx_dependenciesDatasetMapping = rexx_macroPDS :: **/rexxmacros/*.rexx
 #
 #  default copies all dependencies into the dependency dataset definition which was previously passed to the utilities/BuildUitilities.copySourceFiles method
-#   rexx_dependenciesDatasetMapping = rexx_srcPDS :: **/* 
+#   rexx_dependenciesDatasetMapping = rexx_srcPDS :: **/*
 rexx_dependenciesDatasetMapping = rexx_srcPDS :: **/*


### PR DESCRIPTION
Fixing issue #548 
The PR adds some properties as required in the `rexx_requiredBuildProperties` property.