### PR TITLE
Ability to perform impact analysis on changed/updated individual file properties

### DIFF
--- a/test/applications/MortgageApplication/properties/epsmlist.cbl.properties
+++ b/test/applications/MortgageApplication/properties/epsmlist.cbl.properties
@@ -1,0 +1,16 @@
+# Sample of an individual artifact properties file override for source file cobol/epsmlist.cbl
+
+# For details, please see the file property management documentation at:
+# https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md
+
+#
+# Sample to merge properties of this file level overwrite with the default setting for cobol_compileParms
+# A more exclusive overwrite would be cobol_compileParms=SOURCE
+cobol_compileParms=${cobol_compileParms},SOURCE
+
+# Trigger build
+
+#
+# Defines exclusively the compile options for this file
+#cobol_compilerVersion=V4
+

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -93,7 +93,7 @@ impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MF
 # both application level changes and individual file properties
 ###############################
 # changed source files to test impact builds
-impactBuild_properties_changedFile = application-conf/Cobol.properties, properties/epsmlist.cbl.properties
+impactBuild_properties_changedFiles = application-conf/Cobol.properties, properties/epsmlist.cbl.properties
 # build properties file source files to test impact builds
 impactBuild_properties_buildPropSetting = build-conf/impactPropertyChanges.properties
 # Use file properties to associate expected files built for a changed build property

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -90,13 +90,16 @@ impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MF
 
 ###############################
 # impactBuild_properties.groovy properties
+# both application level changes and individual file properties
 ###############################
 # changed source files to test impact builds
-impactBuild_properties_changedFile = application-conf/Cobol.properties
+impactBuild_properties_changedFile = application-conf/Cobol.properties, properties/epsmlist.cbl.properties
 # build properties file source files to test impact builds
 impactBuild_properties_buildPropSetting = build-conf/impactPropertyChanges.properties
 # Use file properties to associate expected files built for a changed build property
 impactBuild_properties_expectedFilesBuilt = epscmort.cbl,epscsmrd.cbl,epscsmrt.cbl,epsmlist.cbl,epsmpmt.cbl,epsnbrvl.cbl :: application-conf/Cobol.properties
+impactBuild_properties_expectedFilesBuilt = epsmlist.cbl,epsmlist.lnk :: properties/epsmlist.cbl.properties
+
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_properties_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -93,7 +93,7 @@ impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MF
 # both application level changes and individual file properties
 ###############################
 # changed source files to test impact builds
-impactBuild_properties_changedFiles = application-conf/Cobol.properties, properties/epsmlist.cbl.properties
+impactBuild_properties_changedFiles = application-conf/Cobol.properties,properties/epsmlist.cbl.properties
 # build properties file source files to test impact builds
 impactBuild_properties_buildPropSetting = build-conf/impactPropertyChanges.properties
 # Use file properties to associate expected files built for a changed build property

--- a/test/testScripts/impactBuild_properties.groovy
+++ b/test/testScripts/impactBuild_properties.groovy
@@ -26,7 +26,7 @@ impactBuildCommand << "--hlq ${props.hlq}"
 impactBuildCommand << "--logEncoding UTF-8"
 impactBuildCommand << (props.url ? "--url ${props.url}" : "")
 impactBuildCommand << (props.id ? "--id ${props.id}" : "")
-impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "") 
+impactBuildCommand << (props.pw ? "--pw ${props.pw}" : "")
 impactBuildCommand << (props.pwFile ? "--pwFile ${props.pwFile}" : "")
 impactBuildCommand << (props.verbose ? "--verbose" : "")
 impactBuildCommand << (props.propFiles ? "--propFiles ${props.propFiles},${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}" : "--propFiles ${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}")
@@ -35,43 +35,51 @@ impactBuildCommand << "--impactBuild"
 // iterate through change files to test impact build
 @Field def assertionList = []
 PropertyMappings filesBuiltMappings = new PropertyMappings('impactBuild_properties_expectedFilesBuilt')
-def changedPropFile = props.impactBuild_properties_changedFile
+def changedFiles = props.impactBuild_properties_changedFiles.split(',')
+
 try {
-		
-		// Test process
-	
-		// Create full build command to set baseline
-		testUtils.runBaselineBuild("${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}")
-	
+
+	// Test process
+
+	// Create full build command to set baseline
+	testUtils.runBaselineBuild("${props.zAppBuildDir}/test/applications/${props.app}/${props.impactBuild_properties_buildPropSetting}")
+
+	changedFiles.each { changedPropFile ->
+
 		// update changed file in Git repo test branch
 		println("\n** Injecting property update impactBuild_properties_changedFiles property : ${changedPropFile}")
 		testUtils.copyAndCommit(changedPropFile)
-		
+
 		// run impact build
 		println "\n** Running impact build test for changed file $changedPropFile"
 		println "** Executing ${impactBuildCommand.join(" ")}"
 		outputStream = new StringBuffer()
-		process = ['bash', '-c', impactBuildCommand.join(" ")].execute()
+		process = [
+			'bash',
+			'-c',
+			impactBuildCommand.join(" ")
+		].execute()
 		process.waitForProcessOutput(outputStream, System.err)
-		
+
 		// validate build results
 		validateImpactBuild(changedPropFile, filesBuiltMappings, outputStream)
+	}
 }
 finally {
-  // report failures
-  if (assertionList.size()>0) {
+	// report failures
+	if (assertionList.size()>0) {
 		println "\n***"
-	println "**START OF FAILED IMPACT BUILD ON PROPERTY CHANGE TEST RESULTS**\n"
-	println "*FAILED IMPACT BUILD ON PROPERT CHANGE TEST  RESULTS*\n" + assertionList
-	println "\n**END OF FAILED IMPACT BUILD ON PROPERTY CHANGE TEST RESULTS**"
-	println "***"
-  }
-  
-  // reset test branch
-  testUtils.resetTestBranch()
-  
-  // cleanup datasets
-  testUtils.cleanUpDatasets(props.impactBuild_properties_datasetsToCleanUp)
+		println "**START OF FAILED IMPACT BUILD ON PROPERTY CHANGE TEST RESULTS**\n"
+		println "*FAILED IMPACT BUILD ON PROPERT CHANGE TEST  RESULTS*\n" + assertionList
+		println "\n**END OF FAILED IMPACT BUILD ON PROPERTY CHANGE TEST RESULTS**"
+		println "***"
+	}
+
+	// reset test branch
+	testUtils.resetTestBranch()
+
+	// cleanup datasets
+	testUtils.cleanUpDatasets(props.impactBuild_properties_datasetsToCleanUp)
 }
 // script end
 
@@ -85,25 +93,25 @@ def validateImpactBuild(String changedFile, PropertyMappings filesBuiltMappings,
 
 	println "** Validating impact build results"
 	def expectedFilesBuiltList = filesBuiltMappings.getValue(changedFile).split(',')
-	
+
 	try{
-	// Validate clean build
-	assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY $changedFile\nOUTPUT STREAM:\n$outputStream\n"
+		// Validate clean build
+		assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY $changedFile\nOUTPUT STREAM:\n$outputStream\n"
 
-	// Validate expected number of files built
-	def numImpactFiles = expectedFilesBuiltList.size()
-	assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY  $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
+		// Validate expected number of files built
+		def numImpactFiles = expectedFilesBuiltList.size()
+		assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY  $changedFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
 
-	// Validate expected built files in output stream
-	assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
-	
-	println "**"
-	println "** IMPACT BUILD ON PROPERTY CHANGE : PASSED FOR $changedFile **"
-	println "**"
+		// Validate expected built files in output stream
+		assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FAILED FOR CHANGED PROPERTY $changedFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+
+		println "**"
+		println "** IMPACT BUILD ON PROPERTY CHANGE : PASSED FOR $changedFile **"
+		println "**"
 	}
 	catch(AssertionError e) {
 		def result = e.getMessage()
 		assertionList << result;
 		props.testsSucceeded = 'false'
- }
+	}
 }

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -56,7 +56,7 @@ def createImpactBuildList() {
 	if (calculatedChanges) {
 
 		// create build list using impact analysis
-		if (props.verbose) println "*** Perform impact analysis for changed files."
+		if (props.verbose) println "*** Perform impacted analysis for changed files."
 
 		PropertyMappings githashBuildableFilesMap = new PropertyMappings("githashBuildableFilesMap")
 
@@ -142,7 +142,7 @@ def createImpactBuildList() {
 		
 		// Perform impact analysis for property changes
 		if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean()){
-			if (props.verbose) println "*** Perform impact analysis for property changes."
+			if (props.verbose) println "*** Perform impacted analysis for property changes."
 
 			changedBuildProperties.each { changedProp ->
 
@@ -181,18 +181,16 @@ def createImpactBuildList() {
 					if (props.verbose) println "** Calculation of impacted files by changed property $changedProp has been skipped due to configuration. "
 				}
 			}
-		
-		if (props.verbose) println "*** Perform impact analysis for changed individual properties file changes."
 			
 		changedIndividualFilePropertiesFiles.each { changedIndividualPropertiesFile ->
-			def repositoryFileName = changedIndividualPropertiesFile.split('/').last().replace(".properties", "")
+			def repositoryFileName = changedIndividualPropertiesFile.last().replace(".properties", "")
 			def repositoryMemberName = CopyToPDS.createMemberName(repositoryFileName)
 			// locate logical files from the collection
 			def logicalFileList = metadataStore.getCollection(props.applicationCollectionName).getLogicalFiles(repositoryMemberName)
 			logicalFileList.each { logicalFile ->
 				if (logicalFile.getFile().contains(repositoryFileName)) {
 					buildSet.add(logicalFile.getFile())
-					if (props.verbose) println "** ${logicalFile.getFile()} is impacted by changed file $changedIndividualPropertiesFile. Adding to build list."
+					if (props.verbose) println "** $logicalFile.getFile() is impacted by changed file $changedIndividualPropertiesFile. Adding to build list."
 				}
 			}
 		}
@@ -464,6 +462,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 				if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean() && file.endsWith(".properties") && file.count('.') > 1){
 					if (props.verbose) println "**** $file"
 					changedIndividualFilePropertiesFiles << file
+					}
 				}
 			}
 		}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -56,7 +56,7 @@ def createImpactBuildList() {
 	if (calculatedChanges) {
 
 		// create build list using impact analysis
-		if (props.verbose) println "*** Perform impacted analysis for changed files."
+		if (props.verbose) println "*** Perform impact analysis for changed files."
 
 		PropertyMappings githashBuildableFilesMap = new PropertyMappings("githashBuildableFilesMap")
 
@@ -142,7 +142,7 @@ def createImpactBuildList() {
 		
 		// Perform impact analysis for property changes
 		if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean()){
-			if (props.verbose) println "*** Perform impacted analysis for property changes."
+			if (props.verbose) println "*** Perform impact analysis for property changes."
 
 			changedBuildProperties.each { changedProp ->
 
@@ -181,16 +181,18 @@ def createImpactBuildList() {
 					if (props.verbose) println "** Calculation of impacted files by changed property $changedProp has been skipped due to configuration. "
 				}
 			}
+		
+		if (props.verbose) println "*** Perform impact analysis for changed individual properties file changes."
 			
 		changedIndividualFilePropertiesFiles.each { changedIndividualPropertiesFile ->
-			def repositoryFileName = changedIndividualPropertiesFile.last().replace(".properties", "")
+			def repositoryFileName = changedIndividualPropertiesFile.split('/').last().replace(".properties", "")
 			def repositoryMemberName = CopyToPDS.createMemberName(repositoryFileName)
 			// locate logical files from the collection
 			def logicalFileList = metadataStore.getCollection(props.applicationCollectionName).getLogicalFiles(repositoryMemberName)
 			logicalFileList.each { logicalFile ->
 				if (logicalFile.getFile().contains(repositoryFileName)) {
 					buildSet.add(logicalFile.getFile())
-					if (props.verbose) println "** $logicalFile.getFile() is impacted by changed file $changedIndividualPropertiesFile. Adding to build list."
+					if (props.verbose) println "** ${logicalFile.getFile()} is impacted by changed file $changedIndividualPropertiesFile. Adding to build list."
 				}
 			}
 		}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -462,7 +462,6 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 				if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean() && file.endsWith(".properties") && file.count('.') > 1){
 					if (props.verbose) println "**** $file"
 					changedIndividualFilePropertiesFiles << file
-					}
 				}
 			}
 		}


### PR DESCRIPTION
This expands the existing  capability to automatically add the corresponding file to the build list build properties change. 

This is specifically for the case when the individual file properties file (e.q. `epsmlist.cbl.properties`) in the application repository changes.

See #582 

