### PR TITLE
Fix file extension for PL/I sample

### DIFF
--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -207,7 +207,7 @@ objectSearch = search:${workspace}/?path=imports/**/include/bin/*.OBJ
 # pliincludeSearch
 # searchPath to locate PLI include files
 # used in dependency resolution and impact analysis
-pliincludeSearch = search:${workspace}/?path=${application}/plinc/*.cpy
+pliincludeSearch = search:${workspace}/?path=${application}/plinc/*.inc
 
 # asmMacroSearch
 # searchPath to locate Assembler macro files


### PR DESCRIPTION
The default `pliincludeSearch` value in the sample's `application-conf` is `search:${workspace}/?path=${application}/plinc/*.cpy` ([here](https://github.com/IBM/dbb-zappbuild/blob/main/samples/application-conf/application.properties#L210)). This PR changes the default value to end in `*.inc`, which is a more common file extension used for PL/I include files (as per [IBM's PL/I programming guide](https://www.ibm.com/docs/en/SSY2V3_5.3.0/com.ibm.ent.pl1.zos.doc/pg.pdf), for example).