### PR TITLE
Adding logicalFileCollectionSizeLimit property to manage collection size during impact analysis.

### DIFF
--- a/build-conf/defaultzAppBuildConf.properties
+++ b/build-conf/defaultzAppBuildConf.properties
@@ -2,7 +2,7 @@
 # Default application properties used by zappbuild
 #
 #  treated as global defaults, if not overridden by
-#  settings in the /application-conf directory   
+#  settings in the /application-conf directory
 
 #
 # dbb.scannerMapping to map file extensions to DBB dependency scanner configurations
@@ -12,13 +12,13 @@
 #  Schema
 #  "scannerClass":"ScannerImplementation" : "languageHint":"DBBScannerHint"  :: comma separated list of file extensions
 #
-#  Be aware, that the DependencyScannerRegistry comes with a set of default scanner configurations, 
+#  Be aware, that the DependencyScannerRegistry comes with a set of default scanner configurations,
 #   which are documented at:
 #   https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/com/ibm/dbb/dependency/DependencyScannerRegistry.html
-# 
-#  If a file extension of a build file is not specified in the mapping,  
+#
+#  If a file extension of a build file is not specified in the mapping,
 #   zAppBuild will skip scanning the file and only record a LogicalFile without capturing dependencies.
-#    
+#
 # Default mappings (always present based on DependencyScannerRegistry)
 dbb.scannerMapping = "scannerClass":"DependencyScanner", "languageHint":"COB" :: cbl,cpy,cob
 dbb.scannerMapping = "scannerClass":"DependencyScanner", "languageHint":"C" :: c, h
@@ -31,14 +31,14 @@ dbb.scannerMapping = "scannerClass":"ZUnitConfigScanner" :: bzucfg
 dbb.scannerMapping = "scannerClass":"DependencyScanner", "languageHint":"REXX" :: rexx
 
 #
-# Service URL for the Git provider to have a visual comparison of two hashes  
+# Service URL for the Git provider to have a visual comparison of two hashes
 # Leveraged as a build result property <props.gitRepositoryURL>/compare/
 # samples: GitHub : /compare/ ; GitLab :  /-/compare/
 gitRepositoryCompareService=/compare/
 
 #
 # Determine the behavior when facing a scanner failure
-# 'true' proceeds with the build and reports a warning 
+# 'true' proceeds with the build and reports a warning
 # 'false' will terminate the build process (default)
 continueOnScanFailure=false
 
@@ -94,4 +94,10 @@ dbb.LinkEditScanner.excludeFilter = ${SDFHLOAD}.*, ${SCEELKED}.*
 # for build files being mapped to language scripts
 #
 # Default : false
-documentDeleteRecords=false 
+documentDeleteRecords=false
+
+#
+# Used in impact analysis to limit the size of the collections, and thus the resulting transactions at one time.
+# The idea is to reduce load on the db2 database and on Heap space
+#
+logicalFileCollectionSizeLimit=500

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -519,7 +519,9 @@ def scanOnlyStaticDependencies(List buildList){
 
 
 def updateCollection(changedFiles, deletedFiles, renamedFiles) {
-
+	
+	int collectionSizeLimit = Integer.valueOf(props.logicalFileCollectionSizeLimit)
+	
 	if (!MetadataStoreFactory.metadataStoreExists()) {
 		if (props.verbose) println "** Unable to update collections. No Metadata Store."
 		return
@@ -631,7 +633,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 			}
 
 			// save logical files in batches of 500 to avoid running out of heap space
-			if (logicalFiles.size() == 500) {
+			if (logicalFiles.size() == collectionSizeLimit) {
 				if (props.verbose)
 					println "** Storing ${logicalFiles.size()} logical files in MetadataStore collection '$props.applicationCollectionName'"
 				metadataStore.getCollection(props.applicationCollectionName).addLogicalFiles(logicalFiles)


### PR DESCRIPTION
#
# Used in impact analysis to limit the size of the collections, and thus the resulting transactions at one time.
# The idea is to reduce load on the db2 database and on Heap space
#
logicalFileCollectionSizeLimit=500