### PR TITLE
Modify fullBuild behaviour to drop dbb collections

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -584,15 +584,15 @@ def createBuildList() {
 	if (props.fullBuild) {
 		println "** --fullBuild option selected. $action all programs for application ${props.application}. Recreating DBB collections."
 		buildSet = buildUtils.createFullBuildList()
-		
-		println("* Deleting collection ${props.applicationCollectionName}")
-		metadataStore.deleteCollection(props.applicationCollectionName)
 
-		println("* Deleting collection ${props.applicationOutputsCollectionName}")
-		metadataStore.deleteCollection(props.applicationOutputsCollectionName)
-		
-		impactUtils.updateCollection(buildList, null, null)
-		
+		if (metadataStore) {
+			println("** Deleting collection ${props.applicationCollectionName}")
+			metadataStore.deleteCollection(props.applicationCollectionName)
+
+			println("** Deleting collection ${props.applicationOutputsCollectionName}")
+			metadataStore.deleteCollection(props.applicationOutputsCollectionName)
+		}
+		impactUtils.updateCollection(buildSet, null, null)
 	}
 	// check if impact build
 	else if (props.impactBuild) {

--- a/build.groovy
+++ b/build.groovy
@@ -582,9 +582,17 @@ def createBuildList() {
 			
 	// check if full build
 	if (props.fullBuild) {
-		println "** --fullBuild option selected. $action all programs for application ${props.application}"
-
+		println "** --fullBuild option selected. $action all programs for application ${props.application}. Recreating DBB collections."
 		buildSet = buildUtils.createFullBuildList()
+		
+		println("* Deleting collection ${props.applicationCollectionName}")
+		metadataStore.deleteCollection(props.applicationCollectionName)
+
+		println("* Deleting collection ${props.applicationOutputsCollectionName}")
+		metadataStore.deleteCollection(props.applicationOutputsCollectionName)
+		
+		impactUtils.updateCollection(buildList, null, null)
+		
 	}
 	// check if impact build
 	else if (props.impactBuild) {
@@ -666,14 +674,6 @@ def createBuildList() {
 				writer.write("$file\n")
 			}
 		}
-	}
-
-	// scan and update source collection with build list files for non-impact builds
-	// since impact build list creation already scanned the incoming changed files
-	// we do not need to scan them again
-	if (!props.impactBuild && !props.userBuild && !props.mergeBuild) {
-		println "** Scanning source code."
-		impactUtils.updateCollection(buildList, null, null)
 	}
 	
 	// Loading file/member level properties from member specific properties files

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -453,7 +453,7 @@ Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
 
 ### Perform Full Build to build all files
 
-The zAppBuild build option `--fullBuild` builds all files within the build scope which have a build script mapping defined in file.properties
+The zAppBuild build option `--fullBuild` drops the existing collections and recreates them by building all files within the build scope which have a build script mapping defined in file.properties
 
 ```
 groovyz dbb-zappbuild/build.groovy \
@@ -510,7 +510,8 @@ MortgageApplication/copybook/epspdata.cpy
 MortgageApplication/cobol/epsmpmt.cbl
 MortgageApplication/cobol/epscmort.cbl
 MortgageApplication/cobol/epscsmrd.cbl
-** Scanning source code.
+** Deleting collection MortgageApplication-master
+** Deleting collection MortgageApplication-master-outputs
 ** Updating collections MortgageApplication-master and MortgageApplication-master-outputs
 *** Scanning file MortgageApplication/copybook/epsmtout.cpy (/var/dbb/dbb-zappbuild/samples/MortgageApplication/copybook/epsmtout.cpy)
 *** Scanning file with the default scanner


### PR DESCRIPTION
Often, the expectations on the fullBuild is to recreate the DBB dependency information in the DBB collections. This is now implementing by dropping the collection before they get updated 