### PR TITLE
Address wrong behaviour on applying a file property override via Individual Property Files

### DIFF
--- a/utilities/FilePropUtilities.groovy
+++ b/utilities/FilePropUtilities.groovy
@@ -170,7 +170,7 @@ def checkExistingFilesPropertyDefinition(String buildFile, String member, String
         expValue = expandedValue.toString()
 	                
         // If build file is already mapped to a value
-        if (propertyMapping.isMapped(expValue, buildFile)) {
+        if (propertyMapping.isMapped(expValue, buildFile) && (props.getProperty(entryKey) != expValue ) ) {
             if (props.verbose) println("    *! An existing file property was detected for $buildFile ") 
             if (props.verbose) println("       Existing value ${entryKey}=${value}")
             filePatternIsMapped = true


### PR DESCRIPTION
This is addressing the defect reported in #654 . This is considered to be a work around, as it feels that the DBB toolkit is misbehaving when programmatically changing file properties.