### PR TITLE
Easytrieve compileSyslibConcatenation property

### DIFF
--- a/languages/Easytrieve.groovy
+++ b/languages/Easytrieve.groovy
@@ -149,9 +149,9 @@ def createCompileCommand(String buildFile, LogicalFile logicalFile, String membe
 	compile.dd(new DDStatement().name("PANDD").dsn(props.easytrieve_cpyPDS).options("shr"))
 	
 	// add custom concatenation
-	def easytrieveSyslibConcatenation = props.getFileProperty('easytrieve_easytrieveSyslibConcatenation', buildFile) ?: ""
-	if (easytrieveSyslibConcatenation) {
-		def String[] syslibDatasets = easytrieveSyslibConcatenation.split(',');
+	def compileSyslibConcatenation = props.getFileProperty('easytrieve_compileSyslibConcatenation', buildFile) ?: ""
+	if (compileSyslibConcatenation) {
+		def String[] syslibDatasets = compileSyslibConcatenation.split(',');
 		for (String syslibDataset : syslibDatasets )
 		compile.dd(new DDStatement().dsn(syslibDataset).options("shr"))
 	}


### PR DESCRIPTION
This addresses the reported problem #595 that pointed out a missing property. This has now been switched to `easytrieve_compileSyslibConcatenation` like documented in the README.

Thanks for reporting the issue.