### PR TITLE
Validate presence of build list files in workspace

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -67,7 +67,7 @@ else {
 		buildList.each { buildFile ->
 			absolutePathBuildFile = buildUtils.getAbsolutePath(buildFile)
 			if (!(new File(absolutePathBuildFile).exists())) {
-				println("** [WARN] Build file $buildFile not found at $absolutePathBuildFile. The file will be removed from the build list, build continues. Please validate situation.")
+				println("** [WARN] The build file '$buildFile' was not found at '$absolutePathBuildFile'. The file will be removed from the build list, and the build process continues. Please validate situation for any inconsistencies.")
 				buildList.remove(buildFile)
 			}			
 		}


### PR DESCRIPTION
This is related to the NPE raised in #655 to walk the build list before executing it

If a file does not exist:
* a warning is issued
* the file is removed from the build list