### PR TITLE
Ensure Java 17 compatibility in ReportingUtilities.groovy

### DIFF
--- a/utilities/ReportingUtilities.groovy
+++ b/utilities/ReportingUtilities.groovy
@@ -133,7 +133,7 @@ def calculateLogicalImpactedFiles(List<String> fileList, Set<String> changedFile
 		}
 	}
 
-	if(logicalDependencies.size != 0) {
+	if(logicalDependencies.size() != 0) {
 
 		// get all collections which match pattern
 		List<String> selectedCollections = new ArrayList()


### PR DESCRIPTION
This addresses a JavaException due to a dirty development style in the ReportingUtilities that was fine with Java 8 and Java 11. The more recent Java runtimes are stricter with this regards.