### PR TITLE
Update .gitattributes removing git-encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,22 +2,22 @@
 * text eol=lf
 
 # file encodings
-*.cpy zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.cbl zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.bms zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.pli zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.mfs zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.bnd zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.lnk zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.txt zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.groovy zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.sh zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.properties zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.asm zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.jcl zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.mac zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.json zos-working-tree-encoding=utf-8 git-encoding=utf-8
-*.yaml zos-working-tree-encoding=utf-8 git-encoding=utf-8
+*.cpy zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.cbl zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.bms zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.pli zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.mfs zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.bnd zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.lnk zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.txt zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.groovy zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.sh zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.properties zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.asm zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.jcl zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.mac zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
+*.json zos-working-tree-encoding=utf-8 working-tree-encoding=utf-8
+*.yaml zos-working-tree-encoding=utf-8 working-tree-encoding=utf-8
 
 # binary managed files
 *.rec binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,22 +2,22 @@
 * text eol=lf
 
 # file encodings
-*.cpy zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.cbl zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.bms zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.pli zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.mfs zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.bnd zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.lnk zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.txt zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.groovy zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.sh zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.properties zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.asm zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.jcl zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.mac zos-working-tree-encoding=ibm-1047 working-tree-encoding=utf-8
-*.json zos-working-tree-encoding=utf-8 working-tree-encoding=utf-8
-*.yaml zos-working-tree-encoding=utf-8 working-tree-encoding=utf-8
+*.cpy zos-working-tree-encoding=ibm-1047
+*.cbl zos-working-tree-encoding=ibm-1047
+*.bms zos-working-tree-encoding=ibm-1047
+*.pli zos-working-tree-encoding=ibm-1047
+*.mfs zos-working-tree-encoding=ibm-1047
+*.bnd zos-working-tree-encoding=ibm-1047
+*.lnk zos-working-tree-encoding=ibm-1047
+*.txt zos-working-tree-encoding=ibm-1047
+*.groovy zos-working-tree-encoding=ibm-1047
+*.sh zos-working-tree-encoding=ibm-1047
+*.properties zos-working-tree-encoding=ibm-1047
+*.asm zos-working-tree-encoding=ibm-1047
+*.jcl zos-working-tree-encoding=ibm-1047
+*.mac zos-working-tree-encoding=ibm-1047
+*.json zos-working-tree-encoding=utf-8
+*.yaml zos-working-tree-encoding=utf-8
 
 # binary managed files
 *.rec binary


### PR DESCRIPTION
working-tree-encoding is the standard option for specifying the encoding - obviously intentionally overridden by zos-working-tree-encoding when using the Git for z/OS port.

`git-encoding` has been obsolete since Git 2.26. Defaulting everywhere but z/OS to utf-8 should obviously be fine.