### PR TITLE
Address NullPointerException if the users has not specified a baseline hash for directory

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -764,7 +764,8 @@ def finalizeBuildProcess(Map args) {
 					String gitchangedfilesKey = "$gitchangedfilesPrefix${buildUtils.relativizePath(dir)}"
 					def lastBuildResult= buildUtils.retrieveLastBuildResult()
 					if (lastBuildResult){
-						String userBaselineRef = (props.baselineRef) ? buildUtils.getUserProvidedBaselineRef(dir).replaceAll("origin/","") : null
+						String baselineRef = props.baselineRef ? buildUtils.getUserProvidedBaselineRef(dir) : null
+						String userBaselineRef = baselineRef?.replaceAll("origin/","")
 						String baselineHash = (userBaselineRef) ? userBaselineRef : lastBuildResult.getProperty(key)
 						String gitchangedfilesLink = props.gitRepositoryURL << "/" << props.gitRepositoryCompareService <<"/" << baselineHash << "..." << currenthash
 						String gitchangedfilesLinkUrl = new URI(gitchangedfilesLink).normalize().toString()


### PR DESCRIPTION
This addresses defect #674  when multiple directories are on applicationSrcDirs, but the user does not have specified a baseline ash for each directory, like outlined in [docs/BUILD.md](https://github.com/IBM/dbb-zappbuild/blob/main/docs/BUILD.md#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files) 