### PR TITLE
Support moving files in the repository without rebuilding them

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -592,7 +592,7 @@ def createBuildList() {
 			println("** Deleting collection ${props.applicationOutputsCollectionName}")
 			metadataStore.deleteCollection(props.applicationOutputsCollectionName)
 		}
-		impactUtils.updateCollection(buildSet, null, null)
+		impactUtils.updateCollection(buildSet, null, null, null)
 	}
 	// check if impact build
 	else if (props.impactBuild) {

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -83,7 +83,7 @@ impactBuild_rename_renameFilesMapping = cobol/epscsmr2.cbl :: cobol/epscsmrt.cbl
 # build properties file source files to test impact builds with renaming
 impactBuild_rename_buildPropSetting = build-conf/impactBuildRename.properties
 # Use file properties to associate expected files built to renamed files
-impactBuild_rename_expectedFilesBuilt = "0" :: cobol/epscsmrt.cbl
+impactBuild_rename_expectedFilesBuilt = 0 :: cobol/epscsmrt.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -83,7 +83,7 @@ impactBuild_rename_renameFilesMapping = cobol/epscsmr2.cbl :: cobol/epscsmrt.cbl
 # build properties file source files to test impact builds with renaming
 impactBuild_rename_buildPropSetting = build-conf/impactBuildRename.properties
 # Use file properties to associate expected files built to renamed files
-impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: 0
+impactBuild_rename_expectedFilesBuilt = "0" :: cobol/epscsmrt.cbl
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -5,8 +5,15 @@
 # list of test scripts to run for this application
 #  each test scripts is expected to be independent of other scripts
 test_testOrder=resetBuild.groovy,\
+mergeBuild.groovy,\
 fullBuild.groovy,\
+fullBuild_languageConfigurations.groovy,\
+fullBuild_fileTruncation.groovy,\
+impactBuild.groovy,\
+impactBuild_preview.groovy,\
+impactBuild_properties.groovy,\
 impactBuild_renaming.groovy,\
+impactBuild_deletion.groovy,\
 resetBuild.groovy
 
 ###############################

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -83,7 +83,7 @@ impactBuild_rename_renameFilesMapping = cobol/epscsmr2.cbl :: cobol/epscsmrt.cbl
 # build properties file source files to test impact builds with renaming
 impactBuild_rename_buildPropSetting = build-conf/impactBuildRename.properties
 # Use file properties to associate expected files built to renamed files
-impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: ""
+impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: 0
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -83,7 +83,7 @@ impactBuild_rename_renameFilesMapping = cobol/epscsmr2.cbl :: cobol/epscsmrt.cbl
 # build properties file source files to test impact builds with renaming
 impactBuild_rename_buildPropSetting = build-conf/impactBuildRename.properties
 # Use file properties to associate expected files built to renamed files
-impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: cobol/epscsmrt.cbl
+impactBuild_rename_expectedFilesBuilt = epscsmr2.cbl :: ""
 # list of source datasets (LLQ) that should be deleted during impactBuild.groovy cleanUp
 impactBuild_rename_datasetsToCleanUp = BMS,COBOL,LINK,COPY,BMS.COPY,DBRM,LOAD,MFS,OBJ,TFORMAT
 

--- a/test/applications/MortgageApplication/test.properties
+++ b/test/applications/MortgageApplication/test.properties
@@ -5,15 +5,8 @@
 # list of test scripts to run for this application
 #  each test scripts is expected to be independent of other scripts
 test_testOrder=resetBuild.groovy,\
-mergeBuild.groovy,\
 fullBuild.groovy,\
-fullBuild_languageConfigurations.groovy,\
-fullBuild_fileTruncation.groovy,\
-impactBuild.groovy,\
-impactBuild_preview.groovy,\
-impactBuild_properties.groovy,\
 impactBuild_renaming.groovy,\
-impactBuild_deletion.groovy,\
 resetBuild.groovy
 
 ###############################

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -65,7 +65,7 @@ try {
 		process.waitForProcessOutput(outputStream, System.err)
 
 		// validate build results
-		validateImpactBuild(renameFile, filesBuiltMappings, outputStream)
+		validateImpactBuild(renameFile, newFilename, filesBuiltMappings, outputStream)
 	}
 }
 finally {
@@ -102,7 +102,7 @@ def renameAndCommit(String renameFile, String newFilename) {
 	task.waitForProcessOutput(outputStream, System.err)
 }
 
-def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
+def validateImpactBuild(String renameFile, String newFilename, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
 
 	try{
 		println "** Validating impact build results"
@@ -119,7 +119,6 @@ def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, 
 		assert outputStream.contains("*** Deleting renamed logical file for ${props.app}/${renameFile}") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
 		
 		// Validate that new files is scanned
-		newFilename=renamedFilesMapping.getValue(renameFile)
 		assert outputStream.contains("*** Scanning file '${props.app}/${newFilename}'") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND SCAN OF NEW FILE\nOUTPUT STREAM:\n$outputStream\n"				
 		
 		println "**"

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -119,7 +119,7 @@ def validateImpactBuild(String renameFile, String newFilename, PropertyMappings 
 		assert outputStream.contains("*** Deleting renamed logical file for ${props.app}/${renameFile}") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
 		
 		// Validate that new files is scanned
-		assert outputStream.contains("*** Scanning file \\'${props.app}/${newFilename}\\'") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND SCAN OF NEW FILE\nOUTPUT STREAM:\n$outputStream\n"				
+		assert outputStream.contains("*** Scanning file ${props.app}/${newFilename}") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND SCAN OF NEW FILE\nOUTPUT STREAM:\n$outputStream\n"				
 		
 		println "**"
 		println "** IMPACT BUILD TEST - FILE RENAME : PASSED FOR RENAMING $renameFile **"

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -119,7 +119,7 @@ def validateImpactBuild(String renameFile, String newFilename, PropertyMappings 
 		assert outputStream.contains("*** Deleting renamed logical file for ${props.app}/${renameFile}") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
 		
 		// Validate that new files is scanned
-		assert outputStream.contains("*** Scanning file '${props.app}/${newFilename}'") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND SCAN OF NEW FILE\nOUTPUT STREAM:\n$outputStream\n"				
+		assert outputStream.contains("*** Scanning file \'${props.app}/${newFilename}\'") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND SCAN OF NEW FILE\nOUTPUT STREAM:\n$outputStream\n"				
 		
 		println "**"
 		println "** IMPACT BUILD TEST - FILE RENAME : PASSED FOR RENAMING $renameFile **"

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -104,10 +104,11 @@ def renameAndCommit(String renameFile, String newFilename) {
 
 def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
 
-	println "** Validating impact build results"
-	def expectedFilesBuilt = filesBuiltMappings.getValue(renameFile) as int
-
 	try{
+		println "** Validating impact build results"
+
+		def expectedFilesBuilt = filesBuiltMappings.getValue(renameFile)
+
 		// Validate clean build
 		assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $renameFile\nOUTPUT STREAM:\n$outputStream\n"
 

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -105,22 +105,22 @@ def renameAndCommit(String renameFile, String newFilename) {
 def validateImpactBuild(String renameFile, PropertyMappings filesBuiltMappings, StringBuffer outputStream) {
 
 	println "** Validating impact build results"
-	def expectedFilesBuiltList = filesBuiltMappings.getValue(renameFile).split(',')
+	def expectedFilesBuilt = filesBuiltMappings.getValue(renameFile) as int
 
 	try{
 		// Validate clean build
 		assert outputStream.contains("Build State : CLEAN") : "*! IMPACT BUILD FAILED FOR $renameFile\nOUTPUT STREAM:\n$outputStream\n"
 
 		// Validate expected number of files built
-		def numImpactFiles = expectedFilesBuiltList.size()
-		assert outputStream.contains("Total files processed : ${numImpactFiles}") : "*! IMPACT BUILD FOR $renameFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${numImpactFiles}\nOUTPUT STREAM:\n$outputStream\n"
-
-		// Validate expected built files in output stream
-		assert expectedFilesBuiltList.count{ i-> outputStream.contains(i) } == expectedFilesBuiltList.size() : "*! IMPACT BUILD FOR $renameFile DOES NOT CONTAIN THE LIST OF BUILT FILES EXPECTED ${expectedFilesBuiltList}\nOUTPUT STREAM:\n$outputStream\n"
+		assert outputStream.contains("Total files processed : ${expectedFilesBuilt}") : "*! IMPACT BUILD FOR $renameFile TOTAL FILES PROCESSED ARE NOT EQUAL TO ${expectedFilesBuilt}\nOUTPUT STREAM:\n$outputStream\n"
 
 		// Validate message that file renamed was deleted from collections
 		assert outputStream.contains("*** Deleting renamed logical file for ${props.app}/${renameFile}") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
-				
+		
+		// Validate that new files is scanned
+		newFilename=renamedFilesMapping.getValue(renameFile)
+		assert outputStream.contains("*** Scanning file '${props.app}/${newFilename}'") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND SCAN OF NEW FILE\nOUTPUT STREAM:\n$outputStream\n"				
+		
 		println "**"
 		println "** IMPACT BUILD TEST - FILE RENAME : PASSED FOR RENAMING $renameFile **"
 		println "**"

--- a/test/testScripts/impactBuild_renaming.groovy
+++ b/test/testScripts/impactBuild_renaming.groovy
@@ -119,7 +119,7 @@ def validateImpactBuild(String renameFile, String newFilename, PropertyMappings 
 		assert outputStream.contains("*** Deleting renamed logical file for ${props.app}/${renameFile}") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND DELETION OF LOGICAL FILE\nOUTPUT STREAM:\n$outputStream\n"
 		
 		// Validate that new files is scanned
-		assert outputStream.contains("*** Scanning file \'${props.app}/${newFilename}\'") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND SCAN OF NEW FILE\nOUTPUT STREAM:\n$outputStream\n"				
+		assert outputStream.contains("*** Scanning file \\'${props.app}/${newFilename}\\'") : "*! IMPACT BUILD FOR $renameFile DO NOT FIND SCAN OF NEW FILE\nOUTPUT STREAM:\n$outputStream\n"				
 		
 		println "**"
 		println "** IMPACT BUILD TEST - FILE RENAME : PASSED FOR RENAMING $renameFile **"

--- a/utilities/GitUtilities.groovy
+++ b/utilities/GitUtilities.groovy
@@ -248,7 +248,7 @@ def getPreviousGitHash(String gitDir) {
 
 /*
  * getChangedFiles - assembles a git diff command to support the impactBuild for a given directory
- *  returns the changed, deleted and renamed files.
+ *  returns the changed, deleted, renamed and moved files.
  * 
  */
 def getChangedFiles(String gitDir, String baseHash, String currentHash) {
@@ -258,7 +258,7 @@ def getChangedFiles(String gitDir, String baseHash, String currentHash) {
 
 /*
  * getMergeChanges - assembles a git triple-dot diff command to support mergeBuild scenarios 
- *  returns the changed, deleted and renamed files between current HEAD and the provided baseline.
+ *  returns the changed, deleted, renamed and moved files between current HEAD and the provided baseline.
  *  
  */
 def getMergeChanges(String gitDir, String baselineReference) {
@@ -268,7 +268,7 @@ def getMergeChanges(String gitDir, String baselineReference) {
 
 /*
  * getMergeChanges - assembles a git triple-dot diff command to support mergeBuild scenarios
- *  returns the changed, deleted and renamed files between current HEAD and the provided baseline.
+ *  returns the changed, deleted, renamed and moved files between current HEAD and the provided baseline.
  *
  */
 def getConcurrentChanges(String gitDir, String baselineReference) {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -26,6 +26,7 @@ def createImpactBuildList() {
 	Set<String> changedFiles = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()
+	Set<String> movedFiles = new HashSet<String>()
 	Set<String> changedIndividualFilePropertiesFiles = new HashSet<String>()
 	Set<String> changedBuildProperties = new HashSet<String>()
 	Set<String> buildSet = new HashSet<String>()
@@ -37,7 +38,7 @@ def createImpactBuildList() {
 
 	// calculate changed files
 	if (lastBuildResult || props.baselineRef) {
-		(changedFiles, deletedFiles, renamedFiles, changedBuildProperties, changedIndividualFilePropertiesFiles) = calculateChangedFiles(lastBuildResult)
+		(changedFiles, deletedFiles, renamedFiles, movedFiles, changedBuildProperties, changedIndividualFilePropertiesFiles) = calculateChangedFiles(lastBuildResult)
 	}
 	else {
 		// else create a fullBuild list
@@ -50,7 +51,7 @@ def createImpactBuildList() {
 	}
 
 	// scan files and update source collection for impact analysis
-	updateCollection(changedFiles, deletedFiles, renamedFiles)
+	updateCollection(changedFiles, deletedFiles, renamedFiles, movedFiles)
 
 
 	if (calculatedChanges) {
@@ -217,13 +218,14 @@ def createMergeBuildList(){
 	Set<String> changedFiles = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()
+	Set<String> movedFiles = new HashSet<String>()
 	Set<String> changedIndividualFilePropertiesFiles = new HashSet<String>()
 	Set<String> changedBuildProperties = new HashSet<String>()
 	
-	(changedFiles, deletedFiles, renamedFiles, changedBuildProperties, changedIndividualFilePropertiesFiles) = calculateChangedFiles(null)
+	(changedFiles, deletedFiles, renamedFiles, movedFiles, changedBuildProperties, changedIndividualFilePropertiesFiles) = calculateChangedFiles(null)
 
 	// scan files and update source collection
-	updateCollection(changedFiles, deletedFiles, renamedFiles)
+	updateCollection(changedFiles, deletedFiles, renamedFiles, movedFiles)
 
 	// iterate over changed file and add them to the buildSet
 
@@ -238,7 +240,7 @@ def createMergeBuildList(){
 		}
 	}
 
-	return [buildSet, changedFiles, deletedFiles, renamedFiles, changedBuildProperties, changedIndividualFilePropertiesFiles]
+	return [buildSet, changedFiles, deletedFiles, renamedFiles, movedFiles, changedBuildProperties, changedIndividualFilePropertiesFiles]
 }
 
 /*
@@ -327,6 +329,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 	Set<String> changedFiles = new HashSet<String>()
 	Set<String> deletedFiles = new HashSet<String>()
 	Set<String> renamedFiles = new HashSet<String>()
+	Set<String> movedFiles = new HashSet<String>()
 	Set<String> changedIndividualFilePropertiesFiles = new HashSet<String>()
 	Set<String> changedBuildProperties = new HashSet<String>()
 
@@ -393,6 +396,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 		def changed = []
 		def deleted = []
 		def renamed = []
+		def moved = []
 		String baseline
 		String current
 		String abbrevCurrent
@@ -414,7 +418,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 				}
 				else {
 					if (props.verbose) println "** Diffing baseline $baseline -> current $current"
-					(changed, deleted, renamed) = gitUtils.getChangedFiles(dir, baseline, current)
+					(changed, deleted, renamed, moved) = gitUtils.getChangedFiles(dir, baseline, current)
 				}
 			}
 			// when no build result is provided but the outgoingChangesBuild, calculate the outgoing changes
@@ -424,11 +428,11 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 				current = "HEAD"
 
 				if (props.verbose) println "** Triple-dot diffing configuration baseline remotes/origin/$baseline -> current HEAD"
-				(changed, deleted, renamed) = gitUtils.getMergeChanges(dir, baseline)
+				(changed, deleted, renamed, moved) = gitUtils.getMergeChanges(dir, baseline)
 			}
 			// calculate concurrent changes
 			else if (calculateConcurrentChanges) {
-				(changed, deleted, renamed) = gitUtils.getConcurrentChanges(dir, gitReference)
+				(changed, deleted, renamed, moved) = gitUtils.getConcurrentChanges(dir, gitReference)
 			}
 		}
 		else {
@@ -442,6 +446,8 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 		List<PathMatcher> excludeMatchers = buildUtils.createPathMatcherPattern(props.excludeFileList)
 
 		if (props.verbose) println "*** Changed files for directory $dir $msg:"
+		if (props.verbose) println "*** To be rebuilt"
+
 		changed.each { file ->
 			(file, mode) = fixGitDiffPath(file, dir, true, mode)
 			if ( file != null ) {
@@ -470,6 +476,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 		}
 
 		if (props.verbose) println "*** Deleted files for directory $dir $msg:"
+		if (props.verbose) println "*** To be removed from DBB Metadatastore"
 		deleted.each { file ->
 			if ( !buildUtils.matches(file, excludeMatchers)) {
 				(file, mode) = fixGitDiffPath(file, dir, false, mode)
@@ -481,10 +488,23 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 		}
 
 		if (props.verbose) println "*** Renamed files for directory $dir $msg:"
+		if (props.verbose) println "*** To be removed from DBB Metadatastore"
 		renamed.each { file ->
 			if ( !buildUtils.matches(file, excludeMatchers)) {
 				(file, mode) = fixGitDiffPath(file, dir, false, mode)
 				renamedFiles << file
+				if (props.verbose) println "**** $file"
+			} else {
+				if (props.verbose) println "**** $file is renamed, but is excluded from build scope. See excludeFileList configuration. No follow-up processing."
+			}
+		}
+
+		if (props.verbose) println "*** Moved files for directory $dir $msg:"
+		if (props.verbose) println "*** To be added to DBB Metadatastore, not rebuilt"
+		moved.each { file ->
+			if ( !buildUtils.matches(file, excludeMatchers)) {
+				(file, mode) = fixGitDiffPath(file, dir, false, mode)
+				movedFiles << file
 				if (props.verbose) println "**** $file"
 			} else {
 				if (props.verbose) println "**** $file is renamed, but is excluded from build scope. See excludeFileList configuration. No follow-up processing."
@@ -497,6 +517,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 		changedFiles,
 		deletedFiles,
 		renamedFiles,
+		movedFiles,
 		changedBuildProperties, 
 		changedIndividualFilePropertiesFiles
 	]
@@ -541,7 +562,7 @@ def scanOnlyStaticDependencies(List buildList){
 	}
 }
 
-def updateCollection(changedFiles, deletedFiles, renamedFiles) {
+def updateCollection(changedFiles, deletedFiles, renamedFiles, movedFiles) {
 
 	if (!MetadataStoreFactory.metadataStoreExists()) {
 		if (props.verbose) println "** Unable to update collections. No Metadata Store."
@@ -580,7 +601,8 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles) {
 	}
 
 	// scan changed files
-	changedFiles.each { file ->
+	def filesToBeScanned = ( changedFiles + movedFiles )
+	filesToBeScanned.each { file ->
 
 		// make sure file is not an excluded file
 		if ( new File("${props.workspace}/${file}").exists() && !buildUtils.matches(file, excludeMatchers)) {

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -496,7 +496,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 			}
 		}
 
-		// files are not built
+		// files are not built. This is for documentation purposes. See logic in GitUtilities.groovy
 		if (props.verbose) println "*** Moved files for directory $dir $msg (to be scanned and added to DBB Metadatastore):"
 		moved.each { file ->
 			if ( !buildUtils.matches(file, excludeMatchers)) {
@@ -504,7 +504,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 				movedFiles << file
 				if (props.verbose) println "**** $file"
 			} else {
-				if (props.verbose) println "**** $file is renamed, but is excluded from build scope. See excludeFileList configuration. No follow-up processing."
+				if (props.verbose) println "**** $file is moved, but is excluded from build scope. See excludeFileList configuration. No follow-up processing."
 			}
 		}
 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -613,7 +613,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, movedFiles) {
 					def logicalFile
 					def scanner = dependencyScannerUtils.getScanner(file)
 					if (scanner != null) {
-						if (props.verbose) println("*** Scanning file ${props.workspace}/${file} with ${scanner.getClass()}")
+						if (props.verbose) println("*** Scanning file ${file} with ${scanner.getClass()}")
 						logicalFile = scanner.scan(file, props.workspace)
 						if (props.verbose) println("*** Logical file for '$file' =\n$logicalFile")
 					} 

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -326,10 +326,10 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 	Map<String,String> currentHashes = new HashMap<String,String>()
 	Map<String,String> currentAbbrevHashes = new HashMap<String,String>()
 	Map<String,String> baselineHashes = new HashMap<String,String>()
-	Set<String> changedFiles = new HashSet<String>()
-	Set<String> deletedFiles = new HashSet<String>()
-	Set<String> renamedFiles = new HashSet<String>()
-	Set<String> movedFiles = new HashSet<String>()
+	Set<String> changedFiles = new HashSet<String>() // to be built
+	Set<String> deletedFiles = new HashSet<String>() // to be removed from metadatastore
+	Set<String> renamedFiles = new HashSet<String>() // to be removed from metadatastore
+	Set<String> movedFiles = new HashSet<String>() // to be scanned and added to metadatastore
 	Set<String> changedIndividualFilePropertiesFiles = new HashSet<String>()
 	Set<String> changedBuildProperties = new HashSet<String>()
 
@@ -445,8 +445,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 		// make sure file is not an excluded file
 		List<PathMatcher> excludeMatchers = buildUtils.createPathMatcherPattern(props.excludeFileList)
 
-		if (props.verbose) println "*** Changed files for directory $dir $msg:"
-		if (props.verbose) println "*** To be rebuilt"
+		if (props.verbose) println "*** Changed files for directory $dir $msg (to be built):"
 
 		changed.each { file ->
 			(file, mode) = fixGitDiffPath(file, dir, true, mode)
@@ -475,8 +474,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 			}
 		}
 
-		if (props.verbose) println "*** Deleted files for directory $dir $msg:"
-		if (props.verbose) println "*** To be removed from DBB Metadatastore"
+		if (props.verbose) println "*** Deleted files for directory $dir $msg (to be removed from DBB Metadatastore):"
 		deleted.each { file ->
 			if ( !buildUtils.matches(file, excludeMatchers)) {
 				(file, mode) = fixGitDiffPath(file, dir, false, mode)
@@ -487,8 +485,7 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 			}
 		}
 
-		if (props.verbose) println "*** Renamed files for directory $dir $msg:"
-		if (props.verbose) println "*** To be removed from DBB Metadatastore"
+		if (props.verbose) println "*** Renamed files for directory $dir $msg (to be removed from DBB Metadatastore):"
 		renamed.each { file ->
 			if ( !buildUtils.matches(file, excludeMatchers)) {
 				(file, mode) = fixGitDiffPath(file, dir, false, mode)
@@ -499,8 +496,8 @@ def calculateChangedFiles(BuildResult lastBuildResult, boolean calculateConcurre
 			}
 		}
 
-		if (props.verbose) println "*** Moved files for directory $dir $msg:"
-		if (props.verbose) println "*** To be added to DBB Metadatastore, not rebuilt"
+		// files are not built
+		if (props.verbose) println "*** Moved files for directory $dir $msg (to be scanned and added to DBB Metadatastore):"
 		moved.each { file ->
 			if ( !buildUtils.matches(file, excludeMatchers)) {
 				(file, mode) = fixGitDiffPath(file, dir, false, mode)

--- a/utilities/ImpactUtilities.groovy
+++ b/utilities/ImpactUtilities.groovy
@@ -613,7 +613,7 @@ def updateCollection(changedFiles, deletedFiles, renamedFiles, movedFiles) {
 					def logicalFile
 					def scanner = dependencyScannerUtils.getScanner(file)
 					if (scanner != null) {
-						if (props.verbose) println("*** Scanning file '(${props.workspace}/${file}' with ${scanner.getClass()}")
+						if (props.verbose) println("*** Scanning file ${props.workspace}/${file} with ${scanner.getClass()}")
 						logicalFile = scanner.scan(file, props.workspace)
 						if (props.verbose) println("*** Logical file for '$file' =\n$logicalFile")
 					} 


### PR DESCRIPTION
This is implementing #274 to support customers that have onboarded to dbb-zappbuild , and want to move files in the repository to different folders after their migration.

When a change with a similarity index of 100 is detected, the DBB metadatastore is only updated, but the file is not added to the buildList.