### PR TITLE
Use case when application teams add folders to applicationSrcDir

### DIFF
--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -27,6 +27,9 @@ reports.properties,languageConfigurationMapping.properties
 #  Supports both absolute and relative paths. Relative assumed
 #  to be relative to ${workspace}.
 #
+#  Adding new folders will result in considering all files in specified directory as
+#  new files, that will be added to the build list.
+#
 #  ex: applicationSrcDirs=${application},/u/build/common/copybooks
 #
 applicationSrcDirs=${application}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -408,7 +408,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 			if (lastBuildResult != null && props.impactBuild && !calculateConcurrentChanges){
 
 				if (!baseline) {
-					if (props.verbose) println "*! Baseline Hash for Directory $dir not found. Retrieving list of files that are considered to be added to the build scope."
+					if (props.verbose) println "*! Baseline hash for directory '$dir' not found. Retrieving list of files in '$dir' and adding to build list."
 					Set<String> fileSet = buildUtils.getFileSet(dir, true, '**/*.*', props.excludeFileList)
 					changed.addAll(fileSet)
 				}

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -406,10 +406,11 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 			// when a build result is provided and build type impactBuild,
 			//   calculate changed between baseline and current state of the repository
 			if (lastBuildResult != null && props.impactBuild && !calculateConcurrentChanges){
-				baseline = baselineHashes.get(buildUtils.relativizePath(dir))
-				current = currentHashes.get(buildUtils.relativizePath(dir))
-				if (!baseline || !current) {
-					if (props.verbose) println "*! Skipping directory $dir because baseline or current hash does not exist.  baseline : $baseline current : $current"
+
+				if (!baseline) {
+					if (props.verbose) println "*! Baseline Hash for Directory $dir not found. Retrieving list of files that are considered to be added to the build scope."
+					Set<String> fileSet = buildUtils.getFileSet(dir, true, '**/*.*', props.excludeFileList)
+					changed.addAll(fileSet)
 				}
 				else {
 					if (props.verbose) println "** Diffing baseline $baseline -> current $current"


### PR DESCRIPTION
This is implementing a strategy on impactBuilds once the application team is adding a new folder to `applicationSrcDir` that was not in scope of the build previously (and therefore does not have a baseline reference that can be retrieved).

From now on, it will add all files to the build list as new files.