### PR TITLE
Implement external impact reporting for changed files without build list

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -694,7 +694,7 @@ def createBuildList() {
 			println "** Perform analysis and reporting of external impacted files for the build list."
 			reportingUtils.reportExternalImpacts(buildSet)
 		} else if(changedFiles) {
-			println "** Perform analysis and reporting of external impacted files for changed files. No files on build list."
+			println "** Perform analysis and reporting of external impacted files for changed files only (no files in the build list)."
 			reportingUtils.reportExternalImpacts(changedFiles)
 		}
 	}

--- a/build.groovy
+++ b/build.groovy
@@ -690,10 +690,12 @@ def createBuildList() {
 		if (buildSet && changedFiles) {
 			println "** Perform analysis and reporting of external impacted files for the build list including changed files."
 			reportingUtils.reportExternalImpacts(buildSet.plus(changedFiles))
-		}
-		else if(buildSet) {
+		} else if(buildSet) {
 			println "** Perform analysis and reporting of external impacted files for the build list."
 			reportingUtils.reportExternalImpacts(buildSet)
+		} else if(changedFiles) {
+			println "** Perform analysis and reporting of external impacted files for changed files. No files on build list."
+			reportingUtils.reportExternalImpacts(changedFiles)
 		}
 	}
 	


### PR DESCRIPTION
This is adding the third condition to implement the case if no files are on the build list (potentially) but the build had identified changed file.

This is useful for  scenarios with just a copybook change in a shared copybook repo that does not have buildable files..