### PR TITLE
Enable processing of files without needing to record them in the DBB Metadatastore

### DIFF
--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -15,13 +15,14 @@ Property | Description | Overridable
 --- | --- | ---
 runzTests | Boolean value to specify if zUnit tests should be run.  Defaults to `false`, to enable zUnit Tests, set value to `true`. | false
 applicationPropFiles | Comma separated list of additional application property files to load. Supports both absolute and relative file paths.  Relative paths assumed to be relative to ${workspace}/${application}/application-conf/. | false
-applicationSrcDirs | Comma separated list of all source directories included in application build. Each directory is assumed to be a local Git repository clone. Supports both absolute and relative paths though for maximum reuse of collected dependency data relative paths should be used.  Relative paths assumed to be relative to ${workspace}. | false
+applicationSrcDirs | Define a comma separated list of all source directories included in application build. Each directory is assumed to be a local Git repository clone or subdirectory of it. Supports both absolute and relative paths though for maximum reuse of collected dependency data relative paths should be used. Relative paths assumed to be relative to ${workspace}. | false
+skipStoringLogicalFile | Define files that should not be tracked/recorded as logical file in the DBB metadatastore. Files can still be processed by language scripts and will be present in the dbb build reports. | false
+excludeFileList | Files that are completely excluded from being processed by the build. | false
+skipImpactCalculationList | Files for which the impact analysis should be skipped in impact build | false
 buildOrder | Comma separated list of the build script processing order. | false
 formatConsoleOutput | Flag to log output in table views instead of printing raw JSON data | false
 mainBuildBranch | The main build branch of the main application repository.  Used for cloning collections for topic branch builds instead of rescanning the entire application. | false
 gitRepositoryURL | git repository URL of the application repository to establish links to the changed files in the build result properties | false
-excludeFileList | Files to exclude when scanning or running full build. | false
-skipImpactCalculationList | Files for which the impact analysis should be skipped in impact build | false
 addSubmodulesToBuildList  | Flag to include Static Sub module files in pipeline builds | false
 jobCard | JOBCARD for JCL execs | false
 **Build Property management** | | 

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -53,8 +53,25 @@ mainBuildBranch=main
 gitRepositoryURL=
 
 #
-# exclude list used when scanning or running full build
+# excludeFileList
+#  files that are completely excluded from being processed by the build
+#  ex: documentation, configuration files
 excludeFileList=.*,**/.*,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/application-conf/*.*
+
+#
+# skipStoringLogicalFile 
+# 
+#  Define files that should not be tracked/recorded as
+#  logical file in the DBB Metadatastore.
+#  
+#  These files can still be processed by language scripts
+#  and will be present in the dbb build reports.
+# 
+#  ex: skip recording logical files for JCL in the DBB Metadatastore
+#   to avoid overloading the DBB collections
+#  skipStoringLogicalFile = true :: **/*.jcl 
+# 
+skipStoringLogicalFile = true :: **/*.jcl 
 
 #
 # comma-separated list of file patterns for which impact calculation should be skipped. Uses glob file patterns

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -16,10 +16,37 @@ Transfer.properties,CRB.properties,CPP.properties,\
 reports.properties,languageConfigurationMapping.properties
 
 #
-# Comma separated list all source directories included in application build. Supports both absolute
-# and relative paths.  Relative assumed to be relative to ${workspace}.
-# ex: applicationSrcDirs=${application},/u/build/common/copybooks
+# applicationSrcDirs
+#  Comma separated list all source directories included in application build.
+#  Supports both absolute and relative paths. Relative assumed
+#  to be relative to ${workspace}.
+#
+#  ex: applicationSrcDirs=${application},/u/build/common/copybooks
+#
 applicationSrcDirs=${application}
+
+#
+# skipStoringLogicalFile 
+# 
+#  Define files that should not be tracked/recorded as
+#  logical file in the DBB Metadatastore.
+#  
+#  These files can still be processed by language scripts
+#  and will be present in the dbb build reports.
+# 
+#  ex: skip recording logical files for JCL in the DBB Metadatastore
+#   to avoid overloading the DBB collections
+# 
+#   skipStoringLogicalFile = true :: **/*.jcl 
+# 
+skipStoringLogicalFile = true :: **/*.jcl 
+
+#
+# excludeFileList
+#  files that are excluded from being processed by the build
+#  ex: documentation, configuration files
+#
+excludeFileList=.*,**/.*,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/application-conf/*.*
 
 #
 # Comma separated list of the build script processing order
@@ -51,27 +78,6 @@ mainBuildBranch=main
 # in the build result properties
 # ex: for GitHub: https://github.com/ibm/dbb-zappbuild/
 gitRepositoryURL=
-
-#
-# excludeFileList
-#  files that are completely excluded from being processed by the build
-#  ex: documentation, configuration files
-excludeFileList=.*,**/.*,**/*.xml,**/*.groovy,**/*.json,**/*.md,**/application-conf/*.*
-
-#
-# skipStoringLogicalFile 
-# 
-#  Define files that should not be tracked/recorded as
-#  logical file in the DBB Metadatastore.
-#  
-#  These files can still be processed by language scripts
-#  and will be present in the dbb build reports.
-# 
-#  ex: skip recording logical files for JCL in the DBB Metadatastore
-#   to avoid overloading the DBB collections
-#  skipStoringLogicalFile = true :: **/*.jcl 
-# 
-skipStoringLogicalFile = true :: **/*.jcl 
 
 #
 # comma-separated list of file patterns for which impact calculation should be skipped. Uses glob file patterns

--- a/utilities/DependencyScannerUtilities.groovy
+++ b/utilities/DependencyScannerUtilities.groovy
@@ -36,7 +36,7 @@ def getScanner(String buildFile){
 	scanner = DependencyScannerRegistry.getScanner(buildFile)
 
 	if (!scanner){
-		println("*! [WARNING]* No scanner specified for $buildFile")
+		println("*! [WARNING] No scanner specified for $buildFile.")
 	}
 
 	return scanner

--- a/utilities/DependencyScannerUtilities.groovy
+++ b/utilities/DependencyScannerUtilities.groovy
@@ -32,21 +32,11 @@ def getScanner(String buildFile){
 
 	def scanner = null
 
-	// check scannerMapping
+	// retrieve scanner from ScannerRegistry
 	scanner = DependencyScannerRegistry.getScanner(buildFile)
 
-	if (scanner){
-		if (scanner instanceof com.ibm.dbb.dependency.DependencyScanner) {
-			// Workaround - if no language hint exists the registry returned the default
-			//   Scanner, and the file is not mapped
-			if (((DependencyScanner) scanner).getLanguageHint() == null) {
-				if (props.verbose) println("*** $buildFile is not mapped to a DBB Dependency scanner.")
-				scanner = null
-			}
-		}
-	}
-	else {
-		if (props.verbose) println("*** No scanner specified for $buildFile")
+	if (!scanner){
+		println("*! [WARNING]* No scanner specified for $buildFile")
 	}
 
 	return scanner
@@ -64,6 +54,9 @@ def getScanner(String buildFile){
 def populateDependencyScannerRegistry() {
 
 	println("** Loading DBB scanner mapping configuration dbb.scannerMapping")
+
+	// Set default scanner as the RegistrationScanner
+	DependencyScannerRegistry.setDefaultScanner(new DummyScanner())
 
 	// loading scannerMappings
 	PropertyMappings scannerMapping = new PropertyMappings("dbb.scannerMapping")
@@ -108,7 +101,7 @@ def populateDependencyScannerRegistry() {
 			}
 			else {
 				println("**! The scanner configuration $scannerConfig could not successfully be parsed and is skipped.")
-			} 
+			}
 		}
 	}
 	else {
@@ -145,12 +138,12 @@ def parseConfigStringToMap(String configString) {
 			scannerConfigMap.put(pair[0].trim(),pair[1].trim())
 		}
 	}
-	
+
 	if (scannerConfigMap.scannerClass == null) {
 		println "*! The provided scanner mapping configuration ($configString) is not formed correctly and skipped."
 		println "*! Sample syntax: 'dbb.scannerMapping = \"scannerClass\":\"DependencyScanner\", \"languageHint\":\"COB\" :: cbl,cpy,cob'"
 		return null
 	}
-	
+
 	return scannerConfigMap
 }

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -252,7 +252,7 @@ def getPreviousGitHash(String gitDir) {
  * 
  */
 def getChangedFiles(String gitDir, String baseHash, String currentHash) {
-	String gitCmd = "git -C $gitDir --no-pager diff --name-status $baseHash $currentHash"
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status $baseHash $currentHash $gitDir"
 	return getChangedFiles(gitCmd)
 }
 
@@ -262,7 +262,7 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
  *  
  */
 def getMergeChanges(String gitDir, String baselineReference) {
-	String gitCmd = "git -C $gitDir --no-pager diff --name-status remotes/origin/$baselineReference...HEAD"
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status remotes/origin/$baselineReference...HEAD $gitDir"
 	return getChangedFiles(gitCmd)
 }
 
@@ -272,7 +272,7 @@ def getMergeChanges(String gitDir, String baselineReference) {
  *
  */
 def getConcurrentChanges(String gitDir, String baselineReference) {
-	String gitCmd = "git -C $gitDir --no-pager diff --name-status HEAD...remotes/origin/$baselineReference"
+	String gitCmd = "git -C $gitDir --no-pager diff --name-status HEAD...remotes/origin/$baselineReference $gitDir"
 	return getChangedFiles(gitCmd)
 }
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -587,15 +587,15 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 
 			if (props.getFileProperty('skipStoringLogicalFile',file)) {
 				// treat file as a build file, but don't create a logicalFile in the DBB Medatastore
-				if (props.verbose) println "*** File $file (${props.workspace}/${file} is skipped from being added to DBB Metadatastore, but can be processed by build scripts.)"
+				if (props.verbose) println("*** The file '${props.workspace}/${file}' is not added to DBB Metadatastore, but can be processed by build scripts.")
 			} else {
 				try {
 					def logicalFile
 					def scanner = dependencyScannerUtils.getScanner(file)
 					if (scanner != null) {
-						if (props.verbose) println "*** Scanning file $file (${props.workspace}/${file} with ${scanner.getClass()})"
+						if (props.verbose) println("*** Scanning file '(${props.workspace}/${file}' with ${scanner.getClass()}")
 						logicalFile = scanner.scan(file, props.workspace)
-						if (props.verbose) println "*** Logical file for $file =\n$logicalFile"
+						if (props.verbose) println("*** Logical file for '$file' =\n$logicalFile")
 					} 
 
 					// Update logical file with dependencies to build properties
@@ -624,7 +624,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 								}
 								testCaseFiles.each{
 									it.addLogicalDependency(new LogicalDependency(sysProgDependency.getLname(),"SYSPROG","PROGRAMDEPENDENCY"))
-									if (props.verbose) println "*** Updating dependencies for test case program ${it.getFile()} =\n$it"
+									if (props.verbose) println("*** Updating dependencies for test case program '${it.getFile()}' =\n$it")
 									logicalFiles.add(it)
 								}
 							}
@@ -634,14 +634,14 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 					logicalFiles.add(logicalFile)
 				} catch (Exception e) {
 
-					String warningMsg = "***** Scanning failed for file $file (${props.workspace}/${file})"
+					String warningMsg = "*! [WARNING] Scanning failed for file '${props.workspace}/${file}'"
 					buildUtils.updateBuildResult(warningMsg:warningMsg)
 					println(warningMsg)
 					e.printStackTrace()
 
 					// terminate when continueOnScanFailure is not set to true
 					if(!(props.continueOnScanFailure == 'true')){
-						println "***** continueOnScan Failure set to false. Build terminates."
+						println("*! [ERROR] 'continueOnScanFailure' set to false. Terminating.")
 						System.exit(1)
 					}
 				}
@@ -659,7 +659,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 
 	// save logical files
 	if (props.verbose)
-		println "** Storing ${logicalFiles.size()} logical files in MetadataStore collection '$props.applicationCollectionName'"
+		println("** Storing ${logicalFiles.size()} logical files in MetadataStore collection '$props.applicationCollectionName'")
 	metadataStore.getCollection(props.applicationCollectionName).addLogicalFiles(logicalFiles)
 }
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -640,7 +640,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 					e.printStackTrace()
 
 					// terminate when continueOnScanFailure is not set to true
-					if(!(props.continueOnScanFailure == 'true')){
+					if(props.continueOnScanFailure && props.continueOnScanFailure.toBoolean() == false){
 						println("*! [ERROR] 'continueOnScanFailure' set to false. Terminating.")
 						System.exit(1)
 					}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -540,10 +540,6 @@ def scanOnlyStaticDependencies(List buildList){
 	}
 }
 
-
-
-
-
 def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 
 	if (!MetadataStoreFactory.metadataStoreExists()) {
@@ -589,70 +585,65 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 		if ( new File("${props.workspace}/${file}").exists() && !buildUtils.matches(file, excludeMatchers)) {
 			// files in a collection are stored as relative paths from a source directory
 
-			def scanner = dependencyScannerUtils.getScanner(file)
-			try {
-				def logicalFile
-				if (scanner != null) {
-					if (props.verbose) println "*** Scanning file $file (${props.workspace}/${file} with ${scanner.getClass()})"
-					logicalFile = scanner.scan(file, props.workspace)
-				} else {
-					// The below logic should be replaced with Registration Scanner when available
-					// See reported idea: https://ibm-z-software-portal.ideas.ibm.com/ideas/DBB-I-48
-					if (props.verbose) println "*** Skipped scanning file $file (${props.workspace}/${file})"
-					
-					// New logical file with Membername, buildfile, language set to file extension
-					logicalFile = new LogicalFile(CopyToPDS.createMemberName(file), file, file.substring(file.lastIndexOf(".") + 1).toUpperCase(), false, false, false)
-					
-					// Add logicalFile to LogicalFileCache
-					LogicalFileCache.add(props.workspace, logicalFile)
-				}
-				if (props.verbose) println "*** Logical file for $file =\n$logicalFile"
+			if (props.getFileProperty('skipStoringLogicalFile',file)) {
+				// treat file as a build file, but don't create a logicalFile in the DBB Medatastore
+				if (props.verbose) println "*** File $file (${props.workspace}/${file} is skipped from being added to DBB Metadatastore, but can be processed by build scripts.)"
+			} else {
+				try {
+					def logicalFile
+					def scanner = dependencyScannerUtils.getScanner(file)
+					if (scanner != null) {
+						if (props.verbose) println "*** Scanning file $file (${props.workspace}/${file} with ${scanner.getClass()})"
+						logicalFile = scanner.scan(file, props.workspace)
+						if (props.verbose) println "*** Logical file for $file =\n$logicalFile"
+					} 
 
-				// Update logical file with dependencies to build properties
-				if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean()){
-					createPropertyDependency(file, logicalFile)
-				}
+					// Update logical file with dependencies to build properties
+					if (props.impactBuildOnBuildPropertyChanges && props.impactBuildOnBuildPropertyChanges.toBoolean()){
+						createPropertyDependency(file, logicalFile)
+					}
 
-				// If configured, update test case program dependencies
-				if (props.createTestcaseDependency && props.createTestcaseDependency.toBoolean()) {
-					// If the file is a zUnit configuration file (BZUCFG)
-					if (scanner != null && scanner.getClass() == com.ibm.dbb.dependency.ZUnitConfigScanner) {
+					// If configured, update test case program dependencies
+					if (props.createTestcaseDependency && props.createTestcaseDependency.toBoolean()) {
+						// If the file is a zUnit configuration file (BZUCFG)
+						if (scanner != null && scanner.getClass() == com.ibm.dbb.dependency.ZUnitConfigScanner) {
 
-						def logicalDependencies = logicalFile.getLogicalDependencies()
+							def logicalDependencies = logicalFile.getLogicalDependencies()
 
-						def sysTestDependency = logicalDependencies.find{it.getLibrary().equals("SYSTEST")} // Get the test case program from testcfg
-						def sysProgDependency = logicalDependencies.find{it.getLibrary().equals("SYSPROG")} // Get the application program name from testcfg
+							def sysTestDependency = logicalDependencies.find{it.getLibrary().equals("SYSTEST")} // Get the test case program from testcfg
+							def sysProgDependency = logicalDependencies.find{it.getLibrary().equals("SYSPROG")} // Get the application program name from testcfg
 
-						if (sysTestDependency){
-							// find in local list of logical files first (batch processing)
-							def testCaseFiles = logicalFiles.findAll{it.getLname().equals(sysTestDependency.getLname())}
-							if (!testCaseFiles){ // alternate retrieve it from the collection
-								testCaseFiles = metadataStore.getCollection(props.applicationCollectionName).getLogicalFiles(sysTestDependency.getLname()).find{
-									it.getLanguage().equals("COB")
+							if (sysTestDependency){
+								// find in local list of logical files first (batch processing)
+								def testCaseFiles = logicalFiles.findAll{it.getLname().equals(sysTestDependency.getLname())}
+								if (!testCaseFiles){
+									// alternate retrieve it from the collection
+									testCaseFiles = metadataStore.getCollection(props.applicationCollectionName).getLogicalFiles(sysTestDependency.getLname()).find{
+										it.getLanguage().equals("COB")
+									}
 								}
-							}
-							testCaseFiles.each{
-								it.addLogicalDependency(new LogicalDependency(sysProgDependency.getLname(),"SYSPROG","PROGRAMDEPENDENCY"))
-								if (props.verbose) println "*** Updating dependencies for test case program ${it.getFile()} =\n$it"
-								logicalFiles.add(it)
+								testCaseFiles.each{
+									it.addLogicalDependency(new LogicalDependency(sysProgDependency.getLname(),"SYSPROG","PROGRAMDEPENDENCY"))
+									if (props.verbose) println "*** Updating dependencies for test case program ${it.getFile()} =\n$it"
+									logicalFiles.add(it)
+								}
 							}
 						}
 					}
-				}
 
-				logicalFiles.add(logicalFile)
+					logicalFiles.add(logicalFile)
+				} catch (Exception e) {
 
-			} catch (Exception e) {
+					String warningMsg = "***** Scanning failed for file $file (${props.workspace}/${file})"
+					buildUtils.updateBuildResult(warningMsg:warningMsg)
+					println(warningMsg)
+					e.printStackTrace()
 
-				String warningMsg = "***** Scanning failed for file $file (${props.workspace}/${file})"
-				buildUtils.updateBuildResult(warningMsg:warningMsg)
-				println(warningMsg)
-				e.printStackTrace()
-
-				// terminate when continueOnScanFailure is not set to true
-				if(!(props.continueOnScanFailure == 'true')){
-					println "***** continueOnScan Failure set to false. Build terminates."
-					System.exit(1)
+					// terminate when continueOnScanFailure is not set to true
+					if(!(props.continueOnScanFailure == 'true')){
+						println "***** continueOnScan Failure set to false. Build terminates."
+						System.exit(1)
+					}
 				}
 			}
 
@@ -670,7 +661,6 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 	if (props.verbose)
 		println "** Storing ${logicalFiles.size()} logical files in MetadataStore collection '$props.applicationCollectionName'"
 	metadataStore.getCollection(props.applicationCollectionName).addLogicalFiles(logicalFiles)
-	
 }
 
 /*


### PR DESCRIPTION
This PR delivers:
* Ability to process files without needing to record them in the DBB Metadatastore, such as JCL, PROC and other standalone files.
* Fixes impact builds defect to process files outside of `applicationSrcDirs` , see #624 
* Updates the `samples/application-conf` for the usage of `applicationSrcDir`, `skipStoringLogicalFile` and `excludeFileList`
* Switches to the DummyScanner API and drops workaround
